### PR TITLE
Refactor Net module

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,11 +91,10 @@ code: [slm_lab/agent/net](https://github.com/kengz/SLM-Lab/tree/master/slm_lab/a
 
 These networks are usable for all algorithms.
 
-- MLPNet (Multi Layer Perceptron)
-- MLPHeterogenousTails (multi-tails)
+- MLPNet (Multi Layer Perceptron, with multi-tails support)
 - HydraMLPNet (multi-heads, multi-tails)
-- RecurrentNet
-- ConvNet
+- RecurrentNet (with multi-tails support)
+- ConvNet (with multi-tails support)
 
 These networks are usable for Q-learning algorithms. For more details see [this paper](http://proceedings.mlr.press/v48/wangf16.pdf).
 

--- a/slm_lab/agent/algorithm/actor_critic.py
+++ b/slm_lab/agent/algorithm/actor_critic.py
@@ -180,12 +180,7 @@ class ActorCritic(Reinforce):
         '''
         The pdparam will be the logits for discrete prob. dist., or the mean and std for continuous prob. dist.
         '''
-        net = self.net if net is None else net
-        if evaluate:
-            pdparam = net.wrap_eval(x)
-        else:
-            net.train()
-            pdparam = net(x)
+        pdparam = super(ActorCritic, self).calc_pdparam(x, evaluate=evaluate, net=net)
         if self.shared:  # output: policy, value
             if len(pdparam) == 2:  # single policy outputs, value
                 pdparam = pdparam[0]

--- a/slm_lab/agent/algorithm/actor_critic.py
+++ b/slm_lab/agent/algorithm/actor_critic.py
@@ -62,7 +62,6 @@ class ActorCritic(Reinforce):
         "entropy_coef": 0.01,
         "policy_loss_coef": 1.0,
         "val_loss_coef": 0.01,
-        "continuous_action_clip": 2.0,
         "training_frequency": 1,
         "training_epoch": 8
     }
@@ -107,7 +106,6 @@ class ActorCritic(Reinforce):
             'entropy_coef',
             'policy_loss_coef',
             'val_loss_coef',
-            'continuous_action_clip',
             'training_frequency',
             'training_epoch',
         ])

--- a/slm_lab/agent/algorithm/actor_critic.py
+++ b/slm_lab/agent/algorithm/actor_critic.py
@@ -66,6 +66,12 @@ class ActorCritic(Reinforce):
         "training_frequency": 1,
         "training_epoch": 8
     }
+
+    e.g. special net_spec param "shared" to share/separate Actor/Critic
+    "net": {
+        "type": "MLPNet",
+        "shared": true,
+        ...
     '''
 
     @lab_api

--- a/slm_lab/agent/algorithm/actor_critic.py
+++ b/slm_lab/agent/algorithm/actor_critic.py
@@ -326,13 +326,7 @@ class ActorCritic(Reinforce):
         if torch.cuda.is_available() and self.net.gpu:
             adv_targets = adv_targets.cuda()
             v_targets = v_targets.cuda()
-
-        # standardization trick
-        # guard nan std by setting to 0 and add small const
-        adv_std = adv_targets.std()
-        adv_std[adv_std != adv_std] = 0
-        adv_std += 1e-08
-        adv_targets = (adv_targets - adv_targets.mean()) / adv_std
+        adv_targets = math_util.standardize(adv_targets)
         logger.debug(f'adv_targets: {adv_targets}\nv_targets: {v_targets}')
         return adv_targets, v_targets
 

--- a/slm_lab/agent/algorithm/actor_critic.py
+++ b/slm_lab/agent/algorithm/actor_critic.py
@@ -1,4 +1,3 @@
-from copy import deepcopy
 from slm_lab.agent import net
 from slm_lab.agent.algorithm import math_util, policy_util
 from slm_lab.agent.algorithm.reinforce import Reinforce

--- a/slm_lab/agent/algorithm/dqn.py
+++ b/slm_lab/agent/algorithm/dqn.py
@@ -230,7 +230,7 @@ class DQNBase(VanillaDQN):
         if self.net.update_type == 'replace':
             if total_t % self.net.update_frequency == 0:
                 logger.debug('Updating target_net by replacing')
-                self.target_net.load_state_dict(self.net.state_dict())
+                net_util.copy(self.target_net, self.net)
                 self.online_net = self.target_net
                 self.eval_net = self.target_net
         elif self.net.update_type == 'polyak':

--- a/slm_lab/agent/algorithm/dqn.py
+++ b/slm_lab/agent/algorithm/dqn.py
@@ -1,4 +1,3 @@
-from copy import deepcopy
 from slm_lab.agent import net
 from slm_lab.agent.algorithm import policy_util
 from slm_lab.agent.algorithm.sarsa import SARSA

--- a/slm_lab/agent/algorithm/dqn.py
+++ b/slm_lab/agent/algorithm/dqn.py
@@ -92,8 +92,10 @@ class VanillaDQN(SARSA):
         '''Initialize the neural network used to learn the Q function from the spec'''
         if self.algorithm_spec['name'] == 'VanillaDQN':
             assert all(k not in self.net_spec for k in ['update_type', 'update_frequency', 'polyak_coef']), 'Network update not available for VanillaDQN; use DQN.'
+        in_dim = self.body.state_dim
+        out_dim = net_util.get_out_dim(self.body)
         NetClass = getattr(net, self.net_spec['type'])
-        self.net = NetClass(self.net_spec, self.body.state_dim, self.body.action_dim)
+        self.net = NetClass(self.net_spec, in_dim, out_dim)
         self.net_names = ['net']
         self.post_init_nets()
 
@@ -196,7 +198,8 @@ class DQNBase(VanillaDQN):
         '''Initialize networks'''
         if self.algorithm_spec['name'] == 'DQNBase':
             assert all(k not in self.net_spec for k in ['update_type', 'update_frequency', 'polyak_coef']), 'Network update not available for DQNBase; use DQN.'
-        in_dim, out_dim = self.body.state_dim, self.body.action_dim
+        in_dim = self.body.state_dim
+        out_dim = net_util.get_out_dim(self.body)
         NetClass = getattr(net, self.net_spec['type'])
         self.net = NetClass(self.net_spec, in_dim, out_dim)
         self.target_net = NetClass(self.net_spec, in_dim, out_dim)

--- a/slm_lab/agent/algorithm/math_util.py
+++ b/slm_lab/agent/algorithm/math_util.py
@@ -86,3 +86,8 @@ def calc_gaes(rewards, v_preds, next_v_preds, gamma, lam):
     assert not np.isnan(gaes).any(), f'GAE has nan: {gaes}'
     gaes = torch.from_numpy(gaes).float()
     return gaes
+
+
+def calc_q_value_logits(state_value, raw_advantages):
+    mean_adv = raw_advantages.mean(dim=-1).unsqueeze_(dim=-1)
+    return state_value + raw_advantages - mean_adv

--- a/slm_lab/agent/algorithm/math_util.py
+++ b/slm_lab/agent/algorithm/math_util.py
@@ -91,3 +91,13 @@ def calc_gaes(rewards, v_preds, next_v_preds, gamma, lam):
 def calc_q_value_logits(state_value, raw_advantages):
     mean_adv = raw_advantages.mean(dim=-1).unsqueeze_(dim=-1)
     return state_value + raw_advantages - mean_adv
+
+
+def standardize(v):
+    '''Method to standardize a rank-1 tensor'''
+    v_std = v.std()
+    # guard nan std by setting to 0 and add small const
+    v_std[v_std != v_std] = 0  # nan guard
+    v_std += 1e-08  # division guard
+    v = (v - v.mean()) / v_std
+    return v

--- a/slm_lab/agent/algorithm/ppo.py
+++ b/slm_lab/agent/algorithm/ppo.py
@@ -1,5 +1,4 @@
 from copy import deepcopy
-from functools import partial
 from slm_lab.agent import net
 from slm_lab.agent.algorithm import math_util, policy_util
 from slm_lab.agent.algorithm.actor_critic import ActorCritic
@@ -7,8 +6,8 @@ from slm_lab.agent.net import net_util
 from slm_lab.lib import logger, util
 from slm_lab.lib.decorator import lab_api
 import numpy as np
-import torch
 import pydash as ps
+import torch
 
 logger = logger.get_logger(__name__)
 

--- a/slm_lab/agent/algorithm/ppo.py
+++ b/slm_lab/agent/algorithm/ppo.py
@@ -46,6 +46,12 @@ class PPO(ActorCritic):
         "training_frequency": 1,
         "training_epoch": 8
     }
+
+    e.g. special net_spec param "shared" to share/separate Actor/Critic
+    "net": {
+        "type": "MLPNet",
+        "shared": true,
+        ...
     '''
 
     @lab_api

--- a/slm_lab/agent/algorithm/reinforce.py
+++ b/slm_lab/agent/algorithm/reinforce.py
@@ -148,12 +148,7 @@ class Reinforce(Algorithm):
         '''Calculate the policy loss for a batch of data.'''
         # use simple returns as advs
         advs = math_util.calc_returns(batch, self.gamma)
-        # advantage standardization trick
-        # guard nan std by setting to 0 and add small const
-        adv_std = advs.std()
-        adv_std[adv_std != adv_std] = 0  # nan guard
-        adv_std += 1e-08  # division guard
-        advs = (advs - advs.mean()) / adv_std
+        advs = math_util.standardize(advs)
         logger.debug(f'advs: {advs}')
         assert len(self.body.log_probs) == len(advs), f'batch_size of log_probs {len(self.body.log_probs)} vs advs: {len(advs)}'
         log_probs = torch.stack(self.body.log_probs)

--- a/slm_lab/agent/algorithm/reinforce.py
+++ b/slm_lab/agent/algorithm/reinforce.py
@@ -35,7 +35,6 @@ class Reinforce(Algorithm):
         "gamma": 0.99,
         "add_entropy": false,
         "entropy_coef": 0.01,
-        "continuous_action_clip": 2.0,
         "training_frequency": 1
     }
     '''
@@ -71,7 +70,6 @@ class Reinforce(Algorithm):
             'gamma',  # the discount factor
             'add_entropy',
             'entropy_coef',
-            'continuous_action_clip',
             'training_frequency',
         ])
         self.to_train = 0

--- a/slm_lab/agent/algorithm/reinforce.py
+++ b/slm_lab/agent/algorithm/reinforce.py
@@ -83,7 +83,7 @@ class Reinforce(Algorithm):
     def init_nets(self):
         '''
         Initialize the neural network used to learn the policy function from the spec
