### PR TITLE
DQN multienv on 2dball and cartpole

### DIFF
--- a/slm_lab/agent/net/net_util.py
+++ b/slm_lab/agent/net/net_util.py
@@ -20,7 +20,7 @@ def get_loss_fn(cls, loss_param):
     '''Helper to parse loss param and construct loss_fn for net'''
     loss_param = loss_param or {}
     loss_fn = getattr(F, _.get(loss_param, 'name', 'mse_loss'))
-    loss_param.pop('name', None)
+    loss_param = _.omit(loss_param, 'name')
     if not _.is_empty(loss_param):
         loss_fn = partial(loss_fn, **loss_param)
     return loss_fn
@@ -30,7 +30,7 @@ def get_optim(cls, optim_param):
     '''Helper to parse optim param and construct optim for net'''
     optim_param = optim_param or {}
     OptimClass = getattr(torch.optim, _.get(optim_param, 'name', 'Adam'))
-    optim_param.pop('name', None)
+    optim_param = _.omit(optim_param, 'name')
     optim = OptimClass(cls.parameters(), **optim_param)
     return optim
 

--- a/slm_lab/env/__init__.py
+++ b/slm_lab/env/__init__.py
@@ -139,7 +139,7 @@ class OpenAIEnv:
             reward_e[(a, b)] = reward
             state_e[(a, b)] = state
             done_e[(a, b)] = done
-        self.done = (util.gen_all(done_e) or
+        self.done = (util.nonan_all(done_e) or
                      self.clock.get('t') > self.max_timestep)
         return reward_e, state_e, done_e
 
@@ -244,7 +244,7 @@ class UnityEnv:
             reward_e[(a, b)] = env_info_a.rewards[b]
             state_e[(a, b)] = env_info_a.states[b]
             done_e[(a, b)] = env_info_a.local_done[b]
-        self.done = (util.gen_all(done_e) or
+        self.done = (util.nonan_all(done_e) or
                      self.clock.get('t') > self.max_timestep)
         return reward_e, state_e, done_e
 

--- a/slm_lab/env/__init__.py
+++ b/slm_lab/env/__init__.py
@@ -139,7 +139,8 @@ class OpenAIEnv:
             reward_e[(a, b)] = reward
             state_e[(a, b)] = state
             done_e[(a, b)] = done
-        self.done = util.gen_all(done_e)
+        self.done = (util.gen_all(done_e) or
+                     self.clock.get('t') > self.max_timestep)
         return reward_e, state_e, done_e
 
     def close(self):
@@ -243,7 +244,8 @@ class UnityEnv:
             reward_e[(a, b)] = env_info_a.rewards[b]
             state_e[(a, b)] = env_info_a.states[b]
             done_e[(a, b)] = env_info_a.local_done[b]
-        self.done = util.gen_all(done_e)
+        self.done = (util.gen_all(done_e) or
+                     self.clock.get('t') > self.max_timestep)
         return reward_e, state_e, done_e
 
     def close(self):

--- a/slm_lab/experiment/monitor.py
+++ b/slm_lab/experiment/monitor.py
@@ -139,7 +139,7 @@ class DataSpace:
         return s
 
     def __bool__(self):
-        return util.gen_all(self.data)
+        return util.nonan_all(self.data)
 
     def init_data_v(self):
         '''Method to init a data volume filled with np.nan'''

--- a/slm_lab/lib/util.py
+++ b/slm_lab/lib/util.py
@@ -125,11 +125,6 @@ def flatten_once(arr):
     return arr.reshape(-1, *arr.shape[2:])
 
 
-def gen_all(v):
-    '''Generic np.all that also returns false if array is all np.nan'''
-    return bool(np.all(v) and ~np.all(np.isnan(v)))
-
-
 def gen_isnan(v):
     '''Check isnan for general type (np.isnan is only operable on np type)'''
     try:
@@ -252,6 +247,11 @@ def is_sub_dict(sub_dict, super_dict):
 def ndenumerate_nonan(arr):
     '''Generic ndenumerate for np.ndenumerate with only not gen_isnan values'''
     return (idx_v for idx_v in np.ndenumerate(arr) if not gen_isnan(idx_v[1]))
+
+
+def nonan_all(v):
+    '''Generic np.all that also returns false if array is all np.nan'''
+    return bool(np.all(v) and ~np.all(np.isnan(v)))
 
 
 def read(data_path):

--- a/slm_lab/spec/dqn.json
+++ b/slm_lab/spec/dqn.json
@@ -262,7 +262,7 @@
         "gamma": 0.999,
         "explore_var_start": 5.0,
         "explore_var_end": 1.0,
-        "explore_anneal_epi": 20,
+        "explore_anneal_epi": 30,
         "training_min_timestep": 10,
         "training_frequency": 1,
         "training_epoch": 5,
@@ -300,7 +300,7 @@
       "max_episode": 50,
       "max_session": 1,
       "max_trial": 1,
-      "train_mode": false
+      "train_mode": true
     }
   },
   "dqn_2dball_cartpole": {
@@ -337,11 +337,11 @@
       }
     }],
     "env": [{
-      "name": "CartPole-v0",
-      "max_timestep": null
-    }, {
       "name": "2DBall",
       "max_timestep": 200
+    }, {
+      "name": "CartPole-v0",
+      "max_timestep": null
     }],
     "body": {
       "product": "outer",
@@ -351,7 +351,7 @@
       "max_episode": 60,
       "max_session": 1,
       "max_trial": 1,
-      "train_mode": false
+      "train_mode": true
     }
   },
   "dqn_acrobot": {
@@ -436,10 +436,10 @@
       }
     }],
     "env": [{
-      "name": "CartPole-v0",
+      "name": "Acrobot-v1",
       "max_timestep": null
     }, {
-      "name": "Acrobot-v1",
+      "name": "CartPole-v0",
       "max_timestep": null
     }],
     "body": {

--- a/slm_lab/spec/dqn.json
+++ b/slm_lab/spec/dqn.json
@@ -3,7 +3,7 @@
     "agent": [{
       "name": "DQN",
       "algorithm": {
-        "name": "DQNBase",
+        "name": "DQN",
         "action_policy": "boltzmann",
         "action_policy_update": "linear_decay",
         "explore_var_start": 5.0,
@@ -24,7 +24,7 @@
         "hid_layers": [64],
         "hid_layers_activation": "relu",
         "optim": {
-          "name": "Adam",
+          "name": "SGD",
           "lr": 0.02
         },
         "loss": {
@@ -55,7 +55,7 @@
     "agent": [{
       "name": "VanillaDQN",
       "algorithm": {
-        "name": "DQNBase",
+        "name": "DQN",
         "action_policy": "boltzmann",
         "action_policy_update": "linear_decay",
         "gamma": 0.999,
@@ -79,7 +79,7 @@
         "polyak_weight": 0,
         "update_frequency": 1.0,
         "optim": {
-          "lr": 0.02
+          "name": "Adam"
         },
         "batch_size": 32
       }
@@ -127,7 +127,7 @@
         "polyak_weight": 0,
         "update_frequency": 1.0,
         "optim": {
-          "lr": 0.02
+          "name": "Adam"
         },
         "batch_size": 32
       }
@@ -178,7 +178,7 @@
         "polyak_weight": 0,
         "update_frequency": 1.0,
         "optim": {
-          "lr": 0.02
+          "name": "Adam"
         },
         "batch_size": 32
       }
@@ -199,57 +199,6 @@
     },
     "meta": {
       "max_episode": 100,
-      "max_session": 1,
-      "max_trial": 1,
-      "train_mode": true
-    }
-  },
-  "dqn_acrobot_cartpole": {
-    "agent": [{
-      "name": "MultitaskDQN",
-      "algorithm": {
-        "name": "MultitaskDQN",
-        "action_policy": "multi_boltzmann",
-        "action_policy_update": "linear_decay",
-        "gamma": 0.999,
-        "explore_var_start": 5.0,
-        "explore_var_end": 1.0,
-        "explore_anneal_epi": 15,
-        "training_min_timestep": 10,
-        "training_frequency": 1,
-        "training_epoch": 5,
-        "training_iters_per_batch": 3
-      },
-      "memory": {
-        "name": "Replay",
-        "max_size": 10000
-      },
-      "net": {
-        "type": "MLPNet",
-        "hid_layers": [64],
-        "hid_layers_activation": "relu",
-        "update_type": "replace",
-        "polyak_weight": 0,
-        "update_frequency": 1.0,
-        "optim": {
-          "lr": 0.02
-        },
-        "batch_size": 32
-      }
-    }],
-    "env": [{
-      "name": "CartPole-v0",
-      "max_timestep": null
-    }, {
-      "name": "Acrobot-v1",
-      "max_timestep": null
-    }],
-    "body": {
-      "product": "outer",
-      "num": 1
-    },
-    "meta": {
-      "max_episode": 50,
       "max_session": 1,
       "max_trial": 1,
       "train_mode": true
@@ -283,7 +232,7 @@
         "polyak_weight": 0,
         "update_frequency": 1.0,
         "optim": {
-          "lr": 0.02
+          "name": "Adam"
         },
         "batch_size": 32
       }
@@ -310,7 +259,7 @@
     "agent": [{
       "name": "VanillaDQN",
       "algorithm": {
-        "name": "DQNBase",
+        "name": "DQN",
         "action_policy": "boltzmann",
         "action_policy_update": "linear_decay",
         "gamma": 0.9999,
@@ -334,7 +283,7 @@
         "polyak_weight": 0,
         "update_frequency": 1.0,
         "optim": {
-          "lr": 0.001
+          "name": "Adam"
         },
         "batch_size": 16
       }
@@ -354,11 +303,62 @@
       "train_mode": true
     }
   },
+  "dqn_acrobot_cartpole": {
+    "agent": [{
+      "name": "MultitaskDQN",
+      "algorithm": {
+        "name": "MultitaskDQN",
+        "action_policy": "multi_boltzmann",
+        "action_policy_update": "linear_decay",
+        "gamma": 0.999,
+        "explore_var_start": 5.0,
+        "explore_var_end": 1.0,
+        "explore_anneal_epi": 15,
+        "training_min_timestep": 10,
+        "training_frequency": 1,
+        "training_epoch": 5,
+        "training_iters_per_batch": 3
+      },
+      "memory": {
+        "name": "Replay",
+        "max_size": 10000
+      },
+      "net": {
+        "type": "MLPNet",
+        "hid_layers": [64],
+        "hid_layers_activation": "relu",
+        "update_type": "replace",
+        "polyak_weight": 0,
+        "update_frequency": 1.0,
+        "optim": {
+          "name": "Adam"
+        },
+        "batch_size": 32
+      }
+    }],
+    "env": [{
+      "name": "CartPole-v0",
+      "max_timestep": null
+    }, {
+      "name": "Acrobot-v1",
+      "max_timestep": null
+    }],
+    "body": {
+      "product": "outer",
+      "num": 1
+    },
+    "meta": {
+      "max_episode": 50,
+      "max_session": 1,
+      "max_trial": 1,
+      "train_mode": true
+    }
+  },
   "dqn_3dball_single": {
     "agent": [{
       "name": "VanillaDQN",
       "algorithm": {
-        "name": "DQNBase",
+        "name": "DQN",
         "action_policy": "boltzmann",
         "action_policy_update": "linear_decay",
         "gamma": 0.999,
@@ -382,7 +382,7 @@
         "polyak_weight": 0,
         "update_frequency": 1.0,
         "optim": {
-          "lr": 0.02
+          "name": "Adam"
         },
         "batch_size": 32
       }
@@ -430,7 +430,7 @@
         "polyak_weight": 0,
         "update_frequency": 1.0,
         "optim": {
-          "lr": 0.02
+          "name": "Adam"
         },
         "batch_size": 32
       }
@@ -481,7 +481,7 @@
         "polyak_weight": 0,
         "update_frequency": 1.0,
         "optim": {
-          "lr": 0.02
+          "name": "Adam"
         },
         "batch_size": 32
       }
@@ -508,7 +508,7 @@
     "agent": [{
       "name": "VanillaDQN",
       "algorithm": {
-        "name": "DQNBase",
+        "name": "DQN",
         "action_policy": "boltzmann",
         "action_policy_update": "linear_decay",
         "gamma": 0.99,
@@ -532,7 +532,7 @@
         "polyak_weight": 0,
         "update_frequency": 1.0,
         "optim": {
-          "lr": 0.005
+          "name": "Adam"
         },
         "batch_size": 32
       }
@@ -561,7 +561,7 @@
     "agent": [{
       "name": "DQN",
       "algorithm": {
-        "name": "DQNBase",
+        "name": "DQN",
         "action_policy": "boltzmann",
         "action_policy_update": "linear_decay",
         "explore_var_start": 5.0,
@@ -582,8 +582,7 @@
         "hid_layers": [64],
         "hid_layers_activation": "relu",
         "optim": {
-          "name": "Adam",
-          "lr": 0.02
+          "name": "Adam"
         },
         "loss": {
           "name": "mse_loss"

--- a/slm_lab/spec/dqn.json
+++ b/slm_lab/spec/dqn.json
@@ -53,7 +53,7 @@
   },
   "dqn_cartpole": {
     "agent": [{
-      "name": "VanillaDQN",
+      "name": "DQN",
       "algorithm": {
         "name": "DQN",
         "action_policy": "boltzmann",
@@ -204,6 +204,105 @@
       "train_mode": true
     }
   },
+  "dqn_2dball": {
+    "agent": [{
+      "name": "DQN",
+      "algorithm": {
+        "name": "DQN",
+        "action_policy": "boltzmann",
+        "action_policy_update": "linear_decay",
+        "gamma": 0.999,
+        "explore_var_start": 5.0,
+        "explore_var_end": 1.0,
+        "explore_anneal_epi": 20,
+        "training_min_timestep": 0,
+        "training_frequency": 1,
+        "training_epoch": 5,
+        "training_iters_per_batch": 3
+      },
+      "memory": {
+        "name": "Replay",
+        "max_size": 10000
+      },
+      "net": {
+        "type": "MLPNet",
+        "hid_layers": [64],
+        "hid_layers_activation": "sigmoid",
+        "update_type": "replace",
+        "polyak_weight": 0,
+        "update_frequency": 1.0,
+        "optim": {
+          "name": "Adam"
+        },
+        "batch_size": 32
+      }
+    }],
+    "env": [{
+      "name": "2DBall",
+      "max_timestep": 200
+    }],
+    "body": {
+      "product": "outer",
+      "num": 1
+    },
+    "meta": {
+      "max_episode": 50,
+      "max_session": 1,
+      "max_trial": 1,
+      "train_mode": true
+    }
+  },
+  "dqn_2dball_2dball": {
+    "agent": [{
+      "name": "MultitaskDQN",
+      "algorithm": {
+        "name": "MultitaskDQN",
+        "action_policy": "multi_boltzmann",
+        "action_policy_update": "linear_decay",
+        "gamma": 0.999,
+        "explore_var_start": 5.0,
+        "explore_var_end": 1.0,
+        "explore_anneal_epi": 20,
+        "training_min_timestep": 10,
+        "training_frequency": 1,
+        "training_epoch": 5,
+        "training_iters_per_batch": 3
+      },
+      "memory": {
+        "name": "Replay",
+        "max_size": 10000
+      },
+      "net": {
+        "type": "MLPNet",
+        "hid_layers": [64],
+        "hid_layers_activation": "sigmoid",
+        "update_type": "replace",
+        "polyak_weight": 0,
+        "update_frequency": 1.0,
+        "optim": {
+          "name": "Adam"
+        },
+        "batch_size": 32
+      }
+    }],
+    "env": [{
+      "name": "2DBall",
+      "max_timestep": 200
+    }, {
+      "name": "2DBall",
+      "max_timestep": 200
+    }],
+    "body": {
+      "product": "outer",
+      "num": 1
+    },
+    "meta": {
+      "max_episode": 50,
+      "max_session": 1,
+      "max_trial": 1,
+      "train_mode": false
+    }
+  },
   "dqn_2dball_cartpole": {
     "agent": [{
       "name": "MultitaskDQN",
@@ -214,7 +313,7 @@
         "gamma": 0.999,
         "explore_var_start": 5.0,
         "explore_var_end": 1.0,
-        "explore_anneal_epi": 15,
+        "explore_anneal_epi": 30,
         "training_min_timestep": 10,
         "training_frequency": 1,
         "training_epoch": 5,
@@ -242,14 +341,14 @@
       "max_timestep": null
     }, {
       "name": "2DBall",
-      "max_timestep": 1000
+      "max_timestep": 200
     }],
     "body": {
       "product": "outer",
       "num": 1
     },
     "meta": {
-      "max_episode": 50,
+      "max_episode": 60,
       "max_session": 1,
       "max_trial": 1,
       "train_mode": false
@@ -257,7 +356,7 @@
   },
   "dqn_acrobot": {
     "agent": [{
-      "name": "VanillaDQN",
+      "name": "DQN",
       "algorithm": {
         "name": "DQN",
         "action_policy": "boltzmann",
@@ -356,7 +455,7 @@
   },
   "dqn_3dball_single": {
     "agent": [{
-      "name": "VanillaDQN",
+      "name": "DQN",
       "algorithm": {
         "name": "DQN",
         "action_policy": "boltzmann",
@@ -506,7 +605,7 @@
   },
   "dqn_gridworld": {
     "agent": [{
-      "name": "VanillaDQN",
+      "name": "DQN",
       "algorithm": {
         "name": "DQN",
         "action_policy": "boltzmann",

--- a/slm_lab/spec/dqn.json
+++ b/slm_lab/spec/dqn.json
@@ -275,7 +275,7 @@
       "net": {
         "type": "MLPNet",
         "hid_layers": [64],
-        "hid_layers_activation": "sigmoid",
+        "hid_layers_activation": "relu",
         "update_type": "replace",
         "polyak_weight": 0,
         "update_frequency": 1.0,
@@ -326,7 +326,7 @@
       "net": {
         "type": "MLPNet",
         "hid_layers": [64],
-        "hid_layers_activation": "sigmoid",
+        "hid_layers_activation": "relu",
         "update_type": "replace",
         "polyak_weight": 0,
         "update_frequency": 1.0,

--- a/test/lib/test_util.py
+++ b/test/lib/test_util.py
@@ -79,18 +79,6 @@ def test_flatten_nonan(arr, res):
     assert np.array_equal(util.flatten_nonan(arr), res)
 
 
-@pytest.mark.parametrize('v,isall', [
-    ([1, 1], True),
-    ([True, True], True),
-    ([np.nan, 1], True),
-    ([0, 1], False),
-    ([False, True], False),
-    ([np.nan, np.nan], False),
-])
-def test_gen_all(v, isall):
-    assert util.gen_all(v) == isall
-
-
 @pytest.mark.parametrize('v,isnan', [
     (0, False),
     (1, False),
@@ -145,6 +133,18 @@ def test_ndenumerate_nonan():
     for (a, b), body in util.ndenumerate_nonan(arr):
         assert a == b
         assert body == 1
+
+
+@pytest.mark.parametrize('v,isall', [
+    ([1, 1], True),
+    ([True, True], True),
+    ([np.nan, 1], True),
+    ([0, 1], False),
+    ([False, True], False),
+    ([np.nan, np.nan], False),
+])
+def test_nonan_all(v, isall):
+    assert util.nonan_all(v) == isall
 
 
 def test_s_get(test_agent):


### PR DESCRIPTION
Run 2dball, cartpole on multienv, fix some things along the way.

Works, though performance could be improved via param tuning and longer training. Notes:
- need `relu` activation to work for multienv
- complexity nearly the same between 2 envs. So similar params could solve both. Good sanity test.
- Though in 2dball agent would have to learn to "catch" the ball when it's first dropped from the sky at reset.

Experiment strategy, sequence of experiments:
- `cartpole`
- `2dball`
- `cartpole-cartpole`
- `2dball-2dball`
- `2dball-cartpole`

![dqn_cartpole_2](https://user-images.githubusercontent.com/8209263/34430179-3ff21f3a-ec30-11e7-9947-126cb5401699.png)
![dqn_2dball_2](https://user-images.githubusercontent.com/8209263/34430183-4a24e852-ec30-11e7-99ef-6c10d8ef65a0.png)
![dqn_cartpole_cartpole_0](https://user-images.githubusercontent.com/8209263/34430172-224a32e2-ec30-11e7-85a9-ba809bf3c8f1.png)
![dqn_2dball_2dball](https://user-images.githubusercontent.com/8209263/34430160-03eeaf44-ec30-11e7-95c4-c2ae8f086f7f.png)
![dqn_2dball_cartpole_5](https://user-images.githubusercontent.com/8209263/34430133-8b848df8-ec2f-11e7-9330-f4d1956c4667.png)
