### PR TITLE
Atari OnPolicy Memory

### DIFF
--- a/slm_lab/agent/algorithm/math_util.py
+++ b/slm_lab/agent/algorithm/math_util.py
@@ -61,7 +61,7 @@ def calc_nstep_returns(batch, gamma, n, next_v_preds):
         then add v_pred for n as final term
     '''
     rets = batch['rewards'].clone()  # prevent mutation
-    _next_v_preds = next_v_preds.clone()  # prevent mutation
+    next_v_preds = next_v_preds.clone()  # prevent mutation
     nstep_rets = torch.zeros_like(rets) + rets
     cur_gamma = gamma
     for i in range(1, n):
@@ -69,14 +69,14 @@ def calc_nstep_returns(batch, gamma, n, next_v_preds):
         rets[:-1] = rets[1:]
         rets *= (1 - batch['dones'])
         # Also shift V(s_t+1) so final terms use V(s_t+n)
-        _next_v_preds[:-1] = _next_v_preds[1:]
-        _next_v_preds *= (1 - batch['dones'])
+        next_v_preds[:-1] = next_v_preds[1:]
+        next_v_preds *= (1 - batch['dones'])
         # Accumulate return
         nstep_rets += cur_gamma * rets
         # Update current gamma
         cur_gamma *= cur_gamma
     # Add final terms. Note no next state if epi is done
-    final_terms = cur_gamma * _next_v_preds * (1 - batch['dones'])
+    final_terms = cur_gamma * next_v_preds * (1 - batch['dones'])
     nstep_rets += final_terms
     return nstep_rets
 

--- a/slm_lab/agent/memory/onpolicy.py
+++ b/slm_lab/agent/memory/onpolicy.py
@@ -297,3 +297,58 @@ class OnPolicySeqBatchReplay(OnPolicyBatchReplay):
         for i in range(len(data)):
             data_seq.append(padded_data[i:i + self.seq_len])
         return data_seq
+
+
+class OnPolicyAtariReplay(OnPolicyReplay):
+    '''
+    Preprocesses an state to be the concatenation of the last four states, after converting the 210 x 160 x 3 image to 84 x 84 x 1 grayscale image, and clips all rewards to [-10, 10] as per "Playing Atari with Deep Reinforcement Learning", Mnih et al, 2013
+    Note: Playing Atari with Deep RL clips the rewards to + / - 1
+    Otherwise the same as OnPolicyReplay memory
+    '''
+
+    def __init__(self, memory_spec, body):
+        self.atari = True  # Memory is specialized for playing Atari games
+        util.set_attr(self, memory_spec, [
+            'stack_len',  # number of stack states
+        ])
+        self.raw_state_dim = (84, 84)
+        body.state_dim = self.raw_state_dim + (self.stack_len,)  # greyscale downsized, stacked
+        OnPolicyReplay.__init__(self, memory_spec, body)
+        self.state_buffer = deque(maxlen=self.stack_len)
+        self.reset()
+
+    @lab_api
+    def reset(self):
+        '''Initializes the memory arrays, size and head pointer'''
+        super(OnPolicyAtariReplay, self).reset()
+        self.state_buffer.clear()
+        for _ in range(self.state_buffer.maxlen):
+            self.state_buffer.append(np.zeros(self.raw_state_dim))
+
+    def epi_reset(self, state):
+        '''Method to reset at new episode'''
+        super(OnPolicyAtariReplay, self).epi_reset(state)
+        self.state_buffer.clear()
+        for _ in range(self.state_buffer.maxlen):
+            self.state_buffer.append(np.zeros(self.raw_state_dim))
+
+    def preprocess_state(self, state, append=True):
+        '''Transforms the raw state into format that is fed into the network'''
+        state = util.transform_image(state)
+        # append when state is first seen when acting in policy_util, don't append elsewhere in memory
+        if append:
+            assert id(state) != id(self.state_buffer[-1]), 'Do not append to buffer other than during action'
+            self.state_buffer.append(state)
+        processed_state = np.stack(self.state_buffer, axis=-1).astype(np.float16)
+        assert processed_state.shape == self.body.state_dim
+        return processed_state
+
+    @lab_api
+    def update(self, action, reward, state, done):
+        '''Interface method to update memory'''
+        self.base_update(action, reward, state, done)
+        state = self.preprocess_state(state, append=False)  # prevent conflict with preprocess in epi_reset
+        if not np.isnan(reward):  # not the start of episode
+            reward = max(-10, min(10, reward))
+            self.add_experience(self.last_state, action, reward, state, done)
+        self.last_state = state

--- a/slm_lab/agent/memory/onpolicy.py
+++ b/slm_lab/agent/memory/onpolicy.py
@@ -327,6 +327,7 @@ class OnPolicyAtariReplay(OnPolicyReplay):
 
     def epi_reset(self, state):
         '''Method to reset at new episode'''
+        state = self.preprocess_state(state, append=False)
         super(OnPolicyAtariReplay, self).epi_reset(state)
         self.state_buffer.clear()
         for _ in range(self.state_buffer.maxlen):

--- a/slm_lab/agent/memory/replay.py
+++ b/slm_lab/agent/memory/replay.py
@@ -289,8 +289,8 @@ class ConcatReplay(Replay):
 
 class AtariReplay(ConcatReplay):
     '''