-        Below we automatically select an appropriate net for a discrete or continuous action space if the setting is of the form 'MLPdefault'. Otherwise the correct type of network is assumed to be specified in the spec.
+        Below we automatically select an appropriate net for a discrete or continuous action space if the setting is of the form 'MLPNet'. Otherwise the correct type of network is assumed to be specified in the spec.
         Networks for continuous action spaces have two heads and return two values, the first is a tensor containing the mean of the action policy, the second is a tensor containing the std deviation of the action policy. The distribution is assumed to be a Gaussian (Normal) distribution.
         Networks for discrete action spaces have a single head and return the logits for a categorical probability distribution over the discrete actions
         '''

--- a/slm_lab/agent/algorithm/sarsa.py
+++ b/slm_lab/agent/algorithm/sarsa.py
@@ -1,6 +1,7 @@
 from slm_lab.agent import net
 from slm_lab.agent.algorithm import policy_util
 from slm_lab.agent.algorithm.base import Algorithm
+from slm_lab.agent.net import net_util
 from slm_lab.lib import logger, util
 from slm_lab.lib.decorator import lab_api
 import numpy as np
@@ -86,8 +87,10 @@ class SARSA(Algorithm):
         '''Initialize the neural network used to learn the Q function from the spec'''
         if 'Recurrent' in self.net_spec['type']:
             self.net_spec.update(seq_len=self.net_spec['seq_len'])
+        in_dim = self.body.state_dim
+        out_dim = net_util.get_out_dim(self.body)
         NetClass = getattr(net, self.net_spec['type'])
-        self.net = NetClass(self.net_spec, self.body.state_dim, self.body.action_dim)
+        self.net = NetClass(self.net_spec, in_dim, out_dim)
         self.net_names = ['net']
         self.post_init_nets()
 

--- a/slm_lab/agent/algorithm/sil.py
+++ b/slm_lab/agent/algorithm/sil.py
@@ -43,6 +43,7 @@ class SIL(ActorCritic):
         "training_frequency": 1,
         "training_epoch": 8
     }
+
     e.g. special memory_spec
     "memory": {
         "name": "OnPolicyReplay",
@@ -213,6 +214,7 @@ class PPOSIL(PPO):
         "training_batch_epoch": 8,
         "training_epoch": 8
     }
+
     e.g. special memory_spec
     "memory": {
         "name": "OnPolicyReplay",

--- a/slm_lab/agent/algorithm/sil.py
+++ b/slm_lab/agent/algorithm/sil.py
@@ -39,7 +39,6 @@ class SIL(ActorCritic):
         "val_loss_coef": 0.01,
         "sil_policy_loss_coef": 1.0,
         "sil_val_loss_coef": 0.01,
-        "continuous_action_clip": 2.0,
         "training_batch_epoch": 8,
         "training_frequency": 1,
         "training_epoch": 8
@@ -96,7 +95,6 @@ class SIL(ActorCritic):
             'val_loss_coef',
             'sil_policy_loss_coef',
             'sil_val_loss_coef',
-            'continuous_action_clip',
             'training_frequency',
             'training_batch_epoch',
             'training_epoch',

--- a/slm_lab/agent/algorithm/sil.py
+++ b/slm_lab/agent/algorithm/sil.py
@@ -1,15 +1,12 @@
-from copy import deepcopy
-from functools import partial
 from slm_lab.agent import net, memory
 from slm_lab.agent.algorithm import math_util, policy_util
 from slm_lab.agent.algorithm.actor_critic import ActorCritic
 from slm_lab.agent.algorithm.ppo import PPO
-from slm_lab.agent.net import net_util
 from slm_lab.lib import logger, util
 from slm_lab.lib.decorator import lab_api
 import numpy as np
-import torch
 import pydash as ps
+import torch
 
 logger = logger.get_logger(__name__)
 

--- a/slm_lab/agent/net/convnet.py
+++ b/slm_lab/agent/net/convnet.py
@@ -189,7 +189,7 @@ class ConvNet(Net, nn.Module):
         x = self.dense_model(x)
         # return tensor if single tail, else list of tail tensors
         if len(self.model_tails) == 1:
-            return model_tails[0](x)
+            return self.model_tails[0](x)
         else:
             outs = []
             for model_tail in self.model_tails:

--- a/slm_lab/agent/net/convnet.py
+++ b/slm_lab/agent/net/convnet.py
@@ -1,3 +1,4 @@
+from slm_lab.agent.algorithm import math_util
 from slm_lab.agent.net import net_util
 from slm_lab.agent.net.base import Net
 from slm_lab.lib import logger, util
@@ -380,5 +381,5 @@ class DuelingConvNet(ConvNet):
         x = self.dense_model(x)
         state_value = self.v(x)
         raw_advantages = self.adv(x)
-        out = net_util.calc_q_value_logits(state_value, raw_advantages)
+        out = math_util.calc_q_value_logits(state_value, raw_advantages)
         return out

--- a/slm_lab/agent/net/convnet.py
+++ b/slm_lab/agent/net/convnet.py
@@ -187,13 +187,13 @@ class ConvNet(Net, nn.Module):
         x = self.conv_model(x)
         x = x.view(-1, self.conv_out_dim)
         x = self.dense_model(x)
-        outs = []
-        for model_tail in self.model_tails:
-            outs.append(model_tail(x))
         # return tensor if single tail, else list of tail tensors
-        if len(outs) == 1:
-            return outs[0]
+        if len(self.model_tails) == 1:
+            return model_tails[0](x)
         else:
+            outs = []
+            for model_tail in self.model_tails:
+                outs.append(model_tail(x))
             return outs
 
     def training_step(self, x=None, y=None, loss=None, retain_graph=False):

--- a/slm_lab/agent/net/mlp.py
+++ b/slm_lab/agent/net/mlp.py
@@ -36,6 +36,7 @@ class MLPNet(Net, nn.Module):
         e.g. net_spec
         "net": {
             "type": "MLPNet",
+            "shared": true,
             "hid_layers": [32],
             "hid_layers_activation": "relu",
             "clip_grad": false,
@@ -72,6 +73,7 @@ class MLPNet(Net, nn.Module):
             gpu=False,
         ))
         util.set_attr(self, self.net_spec, [
+            'separate',
             'hid_layers',
             'hid_layers_activation',
             'clip_grad',

--- a/slm_lab/agent/net/mlp.py
+++ b/slm_lab/agent/net/mlp.py
@@ -1,3 +1,4 @@
+from slm_lab.agent.algorithm import math_util
 from slm_lab.agent.net import net_util
 from slm_lab.agent.net.base import Net
 from slm_lab.lib import logger, util
@@ -447,5 +448,5 @@ class DuelingMLPNet(MLPNet):
         x = self.model_body(x)
         state_value = self.v(x)
         raw_advantages = self.adv(x)
-        out = net_util.calc_q_value_logits(state_value, raw_advantages)
+        out = math_util.calc_q_value_logits(state_value, raw_advantages)
         return out

--- a/slm_lab/agent/net/net_util.py
+++ b/slm_lab/agent/net/net_util.py
@@ -45,6 +45,36 @@ def get_optim(cls, optim_spec):
     return optim
 
 
+def get_out_dim(body, add_critic=False):
+    '''Construct the NetClass out_dim for a body according to is_discrete, action_type, and whether to add a critic unit'''
+    if body.is_discrete:
+        if body.action_type == 'multi_discrete':
+            assert ps.is_list(body.action_dim), body.action_dim
+            policy_out_dim = body.action_dim
+        else:
+            assert ps.is_integer(body.action_dim), body.action_dim
+            policy_out_dim = body.action_dim
+    else:
+        if body.action_type == 'multi_continuous':
+            assert ps.is_list(body.action_dim), body.action_dim
+            raise NotImplementedError('multi_continuous not supported yet')
+        else:
+            assert ps.is_integer(body.action_dim), body.action_dim
+            if body.action_dim == 1:
+                policy_out_dim = 2  # singleton stay as int
+            else:
+                policy_out_dim = body.action_dim * [2]
+
+    if add_critic:
+        if ps.is_list(policy_out_dim):
+            out_dim = policy_out_dim + [1]
+        else:
+            out_dim = [policy_out_dim, 1]
+    else:
+        out_dim = policy_out_dim
+    return out_dim
+
+
 def init_gru_layer(layer):
     '''Initializes a GRU layer in with xavier_uniform initialization and 0 biases'''
     for layer_p in layer._all_weights:

--- a/slm_lab/agent/net/recurrent.py
+++ b/slm_lab/agent/net/recurrent.py
@@ -148,13 +148,13 @@ class RecurrentNet(Net, nn.Module):
         hid_0 = self.init_hidden(batch_size)
         _, final_hid = self.rnn_model(x, hid_0)
         final_hid.squeeze_(dim=0)
-        outs = []
-        for model_tail in self.model_tails:
-            outs.append(model_tail(final_hid))
         # return tensor if single tail, else list of tail tensors
-        if len(outs) == 1:
-            return outs[0]
+        if len(self.model_tails) == 1:
+            return model_tails[0](final_hid)
         else:
+            outs = []
+            for model_tail in self.model_tails:
+                outs.append(model_tail(x))
             return outs
 
     def training_step(self, x=None, y=None, loss=None, retain_graph=False):

--- a/slm_lab/agent/net/recurrent.py
+++ b/slm_lab/agent/net/recurrent.py
@@ -150,11 +150,11 @@ class RecurrentNet(Net, nn.Module):
         final_hid.squeeze_(dim=0)
         # return tensor if single tail, else list of tail tensors
         if len(self.model_tails) == 1:
-            return model_tails[0](final_hid)
+            return self.model_tails[0](final_hid)
         else:
             outs = []
             for model_tail in self.model_tails:
-                outs.append(model_tail(x))
+                outs.append(model_tail(final_hid))
             return outs
 
     def training_step(self, x=None, y=None, loss=None, retain_graph=False):

--- a/slm_lab/experiment/control.py
+++ b/slm_lab/experiment/control.py
@@ -37,7 +37,7 @@ class Session:
     def __init__(self, spec, info_space=None):
         info_space = info_space or InfoSpace()
         init_thread_vars(spec, info_space, unit='session')
-        self.spec = deepcopy(spec)
+        self.spec = spec
         self.info_space = info_space
         self.coor, self.index = self.info_space.get_coor_idx(self)
         self.random_seed = 100 * (info_space.get('trial') or 0) + self.index

--- a/slm_lab/experiment/monitor.py
+++ b/slm_lab/experiment/monitor.py
@@ -19,7 +19,6 @@ DataSpace: a data space storing an AEB data projected to a-axis, and its dual pr
 Object reference (for agent to access env properties, vice versa):
 Agents - AgentSpace - AEBSpace - EnvSpace - Envs
 '''
