### PR TITLE
Multitask timing, first data analysis module

### DIFF
--- a/slm_lab/agent/__init__.py
+++ b/slm_lab/agent/__init__.py
@@ -108,9 +108,11 @@ class AgentSpace:
 
     def reset(self, state_space):
         logger.debug('AgentSpace.reset')
+        _action_v = self.aeb_space.data_spaces['action'].init_data_v()
         for agent in self.agents:
             state_a = state_space.get(a=agent.a)
             agent.reset(state_a)
+        _action_space = self.aeb_space.add('action', _action_v)
 
     def act(self, state_space):
         action_v = self.aeb_space.data_spaces['action'].init_data_v()

--- a/slm_lab/agent/__init__.py
+++ b/slm_lab/agent/__init__.py
@@ -39,6 +39,9 @@ class Agent:
         self.a = a
         self.body_a = None
         self.flat_nonan_body_a = None  # flatten_nonan version of bodies
+        # agent session data TODO make body-based
+        self.loss_history = []
+        self.explore_var_history = []
 
         AlgoClass = getattr(algorithm, _.get(self.spec, 'algorithm.name'))
         self.algorithm = AlgoClass(self)
@@ -66,10 +69,11 @@ class Agent:
         for (e, b), body in util.ndenumerate_nonan(self.body_a):
             body.memory.update(
                 action_a[(e, b)], reward_a[(e, b)], state_a[(e, b)], done_a[(e, b)])
+        # TODO finer loss and explore_var per body
         loss = self.algorithm.train()
         explore_var = self.algorithm.update()
-        # TODO tmp return, to unify with monitor auto-fetch later
-        return loss, explore_var
+        self.loss_history.append(loss)
+        self.explore_var_history.append(explore_var)
 
     def close(self):
         '''Close agent at the end of a session, e.g. save model'''
@@ -125,10 +129,7 @@ class AgentSpace:
             reward_a = reward_space.get(a=a)
             state_a = state_space.get(a=a)
             done_a = done_space.get(a=a)
-            loss, explore_var = agent.update(
-                action_a, reward_a, state_a, done_a)
-        # TODO tmp, single body loss (last); use monitor later
-        return loss, explore_var
+            agent.update(action_a, reward_a, state_a, done_a)
 
     def close(self):
         logger.info('AgentSpace.close')

--- a/slm_lab/agent/__init__.py
+++ b/slm_lab/agent/__init__.py
@@ -50,7 +50,7 @@ class Agent:
         logger.info(util.self_desc(self))
 
     def reset(self, state_a):
-        '''Do agent reset per episode, such as memory pointer'''
+        '''Do agent reset per session, such as memory pointer'''
         for (e, b), body in util.ndenumerate_nonan(self.body_a):
             body.memory.reset_last_state(state_a[(e, b)])
 

--- a/slm_lab/agent/algorithm/algorithm_util.py
+++ b/slm_lab/agent/algorithm/algorithm_util.py
@@ -82,7 +82,7 @@ def act_with_gaussian(body, state, net, stddev):
 
 def update_linear_decay(cls, clock):
     t = clock.get('total_t')
