### PR TITLE
Benchmark result for DQN Boltzmann cartpole

### DIFF
--- a/slm_lab/spec/cartpole.json
+++ b/slm_lab/spec/cartpole.json
@@ -2337,7 +2337,7 @@
         },
         "optim_spec": {
           "name": "Adam",
-          "lr": 0.02
+          "lr": 0.001
         },
         "lr_decay": "linear_decay",
         "lr_decay_frequency": 2000,


### PR DESCRIPTION
# Experiment Result

>*See [PR #180](https://github.com/kengz/SLM-Lab/pull/180) for an example*

>*The data files to upload below are all created automatically in the `data/` folder.*

>*Github does not support `.json` and `.csv` upload, but `.txt`. Please rename those files `.txt` before uploading.*

## Abstract

*Briefly describe the experiment (existing implementation, or a research idea). Explain the hypothesis, design, outcome and conclusion as needed.*

## Methods

*Discuss any relevant methods or technique you used to obtain the result.*

### To Reproduce

1. JSON spec: 
[dqn_boltzmann_cartpole_spec.txt](https://github.com/kengz/SLM-Lab/files/2409363/dqn_boltzmann_cartpole_spec.txt)
2. git SHA (contained in the file above): 54429d06849f02d61d60034264492d383d965005

## Results

*All the results contributed will be added to the [benchmark](BENCHMARK.md), and made [publicly available on Dropbox.](https://www.dropbox.com/sh/y738zvzj3nxthn1/AAAg1e6TxXVf3krD81TD5V0Ra?dl=0)*

- [x] 1. full experiment data zip: *(please find our contact in README and request a "Dropbox file request" to upload it to the public benchmark folder.)*
- [x] 2. experiment graph: 
![dqn_boltzmann_cartpole_experiment_graph](https://user-images.githubusercontent.com/8209263/45934676-82f53200-bf56-11e8-8f44-73141e5561fe.png)
- [x] 3. max fitness score and experiment_df: 4.79, 
[dqn_boltzmann_cartpole_experiment_df.txt](https://github.com/kengz/SLM-Lab/files/2409364/dqn_boltzmann_cartpole_experiment_df.txt)
- [x] 4. best trial JSON spec: 
[dqn_boltzmann_cartpole_t30_spec.txt](https://github.com/kengz/SLM-Lab/files/2409365/dqn_boltzmann_cartpole_t30_spec.txt)
[dqn_boltzmann_cartpole_t0_spec.txt](https://github.com/kengz/SLM-Lab/files/2409368/dqn_boltzmann_cartpole_t0_spec.txt)

- [x] 5. best trial graph: 
![dqn_boltzmann_cartpole_t30_trial_graph](https://user-images.githubusercontent.com/8209263/45934709-cc458180-bf56-11e8-8870-375b6bfe1c46.png)
![dqn_boltzmann_cartpole_t0_trial_graph](https://user-images.githubusercontent.com/8209263/45934730-f8610280-bf56-11e8-9084-ae126566d299.png)

- [x] 6. [optional] best session graph: 
![dqn_boltzmann_cartpole_t0_s1_session_graph](https://user-images.githubusercontent.com/8209263/45934749-32ca9f80-bf57-11e8-8588-288e9eec25ea.png)


## Discussion (optional)

The best trial is above is fitter because of high convergence speed, but at the sacrifice of stability. Trial 0 is included too for reference on a stable trial, with slightly lower speed.

This benchmark uses the Boltzmann policy with DQN.

- `explore_anneal_epi`: fast annealing of exploration boosts convergence speed as expected, but at the sacrifice of stability.
- `hid_layers_activation`: tanh as an activation function leads to stabler solution, and we can also see all the strengths are high.
- `lr`: learning rate needs to be low.
- `update_frequency`: of the network is irrelevant, since polyak is used. The search accidentally includes it.