-from copy import deepcopy
 from slm_lab.agent import AGENT_DATA_NAMES, Body
 from slm_lab.env import ENV_DATA_NAMES, Clock
 from slm_lab.lib import logger, util

--- a/slm_lab/spec/a2c.json
+++ b/slm_lab/spec/a2c.json
@@ -26,7 +26,8 @@
         "name": "OnPolicyReplay"
       },
       "net": {
-        "type": "MLPNetShared",
+        "type": "MLPNet",
+        "shared": true,
         "hid_layers": [64],
         "hid_layers_activation": "relu",
         "clip_grad": false,
@@ -107,7 +108,8 @@
         "name": "OnPolicyReplay"
       },
       "net": {
-        "type": "MLPNetSeparate",
+        "type": "MLPNet",
+        "shared": false,
         "hid_layers": [64],
         "hid_layers_activation": "relu",
         "clip_grad": false,
@@ -188,7 +190,8 @@
         "name": "OnPolicySeqReplay"
       },
       "net": {
-        "type": "RecurrentNetShared",
+        "type": "RecurrentNet",
+        "shared": true,
         "hid_layers": [],
         "hid_layers_activation": "relu",
         "rnn_hidden_size": 64,
@@ -272,7 +275,8 @@
         "name": "OnPolicySeqReplay"
       },
       "net": {
-        "type": "RecurrentNetSeparate",
+        "type": "RecurrentNet",
+        "shared": false,
         "hid_layers": [],
         "hid_layers_activation": "relu",
         "rnn_hidden_size": 64,
@@ -356,7 +360,8 @@
         "name": "OnPolicyReplay"
       },
       "net": {
-        "type": "MLPNetShared",
+        "type": "MLPNet",
+        "shared": true,
         "hid_layers": [64],
         "hid_layers_activation": "relu",
         "clip_grad": false,
@@ -437,7 +442,8 @@
         "name": "OnPolicyReplay"
       },
       "net": {
-        "type": "MLPNetSeparate",
+        "type": "MLPNet",
+        "shared": false,
         "hid_layers": [64],
         "hid_layers_activation": "relu",
         "clip_grad": false,
@@ -518,7 +524,8 @@
         "name": "OnPolicySeqReplay"
       },
       "net": {
-        "type": "RecurrentNetShared",
+        "type": "RecurrentNet",
+        "shared": true,
         "hid_layers": [],
         "hid_layers_activation": "relu",
         "rnn_hidden_size": 64,
@@ -602,7 +609,8 @@
         "name": "OnPolicySeqReplay"
       },
       "net": {
-        "type": "RecurrentNetSeparate",
+        "type": "RecurrentNet",
+        "shared": false,
         "hid_layers": [],
         "hid_layers_activation": "relu",
         "rnn_hidden_size": 64,
@@ -686,7 +694,8 @@
         "name": "OnPolicyReplay"
       },
       "net": {
-        "type": "ConvNetShared",
+        "type": "ConvNet",
+        "shared": true,
         "hid_layers": [
           [
             [3, 16, [5, 5], 2, 0, [1, 1]],
@@ -757,7 +766,8 @@
         "name": "OnPolicyReplay"
       },
       "net": {
-        "type": "ConvNetSeparate",
+        "type": "ConvNet",
+        "shared": false,
         "hid_layers": [
           [
             [3, 16, [5, 5], 2, 0, [1, 1]],

--- a/slm_lab/spec/a2c.json
+++ b/slm_lab/spec/a2c.json
@@ -19,7 +19,6 @@
         "entropy_coef": 0.01,
         "policy_loss_coef": 1.0,
         "val_loss_coef": 0.01,
-        "continuous_action_clip": 2.0,
         "training_frequency": 1,
         "training_epoch": 8
       },
@@ -101,7 +100,6 @@
         "entropy_coef": 0.01,
         "policy_loss_coef": 1.0,
         "val_loss_coef": 0.01,
-        "continuous_action_clip": 2.0,
         "training_frequency": 1,
         "training_epoch": 8
       },
@@ -183,7 +181,6 @@
         "entropy_coef": 0.01,
         "policy_loss_coef": 1.0,
         "val_loss_coef": 0.01,
-        "continuous_action_clip": 2.0,
         "training_frequency": 1,
         "training_epoch": 8
       },
@@ -268,7 +265,6 @@
         "entropy_coef": 0.01,
         "policy_loss_coef": 1.0,
         "val_loss_coef": 0.01,
-        "continuous_action_clip": 2.0,
         "training_frequency": 1,
         "training_epoch": 8
       },
@@ -353,7 +349,6 @@
         "entropy_coef": 0.01,
         "policy_loss_coef": 1.0,
         "val_loss_coef": 0.01,
-        "continuous_action_clip": 2.0,
         "training_frequency": 1,
         "training_epoch": 8
       },
