### PR TITLE
DDQN Boltzmann CartPole benchmark

### DIFF
--- a/slm_lab/spec/ddqn.json
+++ b/slm_lab/spec/ddqn.json
@@ -7,14 +7,14 @@
         "action_pdtype": "Argmax",
         "action_policy": "boltzmann",
         "action_policy_update": "linear_decay",
-        "explore_var_start": 1.5,
-        "explore_var_end": 0.3,
-        "explore_anneal_epi": 20,
+        "explore_var_start": 3.0,
+        "explore_var_end": 1.0,
+        "explore_anneal_epi": 50,
         "gamma": 0.99,
-        "training_batch_epoch": 8,
+        "training_batch_epoch": 10,
         "training_epoch": 4,
-        "training_frequency": 32,
-        "training_min_timestep": 10,
+        "training_frequency": 8,
+        "training_min_timestep": 32,
         "normalize_state": true
       },
       "memory": {
@@ -25,8 +25,8 @@
       },
       "net": {
         "type": "MLPNet",
-        "hid_layers": [32],
-        "hid_layers_activation": "relu",
+        "hid_layers": [64],
+        "hid_layers_activation": "selu",
         "clip_grad": false,
         "clip_grad_val": 1.0,
         "loss_spec": {
@@ -34,23 +34,23 @@
         },
         "optim_spec": {
           "name": "Adam",
-          "lr": 0.02
+          "lr": 0.0008
         },
-        "lr_decay": "rate_decay",
-        "lr_decay_frequency": 500,
-        "lr_decay_min_timestep": 1000,
+        "lr_decay": "linear_decay",
+        "lr_decay_frequency": 2000,
+        "lr_decay_min_timestep": 5000,
         "lr_anneal_timestep": 100000,
         "update_type": "polyak",
         "update_frequency": 1,
-        "polyak_coef": 0.9,
+        "polyak_coef": 0,
         "gpu": false
       }
     }],
     "env": [{
       "name": "CartPole-v0",
       "max_timestep": null,
-      "max_episode": 250,
-      "save_epi_frequency": 1000
+      "max_episode": 400,
+      "save_epi_frequency": 300
     }],
     "body": {
       "product": "outer",
@@ -65,18 +65,12 @@
     "search": {
       "agent": [{
         "algorithm": {
-          "explore_anneal_epi__choice": [10, 30, 50, 100]
+          "explore_anneal_epi__choice": [10, 50, 100]
         },
         "net": {
-          "hid_layers__choice": [
-            [32],
-            [64],
-            [32, 16],
-            [64, 32]
-          ],
-          "hid_layers_activation__choice": ["sigmoid", "relu", "tanh"],
+          "hid_layers_activation__choice": ["tanh", "relu", "selu"],
           "optim_spec": {
-            "lr__uniform": [0.0001, 0.2]
+            "lr__uniform": [0.0001, 0.01]
           }
         }
       }]


### PR DESCRIPTION
# Experiment Result

>*See [PR #180](https://github.com/kengz/SLM-Lab/pull/180) for an example*

>*The data files to upload below are all created automatically in the `data/` folder.*

>*Github does not support `.json` and `.csv` upload, but `.txt`. Please rename those files `.txt` before uploading.*

## Abstract

Benchmark run on DDQN Boltzmann policy on Cartpole.

## Methods

*Discuss any relevant methods or technique you used to obtain the result.*

### To Reproduce

1. JSON spec: 
[ddqn_boltzmann_cartpole_spec.txt](https://github.com/kengz/SLM-Lab/files/2431264/ddqn_boltzmann_cartpole_spec.txt)

2. git SHA (contained in the file above): f4651f2d7a727a5efd7ab7463db0367d95387779

## Results

*All the results contributed will be added to the [benchmark](BENCHMARK.md), and made [publicly available on Dropbox.](https://www.dropbox.com/sh/y738zvzj3nxthn1/AAAg1e6TxXVf3krD81TD5V0Ra?dl=0)*

- [x] 1. full experiment data zip: *(please find our contact in README and request a "Dropbox file request" to upload it to the public benchmark folder.)*
- [x] 2. experiment graph: 
![ddqn_boltzmann_cartpole_experiment_graph](https://user-images.githubusercontent.com/8209263/46253578-d9b9aa80-c433-11e8-89aa-be30e8d962f9.png)

- [x] 3. max fitness score and experiment_df: 5.65, 
[ddqn_boltzmann_cartpole_experiment_df.txt](https://github.com/kengz/SLM-Lab/files/2431267/ddqn_boltzmann_cartpole_experiment_df.txt)

- [x] 4. best trial JSON spec: 
[ddqn_boltzmann_cartpole_t23_spec.txt](https://github.com/kengz/SLM-Lab/files/2431268/ddqn_boltzmann_cartpole_t23_spec.txt)
[ddqn_boltzmann_cartpole_t82_spec.txt](https://github.com/kengz/SLM-Lab/files/2431269/ddqn_boltzmann_cartpole_t82_spec.txt)

- [x] 5. best trial graph: 
![ddqn_boltzmann_cartpole_t23_trial_graph](https://user-images.githubusercontent.com/8209263/46253589-0c63a300-c434-11e8-99aa-f21a7a6057da.png)
![ddqn_boltzmann_cartpole_t82_trial_graph](https://user-images.githubusercontent.com/8209263/46253594-269d8100-c434-11e8-8f75-3cfc4f3a0307.png)

- [x] 6. [optional] best session graph: 
![ddqn_boltzmann_cartpole_t82_s3_session_graph](https://user-images.githubusercontent.com/8209263/46253599-4cc32100-c434-11e8-8037-d686a6c4f2ff.png)

## Discussion (optional)

*Describe some useful observations from the experiment.*

- DDQN working. Note that trial 82 is also reported since it has a stabler graph, even though trial 23 has higher overall fitness due to its speed.