### PR TITLE
Fix CI cache and CC test reporter

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -74,7 +74,6 @@ jobs:
           paths:
             - ~/miniconda3
             - ~/.cache/pip
-            - ~/ml-agents
 
   test:
     environment:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -78,7 +78,7 @@ jobs:
   test:
     environment:
       PY_ENV: test
-      CC_TEST_REPORTER_ID: 633cb615def2956cb2c4b0817b54f0e5b15bb8c42d9f9b921b8b2e02b217c369
+      CC_TEST_REPORTER_ID: ff1651bfca53185e6d295b5989f89074b87fd7d68c6d1f938f19ea9186572a81
 
     working_directory: ~/SLM-Lab
 

--- a/environment.yml
+++ b/environment.yml
@@ -38,6 +38,7 @@ dependencies:
 - olefile=0.44=py36_0
 - openpyxl=2.5.0b1=py36_0
 - openssl=1.0.2l=0
+- pandas=0.21.0=py36_0
 - pexpect=4.2.1=py36_0
 - pickleshare=0.7.4=py36_0
 - pillow=4.3.0=py36_0
@@ -76,7 +77,6 @@ dependencies:
 - zlib=1.2.8=3
 - mkl=2017.0.3=0
 - numpy=1.13.1=py36_0
-- pandas=0.20.3=py36_0
 - plotly=2.0.11=py36_0
 - requests=2.14.2=py36_0
 - scipy=0.19.1=np113py36_0


### PR DESCRIPTION
- ml-agents git footprint is 1Gb, causing huge cache that takes long time and fails. Remove
- update CC test reporter ID to fix CC test reporter