@@ -435,7 +430,6 @@
         "entropy_coef": 0.01,
         "policy_loss_coef": 1.0,
         "val_loss_coef": 0.01,
-        "continuous_action_clip": 2.0,
         "training_frequency": 1,
         "training_epoch": 8
       },
@@ -517,7 +511,6 @@
         "entropy_coef": 0.01,
         "policy_loss_coef": 1.0,
         "val_loss_coef": 0.01,
-        "continuous_action_clip": 2.0,
         "training_frequency": 1,
         "training_epoch": 8
       },
@@ -602,7 +595,6 @@
         "entropy_coef": 0.01,
         "policy_loss_coef": 1.0,
         "val_loss_coef": 0.01,
-        "continuous_action_clip": 2.0,
         "training_frequency": 1,
         "training_epoch": 8
       },
@@ -687,7 +679,6 @@
         "entropy_coef": 0.01,
         "policy_loss_coef": 1.0,
         "val_loss_coef": 0.01,
-        "continuous_action_clip": 2.0,
         "training_frequency": 1,
         "training_epoch": 8
       },
@@ -759,7 +750,6 @@
         "entropy_coef": 0.01,
         "policy_loss_coef": 1.0,
         "val_loss_coef": 0.01,
-        "continuous_action_clip": 2.0,
         "training_frequency": 1,
         "training_epoch": 8
       },

