### PR TITLE
REINFORCE cartpole benchmark

### DIFF
--- a/slm_lab/spec/reinforce.json
+++ b/slm_lab/spec/reinforce.json
@@ -10,9 +10,9 @@
         "explore_var_start": null,
         "explore_var_end": null,
         "explore_anneal_epi": null,
-        "gamma": 0.99,
+        "gamma": 0.98,
         "add_entropy": true,
-        "entropy_coef": 0.01,
+        "entropy_coef": 0.003,
         "training_frequency": 1,
         "normalize_state": true
       },
@@ -22,7 +22,7 @@
       "net": {
         "type": "MLPNet",
         "hid_layers": [64],
-        "hid_layers_activation": "relu",
+        "hid_layers_activation": "tanh",
         "clip_grad": false,
         "clip_grad_val": 1.0,
         "loss_spec": {
@@ -30,11 +30,11 @@
         },
         "optim_spec": {
           "name": "Adam",
-          "lr": 0.01
+          "lr": 0.004
         },
         "lr_decay": "rate_decay",
-        "lr_decay_frequency": 500,
-        "lr_decay_min_timestep": 1000,
+        "lr_decay_frequency": 2000,
+        "lr_decay_min_timestep": 5000,
         "lr_anneal_timestep": 100000,
         "gpu": false
       }
@@ -42,8 +42,8 @@
     "env": [{
       "name": "CartPole-v0",
       "max_timestep": null,
-      "max_episode": 500,
-      "save_epi_frequency": 1000
+      "max_episode": 400,
+      "save_epi_frequency": 300
     }],
     "body": {
       "product": "outer",


### PR DESCRIPTION
# Experiment Result

>*See [PR #180](https://github.com/kengz/SLM-Lab/pull/180) for an example*

>*The data files to upload below are all created automatically in the `data/` folder.*

>*Github does not support `.json` and `.csv` upload, but `.txt`. Please rename those files `.txt` before uploading.*

## Abstract

REINFORCE cartpole benchmark

## Methods

*Discuss any relevant methods or technique you used to obtain the result.*

### To Reproduce

1. JSON spec:
2. git SHA (contained in the file above):

## Results

*All the results contributed will be added to the [benchmark](BENCHMARK.md), and made [publicly available on Dropbox.](https://www.dropbox.com/sh/y738zvzj3nxthn1/AAAg1e6TxXVf3krD81TD5V0Ra?dl=0)*

- [ ] 1. full experiment data zip: *(please find our contact in README and request a "Dropbox file request" to upload it to the public benchmark folder.)*
- [ ] 2. experiment graph: 
![reinforce_mlp_cartpole_experiment_graph](https://user-images.githubusercontent.com/8209263/46269065-5f505f80-c4f3-11e8-8890-80e4da49cfb6.png)

- [ ] 3. max fitness score and experiment_df: 2.38, 
[reinforce_mlp_cartpole_experiment_df.txt](https://github.com/kengz/SLM-Lab/files/2432516/reinforce_mlp_cartpole_experiment_df.txt)

- [ ] 4. best trial JSON spec: 
[reinforce_mlp_cartpole_t25_spec.txt](https://github.com/kengz/SLM-Lab/files/2432512/reinforce_mlp_cartpole_t25_spec.txt)

- [ ] 5. best trial graph: 
![reinforce_mlp_cartpole_t25_trial_graph](https://user-images.githubusercontent.com/8209263/46269016-02ed4000-c4f3-11e8-97a3-0076351f2441.png)

- [ ] 6. [optional] best session graph: ![reinforce_mlp_cartpole_t25_s1_session_graph](https://user-images.githubusercontent.com/8209263/46269020-0aace480-c4f3-11e8-9783-71f7df2e910f.png)

## Discussion (optional)

*Describe some useful observations from the experiment.*

Trial 70 has higher fitness but is unstable. Choosing trial 25 (stable) as the best solution instead.