### PR TITLE
Fix Pandas hanging during save

### DIFF
--- a/slm_lab/agent/net/base.py
+++ b/slm_lab/agent/net/base.py
@@ -19,6 +19,9 @@ class Net(ABC):
         self.in_dim = in_dim
         self.out_dim = out_dim
         if self.net_spec.get('gpu'):
-            self.device = f'cuda:{net_spec.get("cuda_id", 0)}'
+            if torch.cuda.device_count():
+                self.device = f'cuda:{net_spec.get("cuda_id", 0)}'
+            else:
+                self.device = 'cpu'
         else:
             self.device = 'cpu'

--- a/slm_lab/experiment/analysis.py
+++ b/slm_lab/experiment/analysis.py
@@ -215,7 +215,7 @@ def get_session_data(session):
     '''
     session_data = {}
     for aeb, body in util.ndenumerate_nonan(session.aeb_space.body_space.data):
-        session_data[aeb] = body.df
+        session_data[aeb] = body.df.copy()
     return session_data
 
 

--- a/slm_lab/experiment/monitor.py
+++ b/slm_lab/experiment/monitor.py
@@ -141,7 +141,7 @@ class Body:
             'explore_var': self.explore_var,
         })
         # append efficiently to df
-        self.df.loc[len(self.df)] = row
+        self.df.loc[len(self.df)] = pd.Series(row, dtype=np.float32)
         return row
 
     def __str__(self):

--- a/slm_lab/experiment/monitor.py
+++ b/slm_lab/experiment/monitor.py
@@ -92,8 +92,7 @@ class Body:
         self.last_loss = np.nan  # the last non-nan loss, for printing
         # for action policy exploration, so be set in algo during init_algorithm_params()
         self.explore_var = np.nan
-        self.df = pd.DataFrame(columns=['epi', 'total_t', 't', 'reward', 'loss', 'explore_var'])
-        self.df[['epi', 'total_t', 't']] = self.df[['epi', 'total_t', 't']].astype(int)
+        self.df = pd.DataFrame(columns=['epi', 't', 'reward', 'loss', 'explore_var'])
 
         # diagnostics variables/stats from action_policy prob. dist.
         self.entropies = []  # check exploration
@@ -135,7 +134,7 @@ class Body:
         '''Update to append data at the end of an episode (when env.done is true)'''
         assert self.env.done
         clock = self.env.clock
-        row = {k: self.env.clock.get(k) for k in ['epi', 'total_t', 't']}
+        row = {k: self.env.clock.get(k) for k in ['epi', 't']}
         row.update({
             'reward': self.memory.total_reward,
             'loss': self.last_loss,

--- a/slm_lab/lib/util.py
+++ b/slm_lab/lib/util.py
@@ -743,9 +743,11 @@ def try_set_cuda_id(spec, info_space):
     job_idx = trial_idx * spec['meta']['max_session'] + session_idx
     device_count = torch.cuda.device_count()
     if device_count == 0:
-        cuda_id = 0
+        cuda_id = None
     else:
         cuda_id = job_idx % device_count
+        cuda_id += int(os.environ.get('CUDA_ID_OFFSET', 0))
+
     for agent_spec in spec['agent']:
         agent_spec['net']['cuda_id'] = cuda_id
 

--- a/slm_lab/spec/beamrider.json
+++ b/slm_lab/spec/beamrider.json
@@ -20,7 +20,7 @@
       "memory": {
         "name": "AtariReplay",
         "batch_size": 32,
-        "max_size": 500000,
+        "max_size": 1000000,
         "stack_len": 4,
         "use_cer": false
       },
@@ -72,7 +72,7 @@
     "meta": {
       "distributed": false,
       "graph_x": "total_t",
-      "max_session": 4,
+      "max_session": 1,
       "max_trial": 1,
       "search": "RandomSearch"
     }
@@ -98,7 +98,7 @@
       "memory": {
         "name": "AtariReplay",
         "batch_size": 32,
-        "max_size": 500000,
+        "max_size": 1000000,
         "stack_len": 4,
         "use_cer": false
       },
@@ -150,7 +150,7 @@
     "meta": {
       "distributed": false,
       "graph_x": "total_t",
-      "max_session": 4,
+      "max_session": 1,
       "max_trial": 1,
       "search": "RandomSearch"
     }
@@ -225,7 +225,7 @@
     "meta": {
       "distributed": false,
       "graph_x": "total_t",
-      "max_session": 4,
+      "max_session": 1,
       "max_trial": 1,
       "search": "RandomSearch"
     }


### PR DESCRIPTION
- attempt to fix python hang issue at 100k `total_t`
- properly set `cuda_id`, add `CUDA_ID_OFFSET` env var, e.g. `CUDA_ID_OFFSET=1 yarn start`


Pandas df of `body.df` seems to hang when a row with `total_t` value over 100k is being inserted into it, even though the df should be float64.

More or less, the second row below makes it hang:
```python
df = pd.DataFrame(columns=['epi', 'total_t', 't', 'reward', 'loss', 'explore_var'])
row = {'epi': 74, 'total_t': 98186, 't': 1538, 'reward': 660.0, 'loss': 0.0001187251546070911, 'explore_var': 0.87790}
df.loc[len(df)] = row
df
# value below will break when ran in lab, but not in normal ipython
row = {'epi': 75, 'total_t': 100161, 't': 1975, 'reward': 660.0, 'loss': 0.0001187251546070911, 'explore_var': 0.87625}
df.loc[len(df)] = row
df
```