--- a/slm_lab/spec/ac.json
+++ b/slm_lab/spec/ac.json
@@ -26,7 +26,8 @@
         "name": "OnPolicyReplay"
       },
       "net": {
-        "type": "MLPNetShared",
+        "type": "MLPNet",
+        "shared": true,
         "hid_layers": [64],
         "hid_layers_activation": "relu",
         "clip_grad": false,
@@ -107,7 +108,8 @@
         "name": "OnPolicyReplay"
       },
       "net": {
-        "type": "MLPNetSeparate",
+        "type": "MLPNet",
+        "shared": false,
         "hid_layers": [64],
         "hid_layers_activation": "relu",
         "clip_grad": false,
@@ -188,7 +190,8 @@
         "name": "OnPolicySeqReplay"
       },
       "net": {
-        "type": "RecurrentNetShared",
+        "type": "RecurrentNet",
+        "shared": true,
         "hid_layers": [],
         "hid_layers_activation": "relu",
         "rnn_hidden_size": 64,
@@ -272,7 +275,8 @@
         "name": "OnPolicySeqReplay"
       },
       "net": {
-        "type": "RecurrentNetSeparate",
+        "type": "RecurrentNet",
+        "shared": false,
         "hid_layers": [],
         "hid_layers_activation": "relu",
         "rnn_hidden_size": 64,
@@ -356,7 +360,8 @@
         "name": "OnPolicyReplay"
       },
       "net": {
-        "type": "MLPNetShared",
+        "type": "MLPNet",
+        "shared": true,
         "hid_layers": [64],
         "hid_layers_activation": "relu",
         "clip_grad": false,
@@ -437,7 +442,8 @@
         "name": "OnPolicyReplay"
       },
       "net": {
-        "type": "MLPNetSeparate",
+        "type": "MLPNet",
+        "shared": false,
         "hid_layers": [64],
         "hid_layers_activation": "relu",
         "clip_grad": false,
@@ -518,7 +524,8 @@
         "name": "OnPolicySeqReplay"
       },
       "net": {
-        "type": "RecurrentNetShared",
+        "type": "RecurrentNet",
+        "shared": true,
         "hid_layers": [],
         "hid_layers_activation": "relu",
         "rnn_hidden_size": 64,
@@ -602,7 +609,8 @@
         "name": "OnPolicySeqReplay"
       },
       "net": {
-        "type": "RecurrentNetSeparate",
+        "type": "RecurrentNet",
+        "shared": false,
         "hid_layers": [],
         "hid_layers_activation": "relu",
         "rnn_hidden_size": 64,
@@ -686,7 +694,8 @@
         "name": "OnPolicyReplay"
       },
       "net": {
-        "type": "ConvNetShared",
+        "type": "ConvNet",
+        "shared": true,
         "hid_layers": [
           [
             [3, 16, [5, 5], 2, 0, [1, 1]],
@@ -757,7 +766,8 @@
         "name": "OnPolicyReplay"
       },
       "net": {
-        "type": "ConvNetSeparate",
+        "type": "ConvNet",
+        "shared": false,
         "hid_layers": [
           [
             [3, 16, [5, 5], 2, 0, [1, 1]],

--- a/slm_lab/spec/ac.json
+++ b/slm_lab/spec/ac.json
@@ -19,7 +19,6 @@
         "entropy_coef": 0.01,
         "policy_loss_coef": 1.0,
         "val_loss_coef": 0.01,
-        "continuous_action_clip": 2.0,
         "training_frequency": 1,
         "training_epoch": 8
       },
@@ -101,7 +100,6 @@
         "entropy_coef": 0.01,
         "policy_loss_coef": 1.0,
         "val_loss_coef": 0.01,
-        "continuous_action_clip": 2.0,
         "training_frequency": 1,
         "training_epoch": 8
       },
@@ -183,7 +181,6 @@
         "entropy_coef": 0.01,
         "policy_loss_coef": 1.0,
         "val_loss_coef": 0.01,
-        "continuous_action_clip": 2.0,
         "training_frequency": 1,
         "training_epoch": 8
       },
@@ -268,7 +265,6 @@
         "entropy_coef": 0.01,
         "policy_loss_coef": 1.0,
         "val_loss_coef": 0.01,
-        "continuous_action_clip": 2.0,
         "training_frequency": 1,
         "training_epoch": 8
       },
@@ -353,7 +349,6 @@
         "entropy_coef": 0.01,
         "policy_loss_coef": 1.0,
         "val_loss_coef": 0.01,
-        "continuous_action_clip": 2.0,
         "training_frequency": 1,
         "training_epoch": 8
       },
@@ -435,7 +430,6 @@
         "entropy_coef": 0.01,
         "policy_loss_coef": 1.0,
         "val_loss_coef": 0.01,
-        "continuous_action_clip": 2.0,
         "training_frequency": 1,
         "training_epoch": 8
       },
@@ -517,7 +511,6 @@
         "entropy_coef": 0.01,
         "policy_loss_coef": 1.0,
         "val_loss_coef": 0.01,
-        "continuous_action_clip": 2.0,
         "training_frequency": 1,
         "training_epoch": 8
       },
@@ -602,7 +595,6 @@
         "entropy_coef": 0.01,
         "policy_loss_coef": 1.0,
         "val_loss_coef": 0.01,
-        "continuous_action_clip": 2.0,
         "training_frequency": 1,
         "training_epoch": 8
       },
@@ -687,7 +679,6 @@
         "entropy_coef": 0.01,
         "policy_loss_coef": 1.0,
         "val_loss_coef": 0.01,
-        "continuous_action_clip": 2.0,
         "training_frequency": 1,
         "training_epoch": 8
       },
@@ -759,7 +750,6 @@
         "entropy_coef": 0.01,
         "policy_loss_coef": 1.0,
         "val_loss_coef": 0.01,
-        "continuous_action_clip": 2.0,
         "training_frequency": 1,
         "training_epoch": 8
       },

