### PR TITLE
fix floating point precision issue in analysis

### DIFF
--- a/slm_lab/lib/util.py
+++ b/slm_lab/lib/util.py
@@ -96,6 +96,14 @@ def dedent(string):
     return RE_INDENT.sub('', string)
 
 
+def downcast_float32(df):
+    '''Downcast any float64 col to float32 to allow safer pandas comparison'''
+    for col in df.columns:
+        if df[col].dtype == 'float':
+            df[col] = df[col].astype('float32')
+    return df
+
+
 def flatten_dict(obj, delim='.'):
     '''Missing pydash method to flatten dict'''
     nobj = {}


### PR DESCRIPTION
Pandas apparently has unreliable comparison when its values are float64: https://stackoverflow.com/questions/33626443/comparing-floats-in-a-pandas-column

This caused retro-analysis to give wrong results (stability). Fix by downcasting to float32 when computing fitness.