### PR TITLE
Double DQN Lunar Lander benchmark

### DIFF
--- a/BENCHMARK.md
+++ b/BENCHMARK.md
@@ -10,7 +10,7 @@ All the results below link to their respective PRs with the full experiment repo
 |------------|-|-|-|-|-|-|-|-|-|-|-|-|-|-|-|-|-|-|-|
 |[CartPole-v0](https://gym.openai.com/envs/CartPole-v0/)|[4.79](https://github.com/kengz/SLM-Lab/pull/184) | | | | | | | | | | |[44.7](https://github.com/kengz/SLM-Lab/pull/185) | [1.20](https://github.com/kengz/SLM-Lab/pull/180) | | | | | | |
 |[3dball](https://github.com/Unity-Technologies/ml-agents/blob/master/docs/Learning-Environment-Examples.md#3dball-3d-balance-ball)| | | | | | | | | | | | | | | | | | | |
-|[LunarLander-v2](https://gym.openai.com/envs/LunarLander-v2/)|[1.14](https://github.com/kengz/SLM-Lab/pull/191)| | | | | | | | | | | | | | | | | | |
+|[LunarLander-v2](https://gym.openai.com/envs/LunarLander-v2/)|[1.14](https://github.com/kengz/SLM-Lab/pull/191)| |1.15| | | | | | | | | | | | | | | | |
 |[gridworld](https://github.com/Unity-Technologies/ml-agents/blob/master/docs/Learning-Environment-Examples.md#gridworld)| | | | | | | | | | | | | | | | | | | |
 |[BeamRider-v0](https://gym.openai.com/envs/BeamRider-v0/)| | | | | | | | | | | | | | | | | | | |
 |[Pendulum-v0](https://gym.openai.com/envs/Pendulum-v0/)| n/a | n/a | n/a | n/a| n/a | n/a | n/a | n/a | n/a | n/a | | | | | | | | | |

--- a/BENCHMARK.md
+++ b/BENCHMARK.md
@@ -10,7 +10,7 @@ All the results below link to their respective PRs with the full experiment repo
 |------------|-|-|-|-|-|-|-|-|-|-|-|-|-|-|-|-|-|-|-|
 |[CartPole-v0](https://gym.openai.com/envs/CartPole-v0/)|[4.79](https://github.com/kengz/SLM-Lab/pull/184) | | | | | | | | | | |[44.7](https://github.com/kengz/SLM-Lab/pull/185) | [1.20](https://github.com/kengz/SLM-Lab/pull/180) | | | | | | |
 |[3dball](https://github.com/Unity-Technologies/ml-agents/blob/master/docs/Learning-Environment-Examples.md#3dball-3d-balance-ball)| | | | | | | | | | | | | | | | | | | |
-|[LunarLander-v2](https://gym.openai.com/envs/LunarLander-v2/)|[1.14](https://github.com/kengz/SLM-Lab/pull/191)| |1.15| | | | | | | | | | | | | | | | |
+|[LunarLander-v2](https://gym.openai.com/envs/LunarLander-v2/)|[1.14](https://github.com/kengz/SLM-Lab/pull/191)| |[1.15](https://github.com/kengz/SLM-Lab/pull/203)| | | | | | | | | | | | | | | | |
 |[gridworld](https://github.com/Unity-Technologies/ml-agents/blob/master/docs/Learning-Environment-Examples.md#gridworld)| | | | | | | | | | | | | | | | | | | |
 |[BeamRider-v0](https://gym.openai.com/envs/BeamRider-v0/)| | | | | | | | | | | | | | | | | | | |
 |[Pendulum-v0](https://gym.openai.com/envs/Pendulum-v0/)| n/a | n/a | n/a | n/a| n/a | n/a | n/a | n/a | n/a | n/a | | | | | | | | | |


### PR DESCRIPTION
# Experiment Result

>*See [PR #180](https://github.com/kengz/SLM-Lab/pull/180) for an example*

>*The data files to upload below are all created automatically in the `data/` folder.*

>*Github does not support `.json` and `.csv` upload, but `.txt`. Please rename those files `.txt` before uploading.*

## Abstract

Benchmark for Lunar Lander environment with the [Double DQN](https://arxiv.org/abs/1509.06461) algorithm

## Methods

- Polyak updates for the target net
- Epsilon greedy exploration strategy

### To Reproduce

1. JSON spec: [double_dqn_epsilon_greedy_lunar_spec.txt](https://github.com/kengz/SLM-Lab/files/2432738/double_dqn_epsilon_greedy_lunar_spec.txt)

2. git SHA (contained in the file above): 96894d1cd9edf5e45c98eaa019c5935e0f2c3819

## Results

*All the results contributed will be added to the [benchmark](BENCHMARK.md), and made [publicly available on Dropbox.](https://www.dropbox.com/sh/y738zvzj3nxthn1/AAAg1e6TxXVf3krD81TD5V0Ra?dl=0)*

- [x] 1. full experiment data zip: *(please find our contact in README and request a "Dropbox file request" to upload it to the public benchmark folder.)*
- [x] 2. experiment graph: 
![double_dqn_epsilon_greedy_lunar_experiment_graph](https://user-images.githubusercontent.com/5512945/46271964-db52a380-c503-11e8-974e-b7538805d046.png)
- [x] 3. max fitness score and experiment_df: 1.15,  [double_dqn_epsilon_greedy_lunar_experiment_df.txt](https://github.com/kengz/SLM-Lab/files/2432740/double_dqn_epsilon_greedy_lunar_experiment_df.txt)
- [x] 4. best trial JSON spec: [double_dqn_epsilon_greedy_lunar_t28_spec.txt](https://github.com/kengz/SLM-Lab/files/2432743/double_dqn_epsilon_greedy_lunar_t28_spec.txt)
- [x] 5. best trial graph: ![double_dqn_epsilon_greedy_lunar_t28_trial_graph](https://user-images.githubusercontent.com/5512945/46272008-0210da00-c504-11e8-9fb2-0f8692dae0e0.png)
- [x] 6. [optional] best session graph: 
![double_dqn_epsilon_greedy_lunar_t49_s1_session_graph](https://user-images.githubusercontent.com/5512945/46272171-b874bf00-c504-11e8-977c-915f61829437.png)

## Discussion (optional)

- This search was identical to PR #191 with the exception of the search range for the polyak coefficient. It is necessary for the polyak coefficient to be reasonable high (set to between 0.9 and 0.999 in this case) so that Double part of the algorithm is meaningful. Otherwise it effectively reduces to DQN.
- The best fitness score in both cases was similar (1.15 for Double DQN compared with 1.14 for DQN).
- However, Double DQN produced many more fit results. For example 6 results that solved the environment (strength > 1) and another 7 that came close (strength > 0.9).  In contrast DQN only produced 2 results that solved the environment and 4 that came close. This is consistent with the claim that Double DQN is a stronger algorithm.

**Hyper-parameters searched over:**
- `explore_anneal_epi` (how many episodes to anneal epsilon over): 200 episodes was marginally better in terms of speed
- `normalize_state`: slightly better to normalize the state
- `memory.name`: this changed the state input to the network. Either the last 4 states were concatenated (ConcatReplay) or just the most recent state was included (Replay). Replay was clearly better in terms of speed and strength in this case (same as PR #191)
- `hid_layers_activation`: relu yielded slightly better than the others (sigmoid and tanh)  (same as PR #191)
- `lr_decay_frequency`: 60k was the best, mostly driven by speed and stability
- `optim_spec.lr` (learning rate)`: no clear pattern
- `polyak_coef` (how much to weight the target net vs current net when updating the target): 0.95 was clearly the best value, likely striking a good balance between not slowing down learning too much (large values) and generating a target network that was sufficiently different from the current network (the larger the `polyak_coef` the more different the target network is likely to be)
- `training_batch_epoch` (number of batches to sample each training cycle): no clear patten
- `training_epoch` (number of gradient updates per batch): No clear pattern. 3 slightly better in terms of speed, 2 in terms of stability
