### PR TITLE
Graph

### DIFF
--- a/slm_lab/agent/__init__.py
+++ b/slm_lab/agent/__init__.py
@@ -64,8 +64,10 @@ class Agent:
         Update per timestep after env transitions, e.g. memory, algorithm, update agent params, train net
         '''
         self.memory.update(action, reward, state, done)
-        self.algorithm.train()
-        self.algorithm.update()
+        loss = self.algorithm.train()
+        explore_var = self.algorithm.update()
+        # TODO tmp return, to unify with monitor auto-fetch later
+        return loss, explore_var
 
     def close(self):
         '''Close agent at the end of a session, e.g. save model'''
@@ -116,7 +118,9 @@ class AgentSpace:
             reward = reward_space.get(a=a)
             state = state_space.get(a=a)
             done = done_space.get(a=a)
-            agent.update(action, reward, state, done)
+            loss, explore_var = agent.update(action, reward, state, done)
+        # TODO tmp, single body (last); use monitor later
+        return loss, explore_var
 
     def close(self):
         for agent in self.agents:

--- a/slm_lab/agent/algorithm/algorithm_util.py
+++ b/slm_lab/agent/algorithm/algorithm_util.py
@@ -11,7 +11,6 @@ def act_with_epsilon_greedy(net, state, epsilon):
     otherwise select the action associated with the
     largest q value
     '''
-    # TODO store one hot
     # TODO discrete int
     a_dim = net.out_dim
     print(f'epsilon {epsilon}')

