### PR TITLE
Circle CI: Add flake8 tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -112,8 +112,8 @@ jobs:
             ./cc-test-reporter before-build
             conda activate lab
             python --version ; pip --version
-            python setup.py test
             sudo pip install flake8
+            python setup.py test
             # stop the build if there are Python syntax errors or undefined names
             flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics
             # exit-zero treats all errors as warnings.  The GitHub editor is 127 chars wide      

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -111,7 +111,13 @@ jobs:
             chmod +x ./cc-test-reporter
             ./cc-test-reporter before-build
             conda activate lab
+            python --version ; pip --version
             python setup.py test
+            sudo pip install flake8
+            # stop the build if there are Python syntax errors or undefined names
+            flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics
+            # exit-zero treats all errors as warnings.  The GitHub editor is 127 chars wide      
+            flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
             cat coverage.xml
             ./cc-test-reporter after-build -d -p ~/SLM-Lab --exit-code $?
       - store_test_results:


### PR DESCRIPTION
[flake8](http://flake8.pycqa.org) will find _undefined names_ which might not be discovered by other linters or tests.

Each undefined name has the potential to raise NameError at runtime.