### PR TITLE
Add a test to create an Argmax()

### DIFF
--- a/slm_lab/agent/algorithm/policy_util.py
+++ b/slm_lab/agent/algorithm/policy_util.py
@@ -338,3 +338,7 @@ def rate_decay(algorithm, body):
 def periodic_decay(algorithm, body):
     '''Apply _periodic_decay to explore_var'''
     return fn_decay_explore_var(algorithm, body, _periodic_decay)
+
+
+if __name__ == '__main__':
+    Argmax(probs=[])


### PR DESCRIPTION
__python3 slm_lab/agent/algorithm/policy_util.py__  #135 pointed out that there is a difference between __new_prob__ and __new_probs__ (singular vs. plural).

That [typo in the variable name](https://github.com/kengz/SLM-Lab/blob/master/slm_lab/agent/algorithm/policy_util.py#L43) may cause a NameError to be raised when an Argmax() is created.