### PR TITLE
Enable Distributed Cuda, Add AtariPrioritizedReplay

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,7 @@ For off-policy algorithms (value-based)
 - ConcatReplay
 - AtariReplay
 - PrioritizedReplay
+- AtariPrioritizedReplay
 
 #### Neural Network
 

--- a/run_lab.py
+++ b/run_lab.py
@@ -11,6 +11,7 @@ from slm_lab.experiment.control import Session, Trial, Experiment
 from slm_lab.experiment.monitor import InfoSpace
 from slm_lab.lib import logger, util
 from slm_lab.spec import spec_util, benchmarker
+import torch.multiprocessing as mp
 
 
 debug_modules = [
@@ -70,4 +71,5 @@ def main():
 
 
 if __name__ == '__main__':
+    mp.set_start_method('spawn')  # for distributed pytorch to work
     main()

--- a/slm_lab/agent/algorithm/dqn.py
+++ b/slm_lab/agent/algorithm/dqn.py
@@ -132,7 +132,7 @@ class VanillaDQN(SARSA):
             return np.nan
         total_t = self.body.env.clock.get('total_t')
         self.to_train = (total_t > self.training_min_timestep and total_t % self.training_frequency == 0)
-        is_per = util.get_class_name(self.body.memory) == 'PrioritizedReplay'
+        is_per = 'Prioritized' in util.get_class_name(self.body.memory)
         if self.to_train == 1:
             total_loss = torch.tensor(0.0, device=self.net.device)
             for _ in range(self.training_epoch):

--- a/slm_lab/agent/memory/prioritized.py
+++ b/slm_lab/agent/memory/prioritized.py
@@ -1,4 +1,4 @@
-from slm_lab.agent.memory.replay import Replay
+from slm_lab.agent.memory.replay import Replay, AtariReplay
 from slm_lab.lib import util
 from slm_lab.lib.decorator import lab_api
 import numpy as np
@@ -96,7 +96,7 @@ class PrioritizedReplay(Replay):
 
     e.g. memory_spec
     "memory": {
-        "name": "Replay",
+        "name": "PrioritizedReplay",
         "alpha": 1,
         "epsilon": 0,
         "batch_size": 32,
@@ -181,3 +181,8 @@ class PrioritizedReplay(Replay):
         self.priorities[self.batch_idxs] = priorities
         for p, i in zip(priorities, self.tree_idxs):
             self.tree.update(i, p)
+
+
+class AtariPrioritizedReplay(PrioritizedReplay, AtariReplay):
+    '''Make a Prioritized AtariReplay via nice multi-inheritance (python magic)'''
+    pass

--- a/slm_lab/experiment/control.py
+++ b/slm_lab/experiment/control.py
@@ -143,10 +143,10 @@ class SpaceSession(Session):
 class DistSession(mp.Process):
     '''Distributed Session for distributed training'''
 
-    def __init__(self, DistSessionClass, spec, info_space, global_nets):
+    def __init__(self, spec, info_space, global_nets):
         super(DistSession, self).__init__()
         self.name = f'w{info_space.get("session")}'
-        self.session = DistSessionClass(spec, info_space, global_nets)
+        self.session = Session(spec, info_space, global_nets)
         logger.info(f'Initialized DistSession {self.session.index}')
 
     def run(self):
@@ -222,7 +222,7 @@ class Trial:
         workers = []
         for _s in range(self.spec['meta']['max_session']):
             self.info_space.tick('session')
-            w = DistSession(self.SessionClass, deepcopy(self.spec), self.info_space, global_nets)
+            w = DistSession(deepcopy(self.spec), self.info_space, global_nets)
             w.start()
             workers.append(w)
         for w in workers:

--- a/slm_lab/experiment/control.py
+++ b/slm_lab/experiment/control.py
@@ -16,8 +16,6 @@ import pydash as ps
 import torch
 import torch.multiprocessing as mp
 
-mp.set_start_method('spawn', force=True)  # for distributed pytorch to work
-
 
 class Session:
     '''

--- a/slm_lab/experiment/control.py
+++ b/slm_lab/experiment/control.py
@@ -43,6 +43,8 @@ class Session:
         enable_aeb_space(self)  # to use lab's data analysis framework
         logger.info(util.self_desc(self))
         logger.info(f'Initialized session {self.index}')
+        if self.spec['meta'] and self.info_space.get('session') is not None:
+            self.run()
 
     def save_if_ckpt(self, agent, env):
         '''Save for agent, env if episode is at checkpoint'''
@@ -222,7 +224,8 @@ class Trial:
         workers = []
         for _s in range(self.spec['meta']['max_session']):
             self.info_space.tick('session')
-            w = DistSession(deepcopy(self.spec), self.info_space, global_nets)
+            w = mp.Process(target=Session, args=(deepcopy(self.spec), self.info_space, global_nets))
+            # w = DistSession(deepcopy(self.spec), self.info_space, global_nets)
             w.start()
             workers.append(w)
         for w in workers:

--- a/slm_lab/lib/util.py
+++ b/slm_lab/lib/util.py
@@ -394,8 +394,7 @@ def parallelize_fn(fn, args, num_cpus=NUM_CPUS):
         # you can never be too safe in multiprocessing gc
         import gc
         gc.collect()
-    pool = mp.Pool(num_cpus,
-                   initializer=pool_init, maxtasksperchild=1)
+    pool = mp.Pool(num_cpus, initializer=pool_init, maxtasksperchild=1)
     results = pool.map(fn, args)
     pool.close()
     pool.join()

--- a/slm_lab/spec/beamrider.json
+++ b/slm_lab/spec/beamrider.json
@@ -14,13 +14,15 @@
         "training_batch_epoch": 1,
         "training_epoch": 1,
         "training_frequency": 4,
-        "training_min_timestep": 1000,
+        "training_min_timestep": 10000,
         "normalize_state": true
       },
       "memory": {
-        "name": "AtariReplay",
+        "name": "AtariPrioritizedReplay",
+        "alpha": 0.6,
+        "epsilon": 1e-6,
         "batch_size": 32,
-        "max_size": 1000000,
+        "max_size": 50000,
         "stack_len": 4,
         "use_cer": false
       },
@@ -37,17 +39,13 @@
         "hid_layers_activation": "relu",
         "batch_norm": false,
         "clip_grad": true,
-        "clip_grad_val": 5.0,
+        "clip_grad_val": 10.0,
         "loss_spec": {
-          "name": "MSELoss"
+          "name": "SmoothL1Loss"
         },
         "optim_spec": {
-          "name": "RMSprop",
-          "lr": 0.00025,
-          "alpha": 0.99,
-          "eps": 1e-6,
-          "momentum": 0.0,
-          "centered": false
+          "name": "Adam",
+          "lr": 1e-4
         },
         "lr_decay": "linear_decay",
         "lr_decay_frequency": 1000,


### PR DESCRIPTION
- fix long standing pytorch + distributed using `spawn` multiprocessing due to Lab classes not pickleable. Just let the class wrapped in a `mp_runner` passed as `mp.Process(target=mp_runner, args)` so the classes don't get cloned from memory when spawning process, since it is now passed from outside.

- Add AtariPrioritizedReplay via multiinheritance. tested to call methods properly