-    epi = clock.get('e')
+    epi = clock.get('epi')
     rise = cls.explore_var_end - cls.explore_var_start
     slope = rise / float(cls.explore_anneal_epi)
     cls.explore_var = max(

--- a/slm_lab/agent/algorithm/dqn.py
+++ b/slm_lab/agent/algorithm/dqn.py
@@ -133,7 +133,7 @@ class DQNBase(Algorithm):
             return total_loss
         else:
             logger.debug('NOT training')
-            return None
+            return np.nan
 
     def body_act_discrete(self, body, state):
         return self.action_policy(body, state, self.net, self.explore_var)

--- a/slm_lab/agent/memory/base.py
+++ b/slm_lab/agent/memory/base.py
@@ -19,7 +19,7 @@ class Memory(ABC):
 
     @abstractmethod
     def update(self, action, reward, state, done):
-        '''Implement memory update given the full info from the latest timestep. Hint: use self.last_state to construct SARS.'''
+        '''Implement memory update given the full info from the latest timestep. Hint: use self.last_state to construct SARS. NOTE: guard for np.nan reward and done when individual env resets.'''
         raise NotImplementedError
 
     # TODO standardize sample method

--- a/slm_lab/agent/memory/base.py
+++ b/slm_lab/agent/memory/base.py
@@ -14,8 +14,7 @@ class Memory(ABC):
         self.last_state = None
 
     def reset_last_state(self, state):
-        '''Episodic reset of memory, update last_state to the reset_state from env.'''
-        # TODO this is per body, need to generalize
+        '''Do reset of body memory per session during agent_space.reset() to set last_state'''
         self.last_state = state
 
     @abstractmethod

--- a/slm_lab/agent/memory/replay.py
+++ b/slm_lab/agent/memory/replay.py
@@ -49,8 +49,9 @@ class Replay(Memory):
         self.total_experiences = 0
 
     def update(self, action, reward, state, done):
-        '''interface method to update memory'''
-        self.add_experience(self.last_state, action, reward, state, done)
+        '''Interface method to update memory'''
+        if not np.isnan(reward):
+            self.add_experience(self.last_state, action, reward, state, done)
         self.last_state = state
 
     def add_experience(self, state, action, reward, next_state, done, priority=1):

--- a/slm_lab/env/__init__.py
+++ b/slm_lab/env/__init__.py
@@ -140,9 +140,6 @@ class OpenAIEnv:
             state_e[(a, b)] = state
             done_e[(a, b)] = done
         self.done = util.gen_all(done_e)
-        if self.done:
-            logger.info(
-                f'Done: env {self.e} epi {self.clock.get("epi")}, t {self.clock.get("t")}')
         return reward_e, state_e, done_e
 
     def close(self):
@@ -247,9 +244,6 @@ class UnityEnv:
             state_e[(a, b)] = env_info_a.states[b]
             done_e[(a, b)] = env_info_a.local_done[b]
         self.done = util.gen_all(done_e)
-        if self.done:
-            logger.info(
-                f'Done: env {self.e} epi {self.clock.get("epi")}, t {self.clock.get("t")}')
         return reward_e, state_e, done_e
 
     def close(self):

--- a/slm_lab/env/__init__.py
+++ b/slm_lab/env/__init__.py
@@ -139,7 +139,7 @@ class OpenAIEnv:
             reward_e[(a, b)] = reward
             state_e[(a, b)] = state
             done_e[(a, b)] = done
-        self.done = np.all(done_e)
+        self.done = util.gen_all(done_e)
         if self.done:
             logger.info(
                 f'Done: env {self.e} epi {self.clock.get("epi")}, t {self.clock.get("t")}')
@@ -246,7 +246,7 @@ class UnityEnv:
             reward_e[(a, b)] = env_info_a.rewards[b]
             state_e[(a, b)] = env_info_a.states[b]
             done_e[(a, b)] = env_info_a.local_done[b]
-        self.done = np.all(done_e)
+        self.done = util.gen_all(done_e)
         if self.done:
             logger.info(
                 f'Done: env {self.e} epi {self.clock.get("epi")}, t {self.clock.get("t")}')

--- a/slm_lab/env/__init__.py
+++ b/slm_lab/env/__init__.py
@@ -4,6 +4,7 @@ Contains graduated components from experiments for building/using environment.
 Provides the rich experience for agent embodiment, reflects the curriculum and allows teaching (possibly allows teacher to enter).
 To be designed by human and evolution module, based on the curriculum and fitness metrics.
 '''
+from slm_lab.experiment.monitor import Clock
 from slm_lab.lib import logger, util
 from unityagents import UnityEnvironment
 from unityagents.brain import BrainParameters
@@ -60,7 +61,6 @@ extend_unity_brain()
 
 
 class OpenAIEnv:
-    # TODO check done_e on solve_mean_rewards
     def __init__(self, spec, env_space, e=0):
         self.spec = spec
         util.set_attr(self, self.spec)
@@ -70,9 +70,14 @@ class OpenAIEnv:
         self.e = e
         self.body_e = None
         self.flat_nonan_body_e = None  # flatten_nonan version of bodies
+
         self.u_env = gym.make(self.name)
         self.max_timestep = self.max_timestep or self.u_env.spec.tags.get(
             'wrapper_config.TimeLimit.max_episode_steps')
+        # TODO ensure clock_speed from spec
+        self.clock_speed = 1
+        self.clock = Clock(self.clock_speed)
+        self.done = False
 
     def post_body_init(self):
         '''Run init for components that need bodies to exist first, e.g. memory or architecture.'''
@@ -104,7 +109,7 @@ class OpenAIEnv:
         return {'state': state_dim}
 
     def reset(self):
-        self.done_e = False
+        self.done = False
         state_e = self.data_spaces['state'].init_data_s(e=self.e)
         for (a, b), body in util.ndenumerate_nonan(self.body_e):
             state = self.u_env.reset()
@@ -114,12 +119,13 @@ class OpenAIEnv:
         return state_e
 
     def step(self, action_e):
-        # TODO hack for mismaching env timesteps
-        if self.done_e:
+        # TODO step only if self.clock.to_step()
+        if self.done:
             self.reset()
         if not self.train_mode:
             self.u_env.render()
         assert len(action_e) == 1, 'OpenAI Gym supports only single body'
+
         action = action_e[(0, 0)]
         (state, reward, done, _info) = self.u_env.step(action)
         reward_e = self.data_spaces['reward'].init_data_s(e=self.e)
@@ -129,7 +135,10 @@ class OpenAIEnv:
             reward_e[(a, b)] = reward
             state_e[(a, b)] = state
             done_e[(a, b)] = done
-        self.done_e = done
+        self.done = np.all(done_e)
+        if self.done:
+            logger.info(
+                f'Done: env {self.e} epi {self.clock.get("epi")}, t {self.clock.get("t")}')
         return reward_e, state_e, done_e
 
     def close(self):
@@ -156,6 +165,10 @@ class UnityEnv:
         self.u_env = UnityEnvironment(
             file_name=util.get_env_path(self.name), worker_id=worker_id)
         # TODO experiment to find out optimal benchmarking max_timestep, set
+        # TODO ensure clock_speed from spec
+        self.clock_speed = 1
+        self.clock = Clock(self.clock_speed)
+        self.done = False
 
     def check_u_brain_to_agent(self):
         '''Check the size match between unity brain and agent'''
@@ -203,6 +216,7 @@ class UnityEnv:
         return env_info_a
 
     def reset(self):
+        self.done = False
         env_info_dict = self.u_env.reset(
             train_mode=self.train_mode, config=self.spec.get('unity'))
         state_e = self.data_spaces['state'].init_data_s(e=self.e)
@@ -213,6 +227,9 @@ class UnityEnv:
         return state_e
 
     def step(self, action_e):
+        # TODO step only if self.clock.to_step()
+        if self.done:
+            self.reset()
         action_e = util.flatten_nonan(action_e)
         env_info_dict = self.u_env.step(action_e)
         reward_e = self.data_spaces['reward'].init_data_s(e=self.e)
@@ -223,6 +240,10 @@ class UnityEnv:
             reward_e[(a, b)] = env_info_a.rewards[b]
             state_e[(a, b)] = env_info_a.states[b]
             done_e[(a, b)] = env_info_a.local_done[b]
+        self.done = np.all(done_e)
+        if self.done:
+            logger.info(
+                f'Done: env {self.e} epi {self.clock.get("epi")}, t {self.clock.get("t")}')
         return reward_e, state_e, done_e
 
     def close(self):
@@ -248,7 +269,6 @@ class EnvSpace:
             except gym.error.Error:
                 env = UnityEnv(env_spec, self, e)
             self.envs.append(env)
-        self.max_timestep = np.amax([env.max_timestep for env in self.envs])
 
     def post_body_init(self):
         '''Run init for components that need bodies to exist first, e.g. memory or architecture.'''
@@ -258,6 +278,12 @@ class EnvSpace:
 
     def get(self, e):
         return self.envs[e]
+
+    def get_base_clock(self):
+        '''Get the clock with the finest time unit, i.e. ticks the most cycles in a given time, or the highest clock_speed'''
+        fastest_env = _.max_by(self.envs, lambda env: env.clock_speed)
+        clock = fastest_env.clock
+        return clock
 
     def reset(self):
         state_v = self.aeb_space.data_spaces['state'].init_data_v()

--- a/slm_lab/experiment/analysis.py
+++ b/slm_lab/experiment/analysis.py
@@ -2,3 +2,92 @@
 The analysis module
 Handles the analyses of the info and data space for experiment evaluation and design.
 '''
+import numpy as np
+import pandas as pd
+import pydash as _
+from slm_lab.lib import logger, util, viz
+
+
+def get_session_data(session):
+    '''Gather data from session: MDP, Agent, Env data, and form session_data.'''
+    aeb_space = session.aeb_space
+    reward_h_v = np.stack(
+        aeb_space.data_spaces['reward'].data_history, axis=3)
+    done_h_v = np.stack(
+        aeb_space.data_spaces['done'].data_history, axis=3)
+
+    mdp_data = {}
+    for aeb in aeb_space.aeb_list:
+        # remove last entry (env reset after termination)
+        reward_h = reward_h_v[aeb][:-1]
+        reset_idx = np.isnan(reward_h)
+        nonreset_idx = ~reset_idx
+        epi_h = reset_idx.astype(int).cumsum()
+        df = pd.DataFrame({
+            'reward': reward_h[nonreset_idx],
+            'epi': epi_h[nonreset_idx],
+        })
+        agg_df = df.groupby('epi').agg('sum')
+        agg_df.reset_index(drop=False, inplace=True)
+        # TODO write file properly once session_data is in tabular form
+        print(agg_df)
+        util.write(agg_df, f"data/{session.spec['name']}_{aeb}_mdp_data.csv")
+        mdp_data[aeb] = agg_df
+
+    agent_data = {}
+    for agent in aeb_space.agent_space.agents:
+        body = agent.flat_nonan_body_a[0]
+        aeb = body.aeb
+        loss_h = np.array(agent.loss_history)
+        explore_var_h = np.array(agent.explore_var_history)
+
+        reward_h = reward_h_v[aeb][:-1]
+        reset_idx = np.isnan(reward_h)
+        nonreset_idx = ~reset_idx
+        epi_h = reset_idx.astype(int).cumsum()
+        df = pd.DataFrame({
+            'loss': loss_h[nonreset_idx],
+            'explore_var': explore_var_h[nonreset_idx],
+            'epi': epi_h[nonreset_idx],
+        })
+        agg_df = df.groupby('epi').agg('mean')
+        agg_df.reset_index(drop=False, inplace=True)
+        agent_data[agent.a] = agg_df
+    # TODO form proper session data for plot and return
+    return mdp_data, agent_data
+
+
+def plot_session(session, mdp_data, agent_data):
+    fig = viz.tools.make_subplots(rows=3, cols=1, shared_xaxes=True)
+
+    for a, df in agent_data.items():
+        agent_fig = viz.plot_line(
+            df, ['loss'], y2_col=['explore_var'], draw=False)
+        fig.append_trace(agent_fig.data[0], 1, 1)
+        fig.append_trace(agent_fig.data[1], 2, 1)
+
+    for aeb, df in mdp_data.items():
+        body_fig = viz.plot_line(
+            df, 'reward', 'epi', legend_name=str(aeb), draw=False)
+        fig.append_trace(body_fig.data[0], 3, 1)
+
+    fig.layout['yaxis1'].update(agent_fig.layout['yaxis'])
+    fig.layout['yaxis1'].update(domain=[0.55, 1])
+    fig.layout['yaxis2'].update(agent_fig.layout['yaxis2'])
+    fig.layout['yaxis2'].update(showgrid=False)
+
+    fig.layout['yaxis3'].update(body_fig.layout['yaxis'])
+    fig.layout['yaxis3'].update(domain=[0, 0.45])
+    fig.layout.update(_.pick(agent_fig.layout, ['legend']))
+    fig.layout.update(_.pick(body_fig.layout, ['legend']))
+    fig.layout.update(title=session.spec['name'], width=500, height=600)
+    viz.plot(fig)
+    viz.save_image(fig)
+
+
+def analyze_session(session):
+    '''Gather session data, plot, and return session data'''
+    mdp_data, agent_data = get_session_data(session)
+    session_data = pd.DataFrame()
+    plot_session(session, mdp_data, agent_data)
+    return session_data

--- a/slm_lab/experiment/control.py
+++ b/slm_lab/experiment/control.py
@@ -4,7 +4,8 @@ Creates and controls the units of SLM lab: EvolutionGraph, Experiment, Trial, Se
 '''
 from slm_lab.agent import AgentSpace
 from slm_lab.env import EnvSpace
-from slm_lab.experiment.monitor import info_space, AEBSpace, get_body_df_dict
+from slm_lab.experiment import analysis
+from slm_lab.experiment.monitor import info_space, AEBSpace
 from slm_lab.lib import logger, util, viz
 import numpy as np
 import pandas as pd

--- a/slm_lab/experiment/control.py
+++ b/slm_lab/experiment/control.py
@@ -57,15 +57,12 @@ class Session:
                 action_space)
             self.agent_space.update(
                 action_space, reward_space, state_space, done_space)
-        # TODO collect data from different clock speed
-        episode_data = {}
-        return episode_data
+        session_data = analysis.analyze_session(self)
+        self.data = session_data
 
     def run(self):
         self.run_all_episodes()
-        # TODO resore viz
         self.close()
-        # TODO session data checker method
         return self.data
 
 
@@ -96,7 +93,6 @@ class Trial:
             logger.debug(f'session {s}')
             self.init_session().run()
         self.close()
-        # TODO trial data checker method
         return self.data
 
 
@@ -133,7 +129,6 @@ class Experiment:
             logger.debug(f'trial {t}')
             self.init_trial().run()
         self.close()
-        # TODO exp data checker method
         return self.data
 
 

--- a/slm_lab/experiment/control.py
+++ b/slm_lab/experiment/control.py
@@ -45,16 +45,15 @@ class Session:
         '''
         Run all episodes, where each env can step and reset at its own clock_speed and timeline. Will terminate when all envs done running max_episode.
         '''
-        state_space = self.env_space.reset()
+        _reward_space, state_space, _done_space = self.env_space.reset()
         self.agent_space.reset(state_space)
         while True:
             end_session = self.aeb_space.tick_clocks()
             if end_session:
                 break
-
             action_space = self.agent_space.act(state_space)
-            (reward_space, state_space,
-             done_space) = self.env_space.step(action_space)
+            reward_space, state_space, done_space = self.env_space.step(
+                action_space)
             self.agent_space.update(
                 action_space, reward_space, state_space, done_space)
         # TODO collect data from different clock speed

--- a/slm_lab/experiment/monitor.py
+++ b/slm_lab/experiment/monitor.py
@@ -154,7 +154,7 @@ class DataSpace:
         return s
 
     def __bool__(self):
-        return bool(np.all(self.data))
+        return util.gen_all(self.data)
 
     def init_data_v(self):
         '''Method to init a data volume filled with np.nan'''
@@ -270,11 +270,8 @@ class AEBSpace:
         body_end_sessions = []
         for env in self.env_space.envs:
             clock = env.clock
-            if done_space.data is None:
-                done = False
-            else:
-                done = (np.all(done_space.get(e=env.e)) or
-                        clock.get('t') > env.max_timestep)
+            done = (util.gen_all(done_space.get(e=env.e)) or
+                    clock.get('t') > env.max_timestep)
             if done:
                 clock.tick('epi')
             else:

--- a/slm_lab/experiment/monitor.py
+++ b/slm_lab/experiment/monitor.py
@@ -45,10 +45,11 @@ ENV_DATA_NAMES = ['reward', 'state', 'done']
 
 
 class Clock:
+    '''Clock class for each env and space to keep track of relative time. Ticking and control loop is such that reset is at t=0, but epi begins at 1, env step begins at 1.'''
+
     def __init__(self, clock_speed=1):
         self.clock_speed = int(clock_speed)
         self.ticks = 0
-        # units such that when ticked and entered, it starts at 1
         self.t = 0
         self.total_t = 0
         self.epi = 1
@@ -68,7 +69,6 @@ class Clock:
         elif unit == 'epi':  # episode, reset timestep
             self.epi += 1
             self.t = 0
-            self.tick('t')
         else:
             raise KeyError
 
@@ -255,9 +255,10 @@ class AEBSpace:
         body_end_sessions = []
         for env in self.env_space.envs:
             clock = env.clock
-            done = (util.gen_all(done_space.get(e=env.e)) or
-                    clock.get('t') > env.max_timestep)
+            done = env.done or clock.get('t') > env.max_timestep
             if done:
+                logger.info(
+                    f'Done: env {env.e} epi {clock.get("epi")}, t {clock.get("t")}')
                 clock.tick('epi')
             else:
                 clock.tick('t')

--- a/slm_lab/experiment/monitor.py
+++ b/slm_lab/experiment/monitor.py
@@ -44,21 +44,6 @@ AGENT_DATA_NAMES = ['action']
 ENV_DATA_NAMES = ['reward', 'state', 'done']
 
 
-def get_body_df_dict(aeb_space):
-    # TODO rewrite this whole shit
-    body_df_dict = {}
-    reward_h_v = np.stack(
-        aeb_space.data_spaces['reward'].data_history, axis=3)
-    done_h_v = np.stack(
-        aeb_space.data_spaces['done'].data_history, axis=3)
-    for aeb, body in util.ndenumerate_nonan(aeb_space.body_space.data):
-        body.reward_h = reward_h_v[aeb]
-        body.done_h = done_h_v[aeb]
-        df = pd.DataFrame({'reward': body.reward_h, 'done': body.done_h})
-        body_df_dict[aeb] = df
-    return body_df_dict
-
-
 class Clock:
     def __init__(self, clock_speed=1):
         self.clock_speed = int(clock_speed)

--- a/slm_lab/experiment/monitor.py
+++ b/slm_lab/experiment/monitor.py
@@ -41,7 +41,7 @@ COOR_AXES_ORDER = {
 }
 COOR_DIM = len(COOR_AXES)
 AGENT_DATA_NAMES = ['action']
-ENV_DATA_NAMES = ['state', 'reward', 'done']
+ENV_DATA_NAMES = ['reward', 'state', 'done']
 
 
 def get_body_df_dict(aeb_space):

--- a/slm_lab/lib/util.py
+++ b/slm_lab/lib/util.py
@@ -125,6 +125,11 @@ def flatten_once(arr):
     return arr.reshape(-1, *arr.shape[2:])
 
 
+def gen_all(v):
+    '''Generic np.all that also returns false if array is all np.nan'''
+    return bool(np.all(v) and ~np.all(np.isnan(v)))
+
+
 def gen_isnan(v):
     '''Check isnan for general type (np.isnan is only operable on np type)'''
     try:

--- a/test/lib/test_util.py
+++ b/test/lib/test_util.py
@@ -79,7 +79,7 @@ def test_flatten_nonan(arr, res):
     assert np.array_equal(util.flatten_nonan(arr), res)
 
 
-@pytest.mark.parametrize('v,all', [
+@pytest.mark.parametrize('v,isall', [
     ([1, 1], True),
     ([True, True], True),
     ([np.nan, 1], True),
@@ -87,8 +87,8 @@ def test_flatten_nonan(arr, res):
     ([False, True], False),
     ([np.nan, np.nan], False),
 ])
-def test_gen_all(v, isnan):
-    assert util.gen_all(v) == isnan
+def test_gen_all(v, isall):
+    assert util.gen_all(v) == isall
 
 
 @pytest.mark.parametrize('v,isnan', [

--- a/test/lib/test_util.py
+++ b/test/lib/test_util.py
@@ -136,10 +136,10 @@ def test_ndenumerate_nonan():
 
 
 def test_s_get(test_agent):
-    clock = util.s_get(test_agent, 'aeb_space.clock')
-    assert clock.get('t') == 0
-    clock = util.s_get(test_agent, 'aeb_space').clock
-    assert clock.get('t') == 0
+    spec = util.s_get(test_agent, 'aeb_space.spec')
+    assert _.is_dict(spec)
+    spec = util.s_get(test_agent, 'aeb_space').spec
+    assert _.is_dict(spec)
 
 
 def test_set_attr():

--- a/test/lib/test_util.py
+++ b/test/lib/test_util.py
@@ -79,6 +79,18 @@ def test_flatten_nonan(arr, res):
     assert np.array_equal(util.flatten_nonan(arr), res)
 
 
+@pytest.mark.parametrize('v,all', [
+    ([1, 1], True),
+    ([True, True], True),
+    ([np.nan, 1], True),
+    ([0, 1], False),
+    ([False, True], False),
+    ([np.nan, np.nan], False),
+])
+def test_gen_all(v, isnan):
+    assert util.gen_all(v) == isnan
+
+
 @pytest.mark.parametrize('v,isnan', [
     (0, False),
     (1, False),


### PR DESCRIPTION
### Multitask Timing
- each env now has its own `clock`(moved from body), ticking at its own `clock_speed`.
- `aeb_space` will use the fastest clock as its base clock.
- update env logic so that each env can run at its own clock speed, and reset/terminate independently. absorb `env.reset` into `env.step`
- session logic now runs without arbitrary episode termination, but terminates all when all envs have at least ran the max_episode

### Data Analysis
- Implement first data analysis module in `experiment/analysis.py`. Debug and use.
- misc bug fix with numpy.all
- Test run with the new logic. pass.
- WIP more to come; formulation is ready on paper.