### PR TITLE
plotly fix, skip ran benchmark

### DIFF
--- a/run_lab.py
+++ b/run_lab.py
@@ -12,8 +12,10 @@ import os
 def run_benchmark(spec, const):
     benchmark_specs = benchmarker.generate_specs(spec, const)
     logger.info('Running benchmark')
-    for _spec_name, benchmark_spec in benchmark_specs.items():
-        Experiment(benchmark_spec).run()
+    for spec_name, benchmark_spec in benchmark_specs.items():
+        # run only if not already exist; benchmark mode only
+        if not any(spec_name in filename for filename in os.listdir('data')):
+            Experiment(benchmark_spec).run()
 
 
 def run_by_mode(spec_file, spec_name, run_mode):

--- a/slm_lab/lib/viz.py
+++ b/slm_lab/lib/viz.py
@@ -32,14 +32,18 @@ def save_image(figure, filepath=None):
     if os.environ.get('PY_ENV') == 'test':
         return
     if filepath is None:
-        filepath = f"{PLOT_FILEDIR}/{_.get(figure, 'layout.title')}.png"
-
-    plotly.tools.set_credentials_file(
-        username=_.get(config, 'plotly.username'),
-        api_key=_.get(config, 'plotly.api_key'))
-    plotly.tools.set_config_file(
-        world_readable=True, sharing='public')
-    return plotly.plotly.image.save_as(figure, filepath)
+        filepath = f'{PLOT_FILEDIR}/{_.get(figure, "layout.title")}.png'
+    try:
+        plotly.tools.set_credentials_file(
+            username=_.get(config, 'plotly.username'),
+            api_key=_.get(config, 'plotly.api_key'))
+        plotly.tools.set_config_file(
+            world_readable=True, sharing='public')
+        return plotly.plotly.image.save_as(figure, filepath)
+    except Exception:
+        logger.error(
+            'Plotly server unreachable, but you can save the plots later via retro-analysis.')
+        return None
 
 
 def stack_cumsum(df, y_col):


### PR DESCRIPTION
- add guard to save_image to prevent plotly from breaking when failing to reach server
- skip benchmark that is already ran