### PR TITLE
Benchmark fix

### DIFF
--- a/slm_lab/experiment/analysis.py
+++ b/slm_lab/experiment/analysis.py
@@ -400,6 +400,7 @@ def retro_analyze(predir):
     predir = 'data/reinforce_cartpole_2018_01_22_211751'
     analysis.retro_analyze(predir)
     '''
+    os.environ['PREPATH'] = f'{predir}/retro_analyze'  # to prevent overwriting log file
     logger.info(f'Retro-analyzing {predir}')
     retro_analyze_sessions(predir)
     retro_analyze_trials(predir)

--- a/slm_lab/experiment/analysis.py
+++ b/slm_lab/experiment/analysis.py
@@ -294,6 +294,7 @@ def trial_data_dict_from_file(predir):
 
 def mock_info_space_spec(predir):
     '''Helper for retro analysis to build mock info_space and spec'''
+    from slm_lab.experiment.monitor import InfoSpace
     spec_name = spec_name_from_filepath(predir)
     experiment_ts = predir.split('/')[1].replace(f'{spec_name}_', '')
     info_space = InfoSpace()
@@ -302,19 +303,34 @@ def mock_info_space_spec(predir):
     return info_space, spec
 
 
-def analyze_experiment_from_file(predir):
+def retro_analyze(predir):
+    retro_analyze_session(predir)
+    restro_analyze_trial(predir)
+    retro_analyze_experiment(predir)
+    return
+
+
+def retro_analyze_session(predir):
+    return
+
+
+def restro_analyze_trial(predir):
+    from slm_lab.experiment.control import Experiment
+    return
+
+
+def retro_analyze_experiment(predir):
     '''
-    Method to analyze experiment from file.
+    Method to analyze experiment from file after it ran.
     Read trial_data from files, constructs an experiment, then run analyze_experiment
     @example
 
     from slm_lab.experiment import analysis
     predir = 'data/reinforce_cartpole_2018_01_22_211751'
-    analysis.analyze_experiment_from_file(predir)
+    analysis.retro_analyze_experiment(predir)
     '''
-    logger.info('Analyzing experiment from file')
+    logger.info('Retro-analyzing experiment from file')
     from slm_lab.experiment.control import Experiment
-    from slm_lab.experiment.monitor import InfoSpace
     trial_data_dict = trial_data_dict_from_file(predir)
     # create experiment with needed data to call analyze_experiment()
     info_space, spec = mock_info_space_spec(predir)

--- a/slm_lab/experiment/analysis.py
+++ b/slm_lab/experiment/analysis.py
@@ -292,6 +292,16 @@ def trial_data_dict_from_file(predir):
     return trial_data_dict
 
 
+def mock_info_space_spec(predir):
+    '''Helper for retro analysis to build mock info_space and spec'''
+    spec_name = spec_name_from_filepath(predir)
+    experiment_ts = predir.split('/')[1].replace(f'{spec_name}_', '')
+    info_space = InfoSpace()
+    info_space.experiment_ts = experiment_ts
+    spec_name = spec_name_from_filepath(predir)
+    return info_space, spec
+
+
 def analyze_experiment_from_file(predir):
     '''
     Method to analyze experiment from file.
@@ -307,11 +317,7 @@ def analyze_experiment_from_file(predir):
     from slm_lab.experiment.monitor import InfoSpace
     trial_data_dict = trial_data_dict_from_file(predir)
     # create experiment with needed data to call analyze_experiment()
-    spec_name = spec_name_from_filepath(predir)
-    spec = util.read(os.path.join(predir, f'{spec_name}_spec.json'))
-    experiment_ts = predir.split('/')[1].replace(f'{spec_name}_', '')
-    info_space = InfoSpace()
-    info_space.experiment_ts = experiment_ts
+    info_space, spec = mock_info_space_spec(predir)
     info_space.set('experiment', 0)
     experiment = Experiment(spec, info_space)
     experiment.trial_data_dict = trial_data_dict

--- a/slm_lab/experiment/analysis.py
+++ b/slm_lab/experiment/analysis.py
@@ -205,8 +205,7 @@ def save_experiment_data(spec, info_space, experiment_df, experiment_fig):
     util.write(experiment_df, f'{prepath}_experiment_df.csv')
     viz.save_image(experiment_fig, f'{prepath}_experiment_graph.png')
     # TODO tmp hack
-    if os.environ.get('run_mode') == 'search':
-        plot_best_sessions(experiment_df, prepath)
+    plot_best_sessions(experiment_df, prepath)
 
 
 def analyze_session(session, session_data=None):