-    Preprocesses an state to be the concatenation of the last four states, after converting the 210 x 160 x 3 image to 84 x 84 x 1 grayscale image, and clips all rewards to [-1, 1] as per "Playing Atari with Deep Reinforcement Learning", Mnih et al, 2013
-    Otherwise the same as Replay memory
+    Preprocesses an state to be the concatenation of the last four states, after converting the 210 x 160 x 3 image to 84 x 84 x 1 grayscale image, and clips all rewards to [-10, 10] as per "Playing Atari with Deep Reinforcement Learning", Mnih et al, 2013
+    Note: Playing Atari with Deep RL clips the rewards to + / - 1
 
     e.g. memory_spec
     "memory": {
@@ -333,6 +333,6 @@ class AtariReplay(ConcatReplay):
         self.base_update(action, reward, state, done)
         state = self.preprocess_state(state, append=False)  # prevent conflict with preprocess in epi_reset
         if not np.isnan(reward):  # not the start of episode
-            reward = max(-1, min(1, reward))
+            reward = max(-10, min(10, reward))
             self.add_experience(self.last_state, action, reward, state, done)
         self.last_state = state

--- a/slm_lab/agent/memory/replay.py
+++ b/slm_lab/agent/memory/replay.py
@@ -333,7 +333,6 @@ class AtariReplay(ConcatReplay):
         self.base_update(action, reward, state, done)
         state = self.preprocess_state(state, append=False)  # prevent conflict with preprocess in epi_reset
         if not np.isnan(reward):  # not the start of episode
-            if not np.isnan(reward):
-                reward = max(-1, min(1, reward))
+            reward = max(-1, min(1, reward))
             self.add_experience(self.last_state, action, reward, state, done)
         self.last_state = state

--- a/slm_lab/lib/util.py
+++ b/slm_lab/lib/util.py
@@ -699,7 +699,6 @@ def to_render():
 
 def to_torch_batch(batch, device, is_episodic):
     '''Mutate a batch (dict) to make its values from numpy into PyTorch tensor'''
-    # TODO Fix for OnPolicyAtariReplay memory
     for k in batch:
         if is_episodic:  # for episodic format
             batch[k] = np.concatenate(batch[k])

--- a/slm_lab/lib/util.py
+++ b/slm_lab/lib/util.py
@@ -665,6 +665,7 @@ def to_render():
 
 def to_torch_batch(batch, device, is_episodic):
     '''Mutate a batch (dict) to make its values from numpy into PyTorch tensor'''
+    # TODO Fix for OnPolicyAtariReplay memory
     for k in batch:
         if is_episodic:  # for episodic format
             batch[k] = np.concatenate(batch[k])

--- a/slm_lab/spec/beamrider.json
+++ b/slm_lab/spec/beamrider.json
@@ -176,7 +176,8 @@
         "normalize_state": true
       },
       "memory": {
-        "name": "OnPolicyReplay"
+        "name": "OnPolicyAtariReplay",
+        "stack_len": 4
       },
       "net": {
         "type": "ConvNet",


### PR DESCRIPTION
Adds OnPolicyAtariReplay memory so that policy based algorithms can be applied to the Atari suite.
- Fixed crashing ppo_conv_shared_beamrider

Also fixes n-step returns
- V(s) was always being applied for V(s_t+1), now V(s_t+n) as it should be