### PR TITLE
remove data space history; optimize large replay memory

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup
 from setuptools.command.test import test as TestCommand
 
 test_args = [
-    '-n 0',
+    '-n 4',
     '--verbose',
     '--capture=sys',
     '--log-level=INFO',

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ test_args = [
     '--log-cli-level=INFO',
     '--log-file-level=INFO',
     '--no-flaky-report',
-    '--timeout=120',
+    '--timeout=180',
     '--cov-report=html',
     '--cov-report=term',
     '--cov-report=xml',

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ test_args = [
     '--log-cli-level=INFO',
     '--log-file-level=INFO',
     '--no-flaky-report',
-    '--timeout=180',
+    '--timeout=300',
     '--cov-report=html',
     '--cov-report=term',
     '--cov-report=xml',

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup
 from setuptools.command.test import test as TestCommand
 
 test_args = [
-    '-n 4',
+    '-n 0',
     '--verbose',
     '--capture=sys',
     '--log-level=INFO',

--- a/slm_lab/agent/__init__.py
+++ b/slm_lab/agent/__init__.py
@@ -58,14 +58,12 @@ class Agent:
         '''Do agent reset per session, such as memory pointer'''
         logger.debug(f'Agent {self.a} reset')
         self.body.memory.epi_reset(state)
-        self.aeb_space.add_single(AGENT_DATA_NAMES, (np.nan, np.nan, np.nan))
 
     @lab_api
     def act(self, state):
         '''Standard act method from algorithm.'''
         action = self.algorithm.act(state)
         logger.debug(f'Agent {self.a} act: {action}')
-        self.aeb_space.add_single(('action',), (action,))
         return action
 
     @lab_api
@@ -79,7 +77,6 @@ class Agent:
         logger.debug(f'Agent {self.a} loss: {loss}, explore_var {explore_var}')
         if done:
             self.body.epi_update()
-        self.aeb_space.add_single(('loss', 'explore_var'), (loss, explore_var))
         return loss, explore_var
 
     @lab_api

--- a/slm_lab/agent/__init__.py
+++ b/slm_lab/agent/__init__.py
@@ -141,7 +141,7 @@ class Agent:
         explore_var_a = util.guard_data_a(self, explore_var_a, 'explore_var')
         logger.debug(f'Agent {self.a} loss: {loss_a}, explore_var_a {explore_var_a}')
         for eb, body in util.ndenumerate_nonan(self.body_a):
-            if done_a[eb]:
+            if body.env.done:
                 body.epi_update()
         return loss_a, explore_var_a
 

--- a/slm_lab/agent/__init__.py
+++ b/slm_lab/agent/__init__.py
@@ -77,6 +77,8 @@ class Agent:
             self.body.last_loss = loss
         explore_var = self.algorithm.update()
         logger.debug(f'Agent {self.a} loss: {loss}, explore_var {explore_var}')
+        if done:
+            self.body.epi_update()
         self.aeb_space.add_single(('loss', 'explore_var'), (loss, explore_var))
         return loss, explore_var
 
@@ -141,6 +143,9 @@ class Agent:
         explore_var_a = self.algorithm.space_update()
         explore_var_a = util.guard_data_a(self, explore_var_a, 'explore_var')
         logger.debug(f'Agent {self.a} loss: {loss_a}, explore_var_a {explore_var_a}')
+        for eb, body in util.ndenumerate_nonan(self.body_a):
+            if done_a[eb]:
+                body.epi_update()
         return loss_a, explore_var_a
 
 

--- a/slm_lab/agent/memory/base.py
+++ b/slm_lab/agent/memory/base.py
@@ -79,4 +79,4 @@ class Memory(ABC):
         '''Prints size of all of the memory arrays'''
         for k in self.data_keys:
             d = getattr(self, k)
-            logger.info(f'Memory for body {self.body.aeb}: {k} :shape: {d.shape}, dtype: {d.dtype}, size: {util.memory_size(d)}MB')
+            logger.info(f'Memory for body {self.body.aeb}: {k} :shape: {d.shape}, dtype: {d.dtype}, size: {util.sizeof(d)}MB')

--- a/slm_lab/agent/memory/onpolicy.py
+++ b/slm_lab/agent/memory/onpolicy.py
@@ -58,7 +58,7 @@ class OnPolicyReplay(Memory):
         self.true_size = 0  # Size of the current memory
         self.state_buffer.clear()
         for _ in range(self.state_buffer.maxlen):
-            self.state_buffer.append(np.zeros(self.body.state_dim))
+            self.state_buffer.append(np.zeros(self.body.state_dim, dtype=np.float16))
 
     @lab_api
     def update(self, action, reward, state, done):
@@ -252,7 +252,7 @@ class OnPolicySeqBatchReplay(OnPolicyBatchReplay):
         super(OnPolicySeqBatchReplay, self).reset()
         self.state_buffer.clear()
         for _ in range(self.state_buffer.maxlen):
-            self.state_buffer.append(np.zeros(self.body.state_dim))
+            self.state_buffer.append(np.zeros(self.body.state_dim, dtype=np.float16))
 
     def preprocess_state(self, state, append=True):
         '''Transforms the raw state into format that is fed into the network'''

--- a/slm_lab/agent/memory/onpolicy.py
+++ b/slm_lab/agent/memory/onpolicy.py
@@ -58,7 +58,7 @@ class OnPolicyReplay(Memory):
         self.true_size = 0  # Size of the current memory
         self.state_buffer.clear()
         for _ in range(self.state_buffer.maxlen):
-            self.state_buffer.append(np.zeros(self.body.state_dim, dtype=np.float16))
+            self.state_buffer.append(np.zeros(self.body.state_dim))
 
     @lab_api
     def update(self, action, reward, state, done):
@@ -252,7 +252,7 @@ class OnPolicySeqBatchReplay(OnPolicyBatchReplay):
         super(OnPolicySeqBatchReplay, self).reset()
         self.state_buffer.clear()
         for _ in range(self.state_buffer.maxlen):
-            self.state_buffer.append(np.zeros(self.body.state_dim, dtype=np.float16))
+            self.state_buffer.append(np.zeros(self.body.state_dim))
 
     def preprocess_state(self, state, append=True):
         '''Transforms the raw state into format that is fed into the network'''

--- a/slm_lab/agent/memory/replay.py
+++ b/slm_lab/agent/memory/replay.py
@@ -115,7 +115,7 @@ class Replay(Memory):
 
     def sample_idxs(self, batch_size):
         '''Batch indices a sampled random uniformly'''
-        batch_idxs = np.random.choice(range(self.true_size), batch_size)
+        batch_idxs = util.fast_uniform_sample(self.true_size, batch_size)
         if self.use_cer:  # add the latest sample
             batch_idxs[-1] = self.head
         return batch_idxs

--- a/slm_lab/agent/memory/replay.py
+++ b/slm_lab/agent/memory/replay.py
@@ -67,12 +67,12 @@ class Replay(Memory):
             elif k == 'actions':
                 setattr(self, k, np.zeros(self.actions_shape, dtype=self.body.action_space.dtype))
             else:
-                setattr(self, k, np.zeros(self.scalar_shape, dtype=np.float16))
+                setattr(self, k, np.zeros(self.scalar_shape))
         self.true_size = 0
         self.head = -1
         self.state_buffer.clear()
         for _ in range(self.state_buffer.maxlen):
-            self.state_buffer.append(np.zeros(self.body.state_dim, dtype=np.float16))
+            self.state_buffer.append(np.zeros(self.body.state_dim))
 
     @lab_api
     def update(self, action, reward, state, done):
@@ -258,7 +258,7 @@ class ConcatReplay(Replay):
         super(ConcatReplay, self).reset()
         self.state_buffer.clear()
         for _ in range(self.state_buffer.maxlen):
-            self.state_buffer.append(np.zeros(self.raw_state_dim, dtype=np.float16))
+            self.state_buffer.append(np.zeros(self.raw_state_dim))
 
     def epi_reset(self, state):
         '''Method to reset at new episode'''
@@ -266,7 +266,7 @@ class ConcatReplay(Replay):
         # reappend buffer with custom shape
         self.state_buffer.clear()
         for _ in range(self.state_buffer.maxlen):
-            self.state_buffer.append(np.zeros(self.raw_state_dim, dtype=np.float16))
+            self.state_buffer.append(np.zeros(self.raw_state_dim))
 
     def preprocess_state(self, state, append=True):
         '''Transforms the raw state into format that is fed into the network'''

--- a/slm_lab/agent/memory/replay.py
+++ b/slm_lab/agent/memory/replay.py
@@ -63,16 +63,16 @@ class Replay(Memory):
         # set data keys as self.{data_keys}
         for k in self.data_keys:
             if 'states' in k:
-                setattr(self, k, np.zeros(self.states_shape))
+                setattr(self, k, np.zeros(self.states_shape, dtype=np.float16))
             elif k == 'actions':
                 setattr(self, k, np.zeros(self.actions_shape, dtype=self.body.action_space.dtype))
             else:
-                setattr(self, k, np.zeros(self.scalar_shape))
+                setattr(self, k, np.zeros(self.scalar_shape, dtype=np.float16))
         self.true_size = 0
         self.head = -1
         self.state_buffer.clear()
         for _ in range(self.state_buffer.maxlen):
-            self.state_buffer.append(np.zeros(self.body.state_dim))
+            self.state_buffer.append(np.zeros(self.body, dtype=np.float16.state_dim))
 
     @lab_api
     def update(self, action, reward, state, done):
@@ -258,7 +258,7 @@ class ConcatReplay(Replay):
         super(ConcatReplay, self).reset()
         self.state_buffer.clear()
         for _ in range(self.state_buffer.maxlen):
-            self.state_buffer.append(np.zeros(self.raw_state_dim))
+            self.state_buffer.append(np.zeros(self.raw_state_dim, dtype=np.float16))
 
     def epi_reset(self, state):
         '''Method to reset at new episode'''
@@ -266,7 +266,7 @@ class ConcatReplay(Replay):
         # reappend buffer with custom shape
         self.state_buffer.clear()
         for _ in range(self.state_buffer.maxlen):
-            self.state_buffer.append(np.zeros(self.raw_state_dim))
+            self.state_buffer.append(np.zeros(self.raw_state_dim, dtype=np.float16))
 
     def preprocess_state(self, state, append=True):
         '''Transforms the raw state into format that is fed into the network'''

--- a/slm_lab/agent/memory/replay.py
+++ b/slm_lab/agent/memory/replay.py
@@ -72,7 +72,7 @@ class Replay(Memory):
         self.head = -1
         self.state_buffer.clear()
         for _ in range(self.state_buffer.maxlen):
-            self.state_buffer.append(np.zeros(self.body, dtype=np.float16.state_dim))
+            self.state_buffer.append(np.zeros(self.body.state_dim, dtype=np.float16))
 
     @lab_api
     def update(self, action, reward, state, done):

--- a/slm_lab/env/openai.py
+++ b/slm_lab/env/openai.py
@@ -30,7 +30,6 @@ class OpenAIEnv(BaseEnv):
         if util.to_render():
             self.u_env.render()
         logger.debug(f'Env {self.e} reset reward: {_reward}, state: {state}, done: {done}')
-        self.aeb_space.add_single(ENV_DATA_NAMES, (_reward, state, done))
         return _reward, state, done
 
     @lab_api
@@ -42,7 +41,6 @@ class OpenAIEnv(BaseEnv):
             self.u_env.render()
         self.done = done = done or self.clock.get('t') > self.max_timestep
         logger.debug(f'Env {self.e} step reward: {reward}, state: {state}, done: {done}')
-        self.aeb_space.add_single(ENV_DATA_NAMES, (reward, state, done))
         return reward, state, done
 
     @lab_api

--- a/slm_lab/env/unity.py
+++ b/slm_lab/env/unity.py
@@ -116,7 +116,6 @@ class UnityEnv(BaseEnv):
         state = env_info_a.states[b]
         self.done = done = False
         logger.debug(f'Env {self.e} reset reward: {_reward}, state: {state}, done: {done}')
-        self.aeb_space.add_single(ENV_DATA_NAMES, (_reward, state, done))
         return _reward, state, done
 
     @lab_api
@@ -129,7 +128,6 @@ class UnityEnv(BaseEnv):
         done = env_info_a.local_done[b]
         self.done = done = done or self.clock.get('t') > self.max_timestep
         logger.debug(f'Env {self.e} step reward: {reward}, state: {state}, done: {done}')
-        self.aeb_space.add_single(ENV_DATA_NAMES, (reward, state, done))
         return reward, state, done
 
     @lab_api

--- a/slm_lab/experiment/analysis.py
+++ b/slm_lab/experiment/analysis.py
@@ -274,7 +274,7 @@ def is_unfit(fitness_df):
 
 def plot_session(session_spec, info_space, session_data):
     '''Plot the session graph, 2 panes: reward, loss & explore_var. Each aeb_df gets its own color'''
-    graph_x = session_spec['meta'].get('graph_x')
+    graph_x = session_spec['meta'].get('graph_x', 'epi')
     aeb_count = len(session_data)
     palette = viz.get_palette(aeb_count)
     fig = viz.tools.make_subplots(rows=3, cols=1, shared_xaxes=True)

--- a/slm_lab/experiment/analysis.py
+++ b/slm_lab/experiment/analysis.py
@@ -238,7 +238,7 @@ def get_session_data(session):
         aeb_df.reset_index(drop=False, inplace=True)
         session_mdp_data[aeb], session_data[aeb] = mdp_df, aeb_df
     logger.debug(f'{session_data}')
-    data_size_in_bytes = util.memory_size(session_mdp_data)
+    data_size_in_bytes = util.sizeof(session_mdp_data)
     logger.debug(f'Size of session data: {data_size_in_bytes} MB')
     if data_size_in_bytes > 25:
         logger.warn(f'Session data > 25 MB')

--- a/slm_lab/experiment/analysis.py
+++ b/slm_lab/experiment/analysis.py
@@ -274,6 +274,7 @@ def is_unfit(fitness_df):
 
 def plot_session(session_spec, info_space, session_data):
     '''Plot the session graph, 2 panes: reward, loss & explore_var. Each aeb_df gets its own color'''
+    graph_x = session_spec['meta'].get('graph_x')
     aeb_count = len(session_data)
     palette = viz.get_palette(aeb_count)
     fig = viz.tools.make_subplots(rows=3, cols=1, shared_xaxes=True)
@@ -281,14 +282,14 @@ def plot_session(session_spec, info_space, session_data):
         aeb_str = f'{a}{e}{b}'
         aeb_df = session_data[(a, e, b)]
         aeb_df.fillna(0, inplace=True)  # for saving plot, cant have nan
-        fig_1 = viz.plot_line(aeb_df, 'reward', 'epi', legend_name=aeb_str, draw=False, trace_kwargs={'legendgroup': aeb_str, 'line': {'color': palette[idx]}})
+        fig_1 = viz.plot_line(aeb_df, 'reward', graph_x, legend_name=aeb_str, draw=False, trace_kwargs={'legendgroup': aeb_str, 'line': {'color': palette[idx]}})
         fig.append_trace(fig_1.data[0], 1, 1)
 
-        fig_2 = viz.plot_line(aeb_df, ['loss'], 'epi', y2_col=['explore_var'], trace_kwargs={'legendgroup': aeb_str, 'showlegend': False, 'line': {'color': palette[idx]}}, draw=False)
+        fig_2 = viz.plot_line(aeb_df, ['loss'], graph_x, y2_col=['explore_var'], trace_kwargs={'legendgroup': aeb_str, 'showlegend': False, 'line': {'color': palette[idx]}}, draw=False)
         fig.append_trace(fig_2.data[0], 2, 1)
         fig.append_trace(fig_2.data[1], 3, 1)
 
-    fig.layout['xaxis1'].update(title='epi', zerolinewidth=1)
+    fig.layout['xaxis1'].update(title=graph_x, zerolinewidth=1)
     fig.layout['yaxis1'].update(fig_1.layout['yaxis'])
     fig.layout['yaxis1'].update(domain=[0.55, 1])
     fig.layout['yaxis2'].update(fig_2.layout['yaxis'])

--- a/slm_lab/experiment/analysis.py
+++ b/slm_lab/experiment/analysis.py
@@ -315,6 +315,7 @@ def gather_aeb_rewards_df(aeb, session_datas):
 
 def build_aeb_reward_fig(aeb_rewards_df, aeb_str, color):
     '''Build the aeb_reward envelope figure'''
+    # TODO need enable total_t for trial graph, and line up signals at the common total_t
     mean_sr = aeb_rewards_df.mean(axis=1)
     std_sr = aeb_rewards_df.std(axis=1).fillna(0)
     max_sr = mean_sr + std_sr

--- a/slm_lab/experiment/control.py
+++ b/slm_lab/experiment/control.py
@@ -47,7 +47,7 @@ class Session:
     def save_if_ckpt(self, agent, env):
         '''Save for agent, env if episode is at checkpoint'''
         epi = env.clock.get('epi')
-        save_this_epi = epi != self.env.max_episode and epi > 0 and hasattr(env, 'save_epi_frequency') and epi % env.save_epi_frequency == 0
+        save_this_epi = epi != env.max_episode and epi > 0 and hasattr(env, 'save_epi_frequency') and epi % env.save_epi_frequency == 0
         if save_this_epi:
             agent.save(ckpt='last')
             analysis.analyze_session(self)

--- a/slm_lab/experiment/control.py
+++ b/slm_lab/experiment/control.py
@@ -47,7 +47,7 @@ class Session:
     def save_if_ckpt(self, agent, env):
         '''Save for agent, env if episode is at checkpoint'''
         epi = env.clock.get('epi')
-        save_this_epi = epi > 0 and hasattr(env, 'save_epi_frequency') and epi % env.save_epi_frequency == 0
+        save_this_epi = epi != self.env.max_episode and epi > 0 and hasattr(env, 'save_epi_frequency') and epi % env.save_epi_frequency == 0
         if save_this_epi:
             agent.save(ckpt='last')
             analysis.analyze_session(self)

--- a/slm_lab/experiment/control.py
+++ b/slm_lab/experiment/control.py
@@ -75,7 +75,7 @@ class Session:
         logger.info('Session done and closed.')
 
     def run(self):
-        while self.env.clock.get('epi') <= self.env.max_episode:
+        while self.env.clock.get('epi') < self.env.max_episode:
             self.run_episode()
         self.data = analysis.analyze_session(self)  # session fitness
         self.close()

--- a/slm_lab/experiment/monitor.py
+++ b/slm_lab/experiment/monitor.py
@@ -133,7 +133,6 @@ class Body:
 
     def epi_update(self):
         '''Update to append data at the end of an episode (when env.done is true)'''
-        assert self.env.done
         clock = self.env.clock
         row = {k: self.env.clock.get(k) for k in ['epi', 'total_t', 't']}
         row.update({

--- a/slm_lab/experiment/monitor.py
+++ b/slm_lab/experiment/monitor.py
@@ -141,6 +141,7 @@ class Body:
             'loss': self.last_loss,
             'explore_var': self.explore_var,
         })
+        assert all(k in self.df.columns for k in row), f'{self.df.columns} vs {row.keys()}'
         # append efficiently to df
         self.df.loc[len(self.df)] = row
         return row

--- a/slm_lab/experiment/monitor.py
+++ b/slm_lab/experiment/monitor.py
@@ -133,6 +133,7 @@ class Body:
 
     def epi_update(self):
         '''Update to append data at the end of an episode (when env.done is true)'''
+        assert self.env.done
         clock = self.env.clock
         row = {k: self.env.clock.get(k) for k in ['epi', 'total_t', 't']}
         row.update({

--- a/slm_lab/experiment/monitor.py
+++ b/slm_lab/experiment/monitor.py
@@ -233,7 +233,7 @@ class DataSpace:
             self.swap_data = new_data.swapaxes(0, 1)
         # Do not store states with more than 10 dimensions total. It places too much burden on the memory
         if self.data_name == 'state' and self.data[(0, 0, 0)].size > 10:
-            self.data_history.append(np.nan)
+            self.data_history.append(np.zeros_like(self.data))
         else:
             self.data_history.append(self.data)
         return self.data

--- a/slm_lab/experiment/monitor.py
+++ b/slm_lab/experiment/monitor.py
@@ -335,15 +335,6 @@ class AEBSpace:
         else:
             return tuple(self.add(d_name, d_v) for d_name, d_v in zip(data_name, data_v))
 
-    def add_single(self, data_names, datas):
-        '''Backward compatible add method for singleton case - single agent, env, body with aeb = 0,0,0'''
-        assert ps.is_iterable(data_names) and ps.is_iterable(datas)
-        data_vs = self.init_data_v(data_names)
-        for data_v, data in zip(data_vs, datas):
-            data_v[0, 0, 0] = data
-        data_spaces = self.add(data_names, data_vs)
-        return data_spaces
-
     def tick(self, unit=None):
         '''Tick all the clocks in env_space, and tell if all envs are done'''
         end_sessions = []

--- a/slm_lab/experiment/monitor.py
+++ b/slm_lab/experiment/monitor.py
@@ -141,7 +141,6 @@ class Body:
             'loss': self.last_loss,
             'explore_var': self.explore_var,
         })
-        assert all(k in self.df.columns for k in row), f'{self.df.columns} vs {row.keys()}'
         # append efficiently to df
         self.df.loc[len(self.df)] = row
         return row

--- a/slm_lab/experiment/monitor.py
+++ b/slm_lab/experiment/monitor.py
@@ -144,7 +144,7 @@ class Body:
         '''Log the summary for this body when its environment is done'''
         prefix = self.get_log_prefix()
         memory = self.memory
-        msg = f'{prefix}, loss: {self.last_loss:.4f}, total_reward: {memory.total_reward:.4f}, last-{memory.avg_window}-epi avg: {memory.avg_total_reward:.4f}'
+        msg = f'{prefix}, loss: {self.last_loss:.8f}, total_reward: {memory.total_reward:.4f}, last-{memory.avg_window}-epi avg: {memory.avg_total_reward:.4f}'
         logger.info(msg)
 
     def space_init(self, aeb_space):

--- a/slm_lab/experiment/monitor.py
+++ b/slm_lab/experiment/monitor.py
@@ -92,6 +92,8 @@ class Body:
         self.last_loss = np.nan  # the last non-nan loss, for printing
         # for action policy exploration, so be set in algo during init_algorithm_params()
         self.explore_var = np.nan
+        self.df = pd.DataFrame(columns=['epi', 'total_t', 't', 'reward', 'loss', 'explore_var'])
+        self.df[['epi', 'total_t', 't']] = self.df[['epi', 'total_t', 't']].astype(int)
 
         # diagnostics variables/stats from action_policy prob. dist.
         self.entropies = []  # check exploration
@@ -128,6 +130,20 @@ class Body:
         assert t == 0, f'aeb: {self.aeb}, t: {t}'
         if hasattr(self, 'aeb_space'):
             self.space_fix_stats()
+
+    def epi_update(self):
+        '''Update to append data at the end of an episode (when env.done is true)'''
+        assert self.env.done
+        clock = self.env.clock
+        row = {k: self.env.clock.get(k) for k in ['epi', 'total_t', 't']}
+        row.update({
+            'reward': self.memory.total_reward,
+            'loss': self.last_loss,
+            'explore_var': self.explore_var,
+        })
+        # append efficiently to df
+        self.df.loc[len(self.df)] = row
+        return row
 
     def __str__(self):
         return 'body: ' + util.to_json(util.get_class_attr(self))

--- a/slm_lab/lib/util.py
+++ b/slm_lab/lib/util.py
@@ -740,7 +740,7 @@ def try_set_cuda_id(spec, info_space):
             return
     trial_idx = info_space.get('trial') or 0
     session_idx = info_space.get('session') or 0
-    job_idx = trial_idx * session_idx + session_idx
+    job_idx = trial_idx * spec['meta']['max_session'] + session_idx
     device_count = torch.cuda.device_count()
     if device_count == 0:
         cuda_id = 0

--- a/slm_lab/lib/util.py
+++ b/slm_lab/lib/util.py
@@ -700,6 +700,25 @@ def to_tuple_list(l):
     return [tuple(row) for row in l]
 
 
+def track_mem(obj):
+    '''Debug method to track memory footprint of object and its attributes'''
+    global MEMTRACKER
+    if not isinstance(MEMTRACKER, dict):
+        MEMTRACKER = {}
+    obj_name = get_class_name(obj)
+    for k in dir(obj):
+        if not k.startswith('_'):
+            hash_k = f'{obj_name}.{k}'
+            size = sizeof(getattr(obj, k))
+            if hash_k not in MEMTRACKER:
+                MEMTRACKER[hash_k] = size
+            else:
+                diff = size - MEMTRACKER[hash_k]
+                MEMTRACKER[hash_k] = size
+                if (diff > 1e-4) or (size > 1.0):
+                    print(f'{hash_k} diff: {diff:.6f}, size: {size:.6f}')
+
+
 def try_set_cuda_id(spec, info_space):
     '''Use trial and session id to hash and modulo cuda device count for a cuda_id to maximize device usage. Sets the net_spec for the base Net class to pick up.'''
     # Don't trigger any cuda call if not using GPU. Otherwise will break multiprocessing on machines with CUDA.

--- a/slm_lab/lib/util.py
+++ b/slm_lab/lib/util.py
@@ -116,6 +116,8 @@ def downcast_float32(df):
 
 def fast_uniform_sample(mem_size, batch_size):
     '''Fast uniform sampling for large memory size (indices) by binning the number line and sampling from each bin'''
+    if mem_size <= batch_size:
+        return np.random.randint(mem_size, size=batch_size)
     num_base = math.floor(mem_size / batch_size)
     bin_start = np.arange(batch_size, dtype=np.int) * num_base
     bin_idx = np.random.randint(num_base, size=batch_size)

--- a/slm_lab/lib/util.py
+++ b/slm_lab/lib/util.py
@@ -3,6 +3,7 @@ from importlib import reload
 from slm_lab import ROOT_DIR
 import cv2
 import json
+import math
 import numpy as np
 import os
 import pandas as pd
@@ -111,6 +112,15 @@ def downcast_float32(df):
         if df[col].dtype == 'float':
             df[col] = df[col].astype('float32')
     return df
+
+
+def fast_uniform_sample(mem_size, batch_size):
+    '''Fast uniform sampling for large memory size (indices) by binning the number line and sampling from each bin'''
+    num_base = math.floor(mem_size / batch_size)
+    bin_start = np.arange(batch_size, dtype=np.int) * num_base
+    bin_idx = np.random.randint(num_base, size=batch_size)
+    bin_idx += bin_start
+    return bin_idx
 
 
 def flatten_dict(obj, delim='.'):

--- a/slm_lab/lib/viz.py
+++ b/slm_lab/lib/viz.py
@@ -302,7 +302,7 @@ def save_image(figure, filepath=None):
         logger.info(f'Graph saved to {dirname}/{filename}')
     except Exception as e:
         logger.exception(
-            'Please install orca for plotly and run retro-analysis to generate graphs.')
+            'Failed to generate graph. Fix the issue and run retro-analysis to generate graphs.')
 
 
 def stack_cumsum(df, y_col):

--- a/slm_lab/spec/beamrider.json
+++ b/slm_lab/spec/beamrider.json
@@ -71,6 +71,7 @@
     },
     "meta": {
       "distributed": false,
+      "graph_x": "total_t",
       "max_session": 4,
       "max_trial": 1,
       "search": "RandomSearch"
@@ -148,6 +149,7 @@
     },
     "meta": {
       "distributed": false,
+      "graph_x": "total_t",
       "max_session": 4,
       "max_trial": 1,
       "search": "RandomSearch"
@@ -222,6 +224,7 @@
     },
     "meta": {
       "distributed": false,
+      "graph_x": "total_t",
       "max_session": 4,
       "max_trial": 1,
       "search": "RandomSearch"

--- a/slm_lab/spec/beamrider.json
+++ b/slm_lab/spec/beamrider.json
@@ -1,5 +1,5 @@
 {
-  "dqn_breamrider": {
+  "dqn_beamrider": {
     "agent": [{
       "name": "DQN",
       "algorithm": {
@@ -77,7 +77,7 @@
       "search": "RandomSearch"
     }
   },
-  "ddqn_breamrider": {
+  "ddqn_beamrider": {
     "agent": [{
       "name": "DoubleDQN",
       "algorithm": {

--- a/slm_lab/spec/demo.json
+++ b/slm_lab/spec/demo.json
@@ -49,8 +49,8 @@
     "env": [{
       "name": "CartPole-v0",
       "max_timestep": null,
-      "max_episode": 150,
-      "save_epi_frequency": 50
+      "max_episode": 20,
+      "save_epi_frequency": 10
     }],
     "body": {
       "product": "outer",
@@ -58,6 +58,7 @@
     },
     "meta": {
       "distributed": false,
+      "graph_x": "epi",
       "max_trial": 4,
       "max_session": 4,
       "search": "RandomSearch",

--- a/slm_lab/spec/demo.json
+++ b/slm_lab/spec/demo.json
@@ -49,8 +49,8 @@
     "env": [{
       "name": "CartPole-v0",
       "max_timestep": null,
-      "max_episode": 20,
-      "save_epi_frequency": 10
+      "max_episode": 150,
+      "save_epi_frequency": 50
     }],
     "body": {
       "product": "outer",

--- a/slm_lab/spec/demo.json
+++ b/slm_lab/spec/demo.json
@@ -50,7 +50,7 @@
       "name": "CartPole-v0",
       "max_timestep": null,
       "max_episode": 150,
-      "save_epi_frequency": 1000
+      "save_epi_frequency": 50
     }],
     "body": {
       "product": "outer",

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -1,20 +1,14 @@
 from slm_lab.agent import AgentSpace
-from slm_lab.agent.memory import Replay
 from slm_lab.agent.net.convnet import ConvNet
-from slm_lab.agent.net.recurrent import RecurrentNet
 from slm_lab.agent.net.mlp import MLPNet, HydraMLPNet
+from slm_lab.agent.net.recurrent import RecurrentNet
 from slm_lab.env import EnvSpace
-# from slm_lab.experiment.control import Trial
 from slm_lab.experiment.monitor import AEBSpace, InfoSpace
 from slm_lab.lib import util
 from slm_lab.spec import spec_util
 import numpy as np
 import pandas as pd
 import pytest
-import torch
-import torch.nn as nn
-import torch.nn.functional as F
-import torch.optim as optim
 
 
 spec = None

--- a/test/experiment/test_control.py
+++ b/test/experiment/test_control.py
@@ -21,6 +21,8 @@ def test_trial(test_spec, test_info_space):
 
 def test_trial_demo(test_info_space):
     spec = spec_util.get('demo.json', 'dqn_cartpole')
+    spec = util.override_test_spec(spec)
+    spec['env'][0]['save_epi_frequency'] = 2
     test_info_space.tick('trial')
     trial_data = Trial(spec, test_info_space).run()
     assert isinstance(trial_data, pd.DataFrame)

--- a/test/experiment/test_control.py
+++ b/test/experiment/test_control.py
@@ -22,7 +22,7 @@ def test_trial(test_spec, test_info_space):
 def test_trial_demo(test_info_space):
     spec = spec_util.get('demo.json', 'dqn_cartpole')
     spec = util.override_test_spec(spec)
-    spec['env'][0]['save_epi_frequency'] = 2
+    spec['env'][0]['save_epi_frequency'] = 1
     test_info_space.tick('trial')
     trial_data = Trial(spec, test_info_space).run()
     assert isinstance(trial_data, pd.DataFrame)

--- a/test/experiment/test_control.py
+++ b/test/experiment/test_control.py
@@ -21,7 +21,6 @@ def test_trial(test_spec, test_info_space):
 
 def test_trial_demo(test_info_space):
     spec = spec_util.get('demo.json', 'dqn_cartpole')
-    spec = util.override_test_spec(spec)
     test_info_space.tick('trial')
     trial_data = Trial(spec, test_info_space).run()
     assert isinstance(trial_data, pd.DataFrame)

--- a/test/spec/test_spec.py
+++ b/test/spec/test_spec.py
@@ -1,14 +1,14 @@
 from flaky import flaky
-from slm_lab.experiment.control import Trial, Session
+from slm_lab.experiment.control import Trial
 from slm_lab.experiment.monitor import InfoSpace
-from slm_lab.lib import logger, util
+from slm_lab.lib import util
 from slm_lab.spec import spec_util
 import os
 import pandas as pd
 import pytest
 
 
-# helper method to run all tests below, split for parallelization
+# helper method to run all tests in test_spec
 def run_trial_test(spec_file, spec_name=False, distributed=False):
     spec = spec_util.get(spec_file, spec_name)
     spec = util.override_test_spec(spec)


### PR DESCRIPTION
### remove data space history
- debug and fix memory growth (cause: data space saving history)
- remove history saving altogether, and mdp data
- remove aeb `add_single`
- create `body.df` to track data efficiently as a replacement

### large replay memory
- make memory state numpy storage `float16` to accommodate big memory size. half a million max_size virtual memory goes from 200GB to 50GB
- memory index sampling for training with large size is very slow. add a method `fast_uniform_sampling` to speed up

### misc
- add `total_t` option to plot session graph. no equivalence for trial graph. need an eval job
- fix cuda id hashing
- misc fixes from extra stress-testing
