### PR TITLE
DQN lunar benchmark

### DIFF
--- a/BENCHMARK.md
+++ b/BENCHMARK.md
@@ -10,7 +10,7 @@ All the results below link to their respective PRs with the full experiment repo
 |------------|-|-|-|-|-|-|-|-|-|-|-|-|-|-|-|-|-|-|-|
 |[CartPole-v0](https://gym.openai.com/envs/CartPole-v0/)|[4.79](https://github.com/kengz/SLM-Lab/pull/184) | | | | | | | | | | |[44.7](https://github.com/kengz/SLM-Lab/pull/185) | [1.20](https://github.com/kengz/SLM-Lab/pull/180) | | | | | | |
 |[3dball](https://github.com/Unity-Technologies/ml-agents/blob/master/docs/Learning-Environment-Examples.md#3dball-3d-balance-ball)| | | | | | | | | | | | | | | | | | | |
-|[LunarLander-v2](https://gym.openai.com/envs/LunarLander-v2/)| | | | | | | | | | | | | | | | | | | |
+|[LunarLander-v2](https://gym.openai.com/envs/LunarLander-v2/)|111.08| | | | | | | | | | | | | | | | | | |
 |[gridworld](https://github.com/Unity-Technologies/ml-agents/blob/master/docs/Learning-Environment-Examples.md#gridworld)| | | | | | | | | | | | | | | | | | | |
 |[BeamRider-v0](https://gym.openai.com/envs/BeamRider-v0/)| | | | | | | | | | | | | | | | | | | |
 |[Pendulum-v0](https://gym.openai.com/envs/Pendulum-v0/)| n/a | n/a | n/a | n/a| n/a | n/a | n/a | n/a | n/a | n/a | | | | | | | | | |

--- a/BENCHMARK.md
+++ b/BENCHMARK.md
@@ -10,7 +10,7 @@ All the results below link to their respective PRs with the full experiment repo
 |------------|-|-|-|-|-|-|-|-|-|-|-|-|-|-|-|-|-|-|-|
 |[CartPole-v0](https://gym.openai.com/envs/CartPole-v0/)|[4.79](https://github.com/kengz/SLM-Lab/pull/184) | | | | | | | | | | |[44.7](https://github.com/kengz/SLM-Lab/pull/185) | [1.20](https://github.com/kengz/SLM-Lab/pull/180) | | | | | | |
 |[3dball](https://github.com/Unity-Technologies/ml-agents/blob/master/docs/Learning-Environment-Examples.md#3dball-3d-balance-ball)| | | | | | | | | | | | | | | | | | | |
-|[LunarLander-v2](https://gym.openai.com/envs/LunarLander-v2/)|111.08| | | | | | | | | | | | | | | | | | |
+|[LunarLander-v2](https://gym.openai.com/envs/LunarLander-v2/)|[111.08](https://github.com/kengz/SLM-Lab/pull/191)| | | | | | | | | | | | | | | | | | |
 |[gridworld](https://github.com/Unity-Technologies/ml-agents/blob/master/docs/Learning-Environment-Examples.md#gridworld)| | | | | | | | | | | | | | | | | | | |
 |[BeamRider-v0](https://gym.openai.com/envs/BeamRider-v0/)| | | | | | | | | | | | | | | | | | | |
 |[Pendulum-v0](https://gym.openai.com/envs/Pendulum-v0/)| n/a | n/a | n/a | n/a| n/a | n/a | n/a | n/a | n/a | n/a | | | | | | | | | |


### PR DESCRIPTION
# Experiment Result

>*See [PR #180](https://github.com/kengz/SLM-Lab/pull/180) for an example*

>*The data files to upload below are all created automatically in the `data/` folder.*

>*Github does not support `.json` and `.csv` upload, but `.txt`. Please rename those files `.txt` before uploading.*

## Abstract

DQN benchmark for the LunarLander-V2 environment

## Methods

- Standard DQN with target networks
- weighted average between the current and target network (polyak update)

### To Reproduce

1. JSON spec: [dqn_epsilon_greedy_lunar_spec.txt](https://github.com/kengz/SLM-Lab/files/2426952/dqn_epsilon_greedy_lunar_spec.txt)

2. git SHA (contained in the file above): cf8a5f4c4805ebfcb9d98c8999a0f261632bfa0e

## Results

*All the results contributed will be added to the [benchmark](BENCHMARK.md), and made [publicly available on Dropbox.](https://www.dropbox.com/sh/y738zvzj3nxthn1/AAAg1e6TxXVf3krD81TD5V0Ra?dl=0)*

- [x] 1. full experiment data zip: *(please find our contact in README and request a "Dropbox file request" to upload it to the public benchmark folder.)*
- [x] 2. experiment graph: 
![dqn_epsilon_greedy_lunar_experiment_graph](https://user-images.githubusercontent.com/5512945/46190689-6f74fe80-c2a9-11e8-89f6-d6c3a61ff76b.png)

- [x] 3. max fitness score and experiment_df: 111.08, 
[dqn_epsilon_greedy_lunar_experiment_df.txt](https://github.com/kengz/SLM-Lab/files/2426955/dqn_epsilon_greedy_lunar_experiment_df.txt)
- [x] 4. best trial JSON spec: [dqn_epsilon_greedy_lunar_t28_spec.txt](https://github.com/kengz/SLM-Lab/files/2426956/dqn_epsilon_greedy_lunar_t28_spec.txt)
- [x] 5. best trial graph:
![dqn_epsilon_greedy_lunar_t28_trial_graph](https://user-images.githubusercontent.com/5512945/46190754-aba85f00-c2a9-11e8-8a9e-1aed13ed8d62.png)
- [x] 6. [optional] best session graph: This session solved (100 episode average > 200) the environment in 301 episodes. The first episode in which the reward > 200 was episode 86 with a reward of 231.4 (see dqn_epsilon_greedy_lunar_t28_s3_session_df.csv in full experiment results for more details)
![dqn_epsilon_greedy_lunar_t28_s3_session_graph](https://user-images.githubusercontent.com/5512945/46190798-da263a00-c2a9-11e8-9514-1caed9301a6b.png)


## Discussion (optional)

- Some fast and ultimately fairly stable solutions (see trials 28 and 34, 24 comes close)
- The best session solved the environment in 301 episodes (solved = 100 episode average of > 200)
- A number of sessions had a 100 episode average of > 200 after the session completed (800 episodes total) 
- All solutions exhibit a similar pattern of solving the environment then going through a period of performance degradation before recovering 
- This pattern is more pronounced in session 28, which is capable of solving the environment faster than 34, at the expense of a little stability

**Hyper-parameters searched over:**
- `explore_anneal_epi` (how many episodes to anneal epsilon over): didn't affect the results significantly, but the fastest solutions also had the fastest annealing
- `normalize_state`: it is better not to normalize the state in this case
- `memory.name`: this changed the state input to the network. Either the last 4 states were concatenated (ConcatReplay) or just the most recent state was included (Replay). Replay was clearly better in terms of speed and strength in this case
- `hid_layers_activation`: relu yielded slightly better than the others (sigmoid and tanh)
- `lr_decay_frequency`: no clear pattern here
- `optim_spec.lr` (learning rate)`: higher learning rates led to faster solutions, but lower learning rates led to stronger solutions. A learning rate of ~0.002 was best.
- `polyak_coef` (how much to weight the target net vs current net when updating the target): 0.9 yielded the strongest and fastest solutions, 0.99 the most stable. This is consistent with the original motivation for a target net to help stabilize the optimization problem. Higher values correspond to a target that is changing less frequently, so we should expect it to lead to more stable solutions. However, this comes at the expense of speed.
- `training_batch_epoch` (number of batches to sample each training cycle): Unsurprisingly the more batches of data used per update, the faster learning. However, 2 batched yielded the strongest solutions.
- `training_epoch` (number of gradient updates per batch): 1, 2 and 3 updates all had similar results. 2 was marginally better.