--- a/slm_lab/agent/algorithm/algorithm_util.py
+++ b/slm_lab/agent/algorithm/algorithm_util.py
@@ -13,12 +13,12 @@ def act_with_epsilon_greedy(net, state, epsilon):
     '''
     # TODO discrete int
     a_dim = net.out_dim
-    print(f'epsilon {epsilon}')
+    # print(f'epsilon {epsilon}')
     if epsilon > np.random.rand():
-        print('random action')
+        # print('random action')
         action = np.random.randint(a_dim)
     else:
-        print('net action')
+        # print('net action')
         torch_state = Variable(torch.from_numpy(state).float())
         out = net.wrap_eval(torch_state)
         action = int(torch.max(out, dim=0)[1][0])

--- a/slm_lab/agent/algorithm/dqn.py
+++ b/slm_lab/agent/algorithm/dqn.py
@@ -101,6 +101,7 @@ class DQNBase(Algorithm):
             return None
 
     def body_act_discrete(self, body, body_state):
+        # TODO can handle identical bodies now; to use body_net for specific body.
         return self.action_selection(
             self.net,
             body_state,

--- a/slm_lab/agent/algorithm/dqn.py
+++ b/slm_lab/agent/algorithm/dqn.py
@@ -95,7 +95,7 @@ class DQNBase(Algorithm):
                 q_targets = self.compute_q_target_values(batch)
                 y = Variable(q_targets)
                 loss = self.net.training_step(batch['states'], y)
-                print(f'loss {loss.data[0]}\n')
+                # print(f'loss {loss.data[0]}\n')
             return loss.data[0]
         else:
             return None
@@ -114,3 +114,4 @@ class DQNBase(Algorithm):
         slope = rise / float(self.explore_anneal_epi)
         self.explore_var = max(
             slope * epi + self.explore_var_start, self.explore_var_end)
+        return self.explore_var

--- a/slm_lab/experiment/control.py
+++ b/slm_lab/experiment/control.py
@@ -95,8 +95,8 @@ class Session:
         # TODO tmp hack. fix with monitor data later
         data = pd.DataFrame(
             data_list, columns=['total_rewards', 'loss', 'explore_var'])
-        fig = viz.plot_line(
-            data, ['total_rewards', 'loss', 'explore_var'], save=True, draw=False)
+        fig = viz.plot_line(data, ['total_rewards', 'explore_var'], save=True, draw=False)
+        fig_2 = viz.plot_line(data, ['loss'], save=True, draw=False)
         self.close()
         # TODO session data checker method
         return self.data

--- a/slm_lab/experiment/control.py
+++ b/slm_lab/experiment/control.py
@@ -52,7 +52,8 @@ class Session:
         state_space = self.env_space.reset()
         self.agent_space.reset(state_space)
         # RL steps for SARS
-        # TODO absorb later from data space
+        # TODO hack. absorb later from monitor
+        episode_data_list = []
         total_rewards = 0
         for t in range(self.env_space.max_timestep):
             self.aeb_space.tick_clock('t')
@@ -62,22 +63,40 @@ class Session:
             logger.debug(f'action_space {action_space}')
             (reward_space, state_space,
              done_space) = self.env_space.step(action_space)
-            total_rewards += np.sum(reward_space.data_proj)
+            rewards = np.sum(reward_space.data_proj)
+            total_rewards += rewards
             logger.debug(
                 f'reward_space: {reward_space}, state_space: {state_space}, done_space: {done_space}')
             # completes cycle of full info for agent_space
-            self.agent_space.update(action_space, reward_space, state_space, done_space)
+            # TODO tmp return, to unify with monitor auto-fetch later
+            loss, explore_var = self.agent_space.update(
+                action_space, reward_space, state_space, done_space)
+            episode_data_list.append(
+                [rewards, total_rewards, loss, explore_var])
             if bool(done_space):
                 break
         logger.info(f'total_rewards {total_rewards}')
-        # TODO compose episode data
-        episode_data = {}
+        # TODO compose episode data properly with monitor
+        episode_data = pd.DataFrame(
+            episode_data_list, columns=['rewards', 'total_rewards', 'loss', 'explore_var'])
+        # episode_data = {}
         return episode_data
 
     def run(self):
+        data_list = []
         for e in range(_.get(self.spec, 'meta.max_episode')):
             logger.debug(f'episode {e}')
-            self.run_episode()
+            episode_data = self.run_episode()
+            data_list.append([
+                episode_data['total_rewards'].sum(),
+                episode_data['loss'].mean(),
+                episode_data['explore_var'].min(),
+            ])
+        # TODO tmp hack. fix with monitor data later
+        data = pd.DataFrame(
+            data_list, columns=['total_rewards', 'loss', 'explore_var'])
+        fig = viz.plot_line(
+            data, ['total_rewards', 'loss', 'explore_var'], save=True, draw=False)
         self.close()
         # TODO session data checker method
         return self.data

--- a/slm_lab/lib/viz.py
+++ b/slm_lab/lib/viz.py
@@ -15,8 +15,7 @@ from slm_lab import config
 
 PLOT_FILEDIR = util.smart_path('data')
 os.makedirs(PLOT_FILEDIR, exist_ok=True)
-if util.is_jupyter():
-    py.init_notebook_mode(connected=True)
+py.init_notebook_mode(connected=True)
 
 
 def save_image(figure, filename=None):

--- a/slm_lab/spec/dqn.json
+++ b/slm_lab/spec/dqn.json
@@ -7,7 +7,7 @@
         "action_selection": "epsilon_greedy",
         "explore_var_start": 1.0,
         "explore_var_end": 0.1,
-        "explore_anneal_epi": 20
+        "explore_anneal_epi": 50
       },
       "memory": {
         "name": "Replay",
@@ -15,7 +15,7 @@
       },
       "net": {
         "net_type": "MLP",
-        "net_layer_params": [null, [100, 50], null],
+        "net_layer_params": [null, [16, 8], null],
         "net_other_params": [],
         "batch_size": 32,
         "training_iters_per_batch": 5,
@@ -35,10 +35,10 @@
       "num": 1
     },
     "meta": {
-      "max_episode": 30,
+      "max_episode": 100,
       "max_session": 1,
       "max_trial": 1,
-      "train_mode": false
+      "train_mode": true
     }
   },
   "dqn_test_case": {


### PR DESCRIPTION
Add quick but hackish graph for DQN dev work.
- plot 1: 2 data points per episode: `total_rewards`, `explore_var` (epsilon, min over episode which is also the same value thruout episode)
- plot 2: 1 data point per episode: `loss` (mean over episode),  loss is plot separately here cuz it's magnitude is small, wouldn't be visible in plot 1 otherwise
- saves to `data/` automatically 