--- a/slm_lab/experiment/analysis.py
+++ b/slm_lab/experiment/analysis.py
@@ -358,6 +358,7 @@ def retro_analyze_sessions(predir):
             session_data = session_data_from_file(
                 predir, trial_index, session_index)
             analyze_session(session, session_data)
+            # write trial_data.json too
 
 
 def retro_analyze_trials(predir):
@@ -366,6 +367,7 @@ def retro_analyze_trials(predir):
     from slm_lab.experiment.control import Trial
     for filename in os.listdir(predir):
         if filename.endswith('_trial_data.json'):
+            filepath = f'{predir}/{filename}'
             tn = filename.replace('_trial_data.json', '').split('_')[-1]
             trial_index = int(tn[1:])
             # mock trial
@@ -374,7 +376,15 @@ def retro_analyze_trials(predir):
             session_data_dict = session_data_dict_from_file(
                 predir, trial_index)
             trial.session_data_dict = session_data_dict
-            analyze_trial(trial)
+            trial_fitness_df = analyze_trial(trial)
+            # write trial_data that was written from ray search
+            fitness_vec = trial_fitness_df.iloc[0].to_dict()
+            fitness = calc_fitness(trial_fitness_df)
+            trial_data = util.read(filepath)
+            trial_data.update({
+                **fitness_vec, 'fitness': fitness, 'trial_index': trial_index,
+            })
+            util.write(trial_data, filepath)
 
 
 def retro_analyze_experiment(predir):

--- a/slm_lab/experiment/analysis.py
+++ b/slm_lab/experiment/analysis.py
@@ -60,6 +60,7 @@ def calc_session_fitness_df(session, session_data):
         body = session.aeb_space.body_space.data[aeb]
         aeb_fitness_sr = calc_aeb_fitness_sr(aeb_df, body.env.name)
         aeb_fitness_df = pd.DataFrame([aeb_fitness_sr], index=[session.index])
+        aeb_fitness_df = aeb_fitness_df.reindex(FITNESS_COLS[:3], axis=1)
         session_fitness_data[aeb] = aeb_fitness_df
     # form multiindex df, then take mean across all bodies
     session_fitness_df = pd.concat(session_fitness_data, axis=1)
@@ -84,6 +85,7 @@ def calc_trial_fitness_df(trial):
         aeb_fitness_sr = aeb_fitness_sr.append(
             pd.Series({'consistency': consistency}))
         aeb_fitness_df = pd.DataFrame([aeb_fitness_sr], index=[trial.index])
+        aeb_fitness_df = aeb_fitness_df.reindex(FITNESS_COLS, axis=1)
         trial_fitness_data[aeb] = aeb_fitness_df
     # form multiindex df, then take mean across all bodies
     trial_fitness_df = pd.concat(trial_fitness_data, axis=1)

--- a/slm_lab/experiment/control.py
+++ b/slm_lab/experiment/control.py
@@ -34,7 +34,8 @@ class Session:
     then return the session data.
     '''
 
-    def __init__(self, spec, info_space=InfoSpace()):
+    def __init__(self, spec, info_space=None):
+        info_space = info_space or InfoSpace()
         init_thread_vars(info_space, spec, unit='session')
         self.spec = spec
         self.info_space = info_space
@@ -92,7 +93,8 @@ class Trial:
     then return the trial data.
     '''
 
-    def __init__(self, spec, info_space=InfoSpace()):
+    def __init__(self, spec, info_space=None):
+        info_space = info_space or InfoSpace()
         init_thread_vars(info_space, spec, unit='trial')
         self.spec = spec
         self.info_space = info_space
@@ -144,7 +146,8 @@ class Experiment:
     '''
     # TODO metaspec to specify specs to run, can be sourced from evolution suggestion
 
-    def __init__(self, spec, info_space=InfoSpace()):
+    def __init__(self, spec, info_space=None):
+        info_space = info_space or InfoSpace()
         init_thread_vars(info_space, spec, unit='experiment')
         self.spec = spec
         spec['meta']['train_mode'] = True

--- a/slm_lab/experiment/control.py
+++ b/slm_lab/experiment/control.py
@@ -16,12 +16,12 @@ import pydash as _
 import torch
 
 
-def init_thread_vars(info_space, spec, unit):
+def init_thread_vars(spec, info_space, unit):
     '''Initialize thread variables from lab units that do not get carried over properly from master'''
     if info_space.get(unit) is None:
         info_space.tick(unit)
-    if logger.to_init(info_space, spec):
-        os.environ['PREPATH'] = analysis.get_prepath(info_space, spec)
+    if logger.to_init(spec, info_space):
+        os.environ['PREPATH'] = analysis.get_prepath(spec, info_space)
         importlib.reload(logger)
 
 
@@ -36,7 +36,7 @@ class Session:
 
     def __init__(self, spec, info_space=None):
         info_space = info_space or InfoSpace()
-        init_thread_vars(info_space, spec, unit='session')
+        init_thread_vars(spec, info_space, unit='session')
         self.spec = spec
         self.info_space = info_space
         self.coor, self.index = self.info_space.get_coor_idx(self)
@@ -95,13 +95,13 @@ class Trial:
 
     def __init__(self, spec, info_space=None):
         info_space = info_space or InfoSpace()
-        init_thread_vars(info_space, spec, unit='trial')
+        init_thread_vars(spec, info_space, unit='trial')
         self.spec = spec
         self.info_space = info_space
         self.coor, self.index = self.info_space.get_coor_idx(self)
         self.session_data_dict = {}
         self.data = None
-        analysis.save_spec(info_space, spec, unit='trial')
+        analysis.save_spec(spec, info_space, unit='trial')
         logger.info(f'Initialized trial {self.index}')
 
     def init_session_and_run(self, info_space):
@@ -148,7 +148,7 @@ class Experiment:
 
     def __init__(self, spec, info_space=None):
         info_space = info_space or InfoSpace()
-        init_thread_vars(info_space, spec, unit='experiment')
+        init_thread_vars(spec, info_space, unit='experiment')
         self.spec = spec
         spec['meta']['train_mode'] = True
         self.info_space = info_space
@@ -157,7 +157,7 @@ class Experiment:
         self.data = None
         SearchClass = getattr(search, 'RaySearch')
         self.search = SearchClass(self)
-        analysis.save_spec(info_space, spec, unit='experiment')
+        analysis.save_spec(spec, info_space, unit='experiment')
         logger.info(f'Initialized experiment {self.index}')
 
     def init_trial_and_run(self, spec, info_space):

--- a/slm_lab/experiment/search.py
+++ b/slm_lab/experiment/search.py
@@ -83,7 +83,7 @@ class RaySearch:
             trial_data = {
                 **config, **fitness_vec, 'fitness': fitness, 'trial_index': trial_index,
             }
-            prepath = analysis.get_prepath(info_space, spec, unit='trial')
+            prepath = analysis.get_prepath(spec, info_space, unit='trial')
             util.write(trial_data, f'{prepath}_trial_data.json')
             done = True
             # TODO timesteps = episode len or total_t from space_clock
@@ -121,7 +121,7 @@ class RaySearch:
             logger.exception(
                 'Some Ray trials failed, finish experiment analysis from files.')
             prepath = analysis.get_prepath(
-                self.experiment.info_space, self.experiment.spec, unit='experiment')
+                self.experiment.spec, self.experiment.info_space, unit='experiment')
             predir = os.path.dirname(prepath)
             trial_data_dict = analysis.trial_data_dict_from_file(predir)
 

--- a/slm_lab/lib/logger.py
+++ b/slm_lab/lib/logger.py
@@ -57,7 +57,7 @@ class DedentFormatter(logging.Formatter):
         return super(DedentFormatter, self).format(record)
 
 
-def to_init(info_space, spec):
+def to_init(spec, info_space):
     '''
     Whether the lab's logger had been initialized:
     - prepath present in env

--- a/slm_lab/lib/util.py
+++ b/slm_lab/lib/util.py
@@ -126,6 +126,13 @@ def filter_nonan(arr):
         return np.array(mixed_type, dtype=arr.dtype)
 
 
+def fix_multiindex_dtype(df):
+    '''Restore aeb multiindex dtype from string to int, when read from file'''
+    df.columns = pd.MultiIndex.from_tuples(
+        [(int(x[0]), int(x[1]), int(x[2]), x[3]) for x in df.columns])
+    return df
+
+
 def nanflatten(arr):
     '''Flatten np array while ignoring nan, like np.nansum etc.'''
     flat_arr = arr.reshape(-1)
@@ -538,6 +545,7 @@ def session_df_to_data(session_df):
     session_data = util.session_df_to_data(session_df)
     '''
     session_data = {}
+    fix_multiindex_dtype(session_df)
     aeb_list = get_df_aeb_list(session_df)
     for aeb in aeb_list:
         aeb_df = session_df.loc[:, aeb]

--- a/slm_lab/spec/_fitness_std.json
+++ b/slm_lab/spec/_fitness_std.json
@@ -7,6 +7,6 @@
   "CartPole-v0": {
     "rand_epi_reward": 20,
     "std_epi_reward": 200,
-    "std_timestep": 1500
+    "std_timestep": 20000
   }
 }


### PR DESCRIPTION
- fix small issues with benchmark indexing
- add retro analysis to rerun analysis on standard update
- standardize args to use `spec` before `info_space`
- update CartPole-v0 benchmark to 20k timesteps