--- a/slm_lab/spec/ppo.json
+++ b/slm_lab/spec/ppo.json
@@ -22,7 +22,8 @@
         "name": "OnPolicyReplay"
       },
       "net": {
-        "type": "MLPNetShared",
+        "type": "MLPNet",
+        "shared": true,
         "hid_layers": [32],
         "hid_layers_activation": "relu",
         "clip_grad": false,
@@ -102,7 +103,8 @@
         "name": "OnPolicyReplay"
       },
       "net": {
-        "type": "MLPNetSeparate",
+        "type": "MLPNet",
+        "shared": false,
         "hid_layers": [32],
         "hid_layers_activation": "relu",
         "clip_grad": false,
@@ -182,7 +184,8 @@
         "name": "OnPolicySeqReplay"
       },
       "net": {
-        "type": "RecurrentNetShared",
+        "type": "RecurrentNet",
+        "shared": true,
         "hid_layers": [],
         "hid_layers_activation": "relu",
         "rnn_hidden_size": 32,
@@ -265,7 +268,8 @@
         "name": "OnPolicySeqReplay"
       },
       "net": {
-        "type": "RecurrentNetSeparate",
+        "type": "RecurrentNet",
+        "shared": false,
         "hid_layers": [],
         "hid_layers_activation": "relu",
         "rnn_hidden_size": 32,
@@ -348,7 +352,8 @@
         "name": "OnPolicyReplay"
       },
       "net": {
-        "type": "MLPNetShared",
+        "type": "MLPNet",
+        "shared": true,
         "hid_layers": [32],
         "hid_layers_activation": "relu",
         "clip_grad": false,
@@ -428,7 +433,8 @@
         "name": "OnPolicyReplay"
       },
       "net": {
-        "type": "MLPNetSeparate",
+        "type": "MLPNet",
+        "shared": false,
         "hid_layers": [32],
         "hid_layers_activation": "relu",
         "clip_grad": false,
@@ -508,7 +514,8 @@
         "name": "OnPolicySeqReplay"
       },
       "net": {
-        "type": "RecurrentNetShared",
+        "type": "RecurrentNet",
+        "shared": true,
         "hid_layers": [],
         "hid_layers_activation": "relu",
         "rnn_hidden_size": 32,
@@ -591,7 +598,8 @@
         "name": "OnPolicySeqReplay"
       },
       "net": {
-        "type": "RecurrentNetSeparate",
+        "type": "RecurrentNet",
+        "shared": false,
         "hid_layers": [],
         "hid_layers_activation": "relu",
         "rnn_hidden_size": 32,
@@ -674,7 +682,8 @@
         "name": "OnPolicyReplay"
       },
       "net": {
-        "type": "ConvNetShared",
+        "type": "ConvNet",
+        "shared": true,
         "hid_layers": [
           [
             [3, 16, [5, 5], 2, 0, [1, 1]],
@@ -741,7 +750,8 @@
         "name": "OnPolicyReplay"
       },
       "net": {
-        "type": "ConvNetSeparate",
+        "type": "ConvNet",
+        "shared": false,
         "hid_layers": [
           [
             [3, 16, [5, 5], 2, 0, [1, 1]],

--- a/slm_lab/spec/ppo_sil.json
+++ b/slm_lab/spec/ppo_sil.json
@@ -29,7 +29,8 @@
         "use_cer": true
       },
       "net": {
-        "type": "MLPNetShared",
+        "type": "MLPNet",
+        "shared": true,
         "hid_layers": [64],
         "hid_layers_activation": "tanh",
         "clip_grad": false,
@@ -118,7 +119,8 @@
         "use_cer": true
       },
       "net": {
-        "type": "MLPNetSeparate",
+        "type": "MLPNet",
+        "shared": false,
         "hid_layers": [32],
         "hid_layers_activation": "tanh",
         "clip_grad": false,
@@ -207,7 +209,8 @@
         "use_cer": true
       },
       "net": {
-        "type": "RecurrentNetShared",
+        "type": "RecurrentNet",
+        "shared": true,
         "hid_layers": [],
         "hid_layers_activation": "tanh",
         "rnn_hidden_size": 32,
@@ -299,7 +302,8 @@
         "use_cer": true
       },
       "net": {
-        "type": "RecurrentNetSeparate",
+        "type": "RecurrentNet",
+        "shared": false,
         "hid_layers": [],
         "hid_layers_activation": "tanh",
         "rnn_hidden_size": 32,
@@ -391,7 +395,8 @@
         "use_cer": true
       },
       "net": {
-        "type": "MLPNetShared",
+        "type": "MLPNet",
+        "shared": true,
         "hid_layers": [64],
         "hid_layers_activation": "tanh",
         "clip_grad": false,
@@ -480,7 +485,8 @@
         "use_cer": true
       },
       "net": {
-        "type": "MLPNetSeparate",
+        "type": "MLPNet",
+        "shared": false,
         "hid_layers": [32],
         "hid_layers_activation": "tanh",
         "clip_grad": false,
@@ -569,7 +575,8 @@
         "use_cer": true
       },
       "net": {
-        "type": "RecurrentNetShared",
+        "type": "RecurrentNet",
+        "shared": true,
         "hid_layers": [],
         "hid_layers_activation": "tanh",
         "rnn_hidden_size": 32,
@@ -661,7 +668,8 @@
         "use_cer": true
       },
       "net": {
-        "type": "RecurrentNetSeparate",
+        "type": "RecurrentNet",
+        "shared": false,
         "hid_layers": [],
         "hid_layers_activation": "tanh",
         "rnn_hidden_size": 32,

--- a/slm_lab/spec/reinforce.json
+++ b/slm_lab/spec/reinforce.json
@@ -19,7 +19,7 @@
         "name": "OnPolicyReplay"
       },
       "net": {
-        "type": "MLPdefault",
+        "type": "MLPNet",
         "hid_layers": [64],
         "hid_layers_activation": "relu",
         "clip_grad": false,
@@ -160,7 +160,7 @@
         "name": "OnPolicyReplay"
       },
       "net": {
-        "type": "MLPdefault",
+        "type": "MLPNet",
         "hid_layers": [64],
         "hid_layers_activation": "relu",
         "clip_grad": false,

--- a/slm_lab/spec/reinforce.json
+++ b/slm_lab/spec/reinforce.json
@@ -13,7 +13,6 @@
         "gamma": 0.99,
         "add_entropy": true,
         "entropy_coef": 0.01,
-        "continuous_action_clip": 2.0,
         "training_frequency": 1
       },
       "memory": {
@@ -83,7 +82,6 @@
         "gamma": 0.99,
         "add_entropy": true,
         "entropy_coef": 0.01,
-        "continuous_action_clip": 2.0,
         "training_frequency": 1
       },
       "memory": {
@@ -156,7 +154,6 @@
         "gamma": 0.99,
         "add_entropy": true,
         "entropy_coef": 0.01,
-        "continuous_action_clip": 2.0,
         "training_frequency": 1
       },
       "memory": {
@@ -226,7 +223,6 @@
         "gamma": 0.99,
         "add_entropy": true,
         "entropy_coef": 0.01,
-        "continuous_action_clip": 2.0,
         "training_frequency": 1
       },
       "memory": {
@@ -299,7 +295,6 @@
         "gamma": 0.99,
         "add_entropy": true,
         "entropy_coef": 0.01,
-        "continuous_action_clip": 2.0,
         "training_frequency": 1
       },
       "memory": {

--- a/slm_lab/spec/sil.json
+++ b/slm_lab/spec/sil.json
@@ -33,7 +33,8 @@
         "use_cer": true
       },
       "net": {
-        "type": "MLPNetShared",
+        "type": "MLPNet",
+        "shared": true,
         "hid_layers": [64],
         "hid_layers_activation": "tanh",
         "clip_grad": false,
@@ -126,7 +127,8 @@
         "use_cer": true
       },
       "net": {
-        "type": "MLPNetSeparate",
+        "type": "MLPNet",
+        "shared": false,
         "hid_layers": [32],
         "hid_layers_activation": "tanh",
         "clip_grad": false,
@@ -219,7 +221,8 @@
         "use_cer": true
       },
       "net": {
-        "type": "RecurrentNetShared",
+        "type": "RecurrentNet",
+        "shared": true,
         "hid_layers": [],
         "hid_layers_activation": "tanh",
         "rnn_hidden_size": 32,
@@ -315,7 +318,8 @@
         "use_cer": true
       },
       "net": {
-        "type": "RecurrentNetSeparate",
+        "type": "RecurrentNet",
+        "shared": false,
         "hid_layers": [],
         "hid_layers_activation": "tanh",
         "rnn_hidden_size": 32,
@@ -411,7 +415,8 @@
         "use_cer": true
       },
       "net": {
-        "type": "MLPNetShared",
+        "type": "MLPNet",
+        "shared": true,
         "hid_layers": [64],
         "hid_layers_activation": "tanh",
         "clip_grad": false,
@@ -504,7 +509,8 @@
         "use_cer": true
       },
       "net": {
-        "type": "MLPNetSeparate",
+        "type": "MLPNet",
+        "shared": false,
         "hid_layers": [32],
         "hid_layers_activation": "tanh",
         "clip_grad": false,
@@ -597,7 +603,8 @@
         "use_cer": true
       },
       "net": {
-        "type": "RecurrentNetShared",
+        "type": "RecurrentNet",
+        "shared": true,
         "hid_layers": [],
         "hid_layers_activation": "tanh",
         "rnn_hidden_size": 32,
@@ -693,7 +700,8 @@
         "use_cer": true
       },
       "net": {
-        "type": "RecurrentNetSeparate",
+        "type": "RecurrentNet",
+        "shared": false,
         "hid_layers": [],
         "hid_layers_activation": "tanh",
         "rnn_hidden_size": 32,
@@ -789,7 +797,8 @@
         "use_cer": true
       },
       "net": {
-        "type": "ConvNetShared",
+        "type": "ConvNet",
+        "shared": true,
         "hid_layers": [
           [
             [3, 16, [5, 5], 2, 0, [1, 1]],
@@ -867,7 +876,8 @@
         "use_cer": true
       },
       "net": {
-        "type": "ConvNetSeparate",
+        "type": "ConvNet",
+        "shared": false,
         "hid_layers": [
           [
             [3, 16, [5, 5], 2, 0, [1, 1]],

--- a/slm_lab/spec/sil.json
+++ b/slm_lab/spec/sil.json
@@ -21,7 +21,6 @@
         "val_loss_coef": 0.01,
         "sil_policy_loss_coef": 1.0,
         "sil_val_loss_coef": 0.1,
-        "continuous_action_clip": 2.0,
         "training_frequency": 1,
         "training_batch_epoch": 4,
         "training_epoch": 4
@@ -115,7 +114,6 @@
         "val_loss_coef": 0.01,
         "sil_policy_loss_coef": 1.0,
         "sil_val_loss_coef": 0.1,
-        "continuous_action_clip": 2.0,
         "training_frequency": 1,
         "training_batch_epoch": 8,
         "training_epoch": 4
@@ -209,7 +207,6 @@
         "val_loss_coef": 0.01,
         "sil_policy_loss_coef": 1.0,
         "sil_val_loss_coef": 0.1,
-        "continuous_action_clip": 2.0,
         "training_frequency": 1,
         "training_batch_epoch": 8,
         "training_epoch": 4
@@ -306,7 +303,6 @@
         "val_loss_coef": 0.01,
         "sil_policy_loss_coef": 1.0,
         "sil_val_loss_coef": 0.1,
-        "continuous_action_clip": 2.0,
         "training_frequency": 1,
         "training_batch_epoch": 8,
         "training_epoch": 4
@@ -403,7 +399,6 @@
         "val_loss_coef": 0.01,
         "sil_policy_loss_coef": 1.0,
         "sil_val_loss_coef": 0.1,
-        "continuous_action_clip": 2.0,
         "training_frequency": 1,
         "training_batch_epoch": 4,
         "training_epoch": 4
@@ -497,7 +492,6 @@
         "val_loss_coef": 0.01,
         "sil_policy_loss_coef": 1.0,
         "sil_val_loss_coef": 0.1,
-        "continuous_action_clip": 2.0,
         "training_frequency": 1,
         "training_batch_epoch": 8,
         "training_epoch": 4
@@ -591,7 +585,6 @@
         "val_loss_coef": 0.01,
         "sil_policy_loss_coef": 1.0,
         "sil_val_loss_coef": 0.1,
-        "continuous_action_clip": 2.0,
         "training_frequency": 1,
         "training_batch_epoch": 8,
         "training_epoch": 4
@@ -688,7 +681,6 @@
         "val_loss_coef": 0.01,
         "sil_policy_loss_coef": 1.0,
         "sil_val_loss_coef": 0.1,
-        "continuous_action_clip": 2.0,
         "training_frequency": 1,
         "training_batch_epoch": 8,
         "training_epoch": 4
@@ -785,7 +777,6 @@
         "val_loss_coef": 0.01,
         "sil_policy_loss_coef": 1.0,
         "sil_val_loss_coef": 0.1,
-        "continuous_action_clip": 2.0,
         "training_frequency": 1,
         "training_batch_epoch": 8,
         "training_epoch": 4
@@ -864,7 +855,6 @@
         "val_loss_coef": 0.01,
         "sil_policy_loss_coef": 1.0,
         "sil_val_loss_coef": 0.1,
-        "continuous_action_clip": 2.0,
         "training_frequency": 1,
         "training_batch_epoch": 8,
         "training_epoch": 4

--- a/slm_lab/spec/test.json
+++ b/slm_lab/spec/test.json
@@ -166,7 +166,8 @@
         "name": "OnPolicyReplay"
       },
       "net": {
-        "type": "MLPNetSeparate",
+        "type": "MLPNet",
+        "shared": false,
         "hid_layers": [64],
         "hid_layers_activation": "relu",
         "clip_grad": false,

--- a/slm_lab/spec/test.json
+++ b/slm_lab/spec/test.json
@@ -110,7 +110,7 @@
         "name": "OnPolicyReplay"
       },
       "net": {
-        "type": "MLPdefault",
+        "type": "MLPNet",
         "hid_layers": [64],
         "hid_layers_activation": "relu",
         "clip_grad": false,

--- a/slm_lab/spec/test.json
+++ b/slm_lab/spec/test.json
@@ -104,7 +104,6 @@
         "gamma": 0.95,
         "add_entropy": false,
         "entropy_coef": 0.01,
-        "continuous_action_clip": 2.0,
         "training_frequency": 1
       },
       "memory": {
@@ -160,7 +159,6 @@
         "entropy_coef": 0.01,
         "policy_loss_coef": 1.0,
         "val_loss_coef": 0.01,
-        "continuous_action_clip": 2.0,
         "training_frequency": 1,
         "training_epoch": 8
       },

--- a/test/agent/memory/test_onpolicy_memory.py
+++ b/test/agent/memory/test_onpolicy_memory.py
@@ -1,5 +1,4 @@
 from collections import Counter
-from copy import deepcopy
 from flaky import flaky
 import numpy as np
 import pytest

--- a/test/agent/memory/test_per_memory.py
+++ b/test/agent/memory/test_per_memory.py
@@ -1,5 +1,4 @@
 from collections import Counter
-from copy import deepcopy
 from flaky import flaky
 import numpy as np
 import pytest

--- a/test/agent/net/test_nn.py
+++ b/test/agent/net/test_nn.py
@@ -32,7 +32,7 @@ class TestNet:
             dummy_output = []
             for outdim in net.out_dim:
                 dummy_output.append(torch.zeros((2, outdim[-1])))
-        elif 'MLPHeterogenousTails' in net.__class__.__name__ or len(net.out_dim) > 1:
+        elif 'MLPNet' in net.__class__.__name__ or len(net.out_dim) > 1:
             dummy_output = []
             for outdim in net.out_dim:
                 print(type(outdim), outdim)
@@ -42,8 +42,8 @@ class TestNet:
         return dummy_output
 
     def check_net_type(self, net):
-        # Skipping test for 'MLPHeterogenousTails' because there is no training step function
-        if 'MLPHeterogenousTails' in net.__class__.__name__:
+        # Skipping test for 'MLPNet' because there is no training step function
+        if 'MLPNet' in net.__class__.__name__:
             return True
         # Skipping test for 'RecurrentNet' and 'ConvNet' with multiple output heads because training step not applicable
         elif any(k in net.__class__.__name__ for k in ('RecurrentNet', 'ConvNet')) and len(net.out_dim) > 1:
@@ -168,7 +168,7 @@ class TestNet:
         assert loss is None
 
     def check_multi_output(self, net):
-        if any(k in net.__class__.__name__ for k in ('HydraMLPNet', 'MLPHeterogenousTails', 'RecurrentNet', 'ConvNet')) and len(net.out_dim) > 1:
+        if any(k in net.__class__.__name__ for k in ('HydraMLPNet', 'MLPNet', 'RecurrentNet', 'ConvNet')) and len(net.out_dim) > 1:
             return True
         else:
             return False

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -2,7 +2,7 @@ from slm_lab.agent import AgentSpace, Body
 from slm_lab.agent.memory import Replay
 from slm_lab.agent.net.convnet import ConvNet
 from slm_lab.agent.net.recurrent import RecurrentNet
-from slm_lab.agent.net.mlp import MLPNet, HydraMLPNet, MLPHeterogenousTails
+from slm_lab.agent.net.mlp import MLPNet, HydraMLPNet
 from slm_lab.env import EnvSpace
 # from slm_lab.experiment.control import Trial
 from slm_lab.experiment.monitor import AEBSpace, InfoSpace
@@ -136,7 +136,7 @@ def test_multiline_str():
         None,
         2
     ), (
-        MLPHeterogenousTails,
+        MLPNet,
         {
             'in_dim': 10, 'hid_layers': [5, 3],
             'out_dim':[2],
@@ -145,7 +145,7 @@ def test_multiline_str():
         None,
         2
     ), (
-        MLPHeterogenousTails,
+        MLPNet,
         {
             'in_dim': 10, 'hid_layers': [5, 3],
             'out_dim':[2, 1],
@@ -154,7 +154,7 @@ def test_multiline_str():
         None,
         2
     ), (
-        MLPHeterogenousTails,
+        MLPNet,
         {
             'in_dim': 10, 'hid_layers': [5, 3],
             'out_dim':[2, 5, 1],
@@ -163,7 +163,7 @@ def test_multiline_str():
         None,
         2
     ), (
-        MLPHeterogenousTails,
+        MLPNet,
         {
             'in_dim': 10, 'hid_layers': [10, 50, 5],
             'out_dim':[2, 5, 1],
@@ -172,7 +172,7 @@ def test_multiline_str():
         None,
         2
     ), (
-        MLPHeterogenousTails,
+        MLPNet,
         {
             'in_dim': 10, 'hid_layers': [],
             'out_dim':[5], 'hid_layers_activation': 'tanh',
@@ -180,7 +180,7 @@ def test_multiline_str():
         None,
         2
     ), (
-        MLPHeterogenousTails,
+        MLPNet,
         {
             'in_dim': 10, 'hid_layers': [],
             'out_dim':[5, 2], 'hid_layers_activation': 'tanh',
@@ -188,7 +188,7 @@ def test_multiline_str():
         None,
         2
     ), (
-        MLPHeterogenousTails,
+        MLPNet,
         {
             'in_dim': 10, 'hid_layers': [],
             'out_dim':[5, 2, 1], 'hid_layers_activation': 'tanh',

--- a/test/spec/test_spec.py
+++ b/test/spec/test_spec.py
@@ -17,26 +17,6 @@ def run_trial_test(spec_file, spec_name):
 
 
 @pytest.mark.parametrize('spec_file,spec_name', [
-    ('base.json', 'base_case_unity'),
-    ('base.json', 'base_case_openai'),
-    ('random.json', 'random_cartpole'),
-    # ('base.json', 'multi_agent'),
-    # ('base.json', 'multi_agent_multi_env'),
-])
-def test_base(spec_file, spec_name):
-    run_trial_test(spec_file, spec_name)
-
-
-@pytest.mark.parametrize('spec_file,spec_name', [
-    ('base.json', 'multi_body'),
-    ('base.json', 'multi_env'),
-])
-def test_base_multi(spec_file, spec_name):
-    run_trial_test(spec_file, spec_name)
-
-
-# NOTE mute conv tests for onpolicy memory because there is no preprocessor yet and images will be very large
-@pytest.mark.parametrize('spec_file,spec_name', [
     ('reinforce.json', 'reinforce_mlp_cartpole'),
     ('reinforce.json', 'reinforce_rnn_cartpole'),
     # ('reinforce.json', 'reinforce_conv_breakout'),
@@ -234,4 +214,23 @@ def test_multitask_dqn(spec_file, spec_name):
     ('hydra_dqn.json', 'hydra_dqn_epsilon_greedy_cartpole'),
 ])
 def test_multitask_dqn(spec_file, spec_name):
+    run_trial_test(spec_file, spec_name)
+
+
+@pytest.mark.parametrize('spec_file,spec_name', [
+    ('base.json', 'base_case_unity'),
+    ('base.json', 'base_case_openai'),
+    ('random.json', 'random_cartpole'),
+    # ('base.json', 'multi_agent'),
+    # ('base.json', 'multi_agent_multi_env'),
+])
+def test_base(spec_file, spec_name):
+    run_trial_test(spec_file, spec_name)
+
+
+@pytest.mark.parametrize('spec_file,spec_name', [
+    ('base.json', 'multi_body'),
+    ('base.json', 'multi_env'),
+])
+def test_base_multi(spec_file, spec_name):
     run_trial_test(spec_file, spec_name)


### PR DESCRIPTION
- unify `out_dim` calculation to `net_util.get_out_dim` to consider body action type, dim, and if to add critic
- externalize Actor/Critic shared/separate to net_spec param
- unify `MLPHeterogenousTails` to `MLPNet`, vastly simplify code. There is only one MLP now, just like RecurrentNet and ConvNet
- remove all hacks and spec mutations in Actor/Critic `init_nets()` method. vastly simplify code.
- refactor all `calc_pdparam()` methods
- misc refactor