### PR TITLE
Fix Xvfb zombie processes

### DIFF
--- a/run_lab.py
+++ b/run_lab.py
@@ -12,6 +12,7 @@ from slm_lab.experiment.control import Session, Trial, Experiment
 from slm_lab.experiment.monitor import InfoSpace
 from slm_lab.lib import logger, util
 from slm_lab.spec import spec_util
+from xvfbwrapper import Xvfb
 import sys
 import torch.multiprocessing as mp
 
@@ -89,4 +90,5 @@ def main():
 
 if __name__ == '__main__':
     mp.set_start_method('spawn')  # for distributed pytorch to work
-    main()
+    with Xvfb() as xvfb:  # safety context for headless machines
+        main()

--- a/slm_lab/env/openai.py
+++ b/slm_lab/env/openai.py
@@ -1,7 +1,7 @@
 from slm_lab.env.base import BaseEnv, ENV_DATA_NAMES
+from slm_lab.env.registration import register_env
 from slm_lab.lib import logger, util
 from slm_lab.lib.decorator import lab_api
-from slm_lab.env.registration import register_env
 import gym
 import numpy as np
 

--- a/slm_lab/env/registration.py
+++ b/slm_lab/env/registration.py
@@ -1,12 +1,20 @@
-import gym
+# module to register and mange multiple environment offerings
 from gym.envs.registration import register
+from slm_lab.lib import util
+import gym
+import os
 
-'''
-Register additional environments for OpenAI gym.
-'''
+
+def get_env_path(env_name):
+    '''Get the path to Unity env binaries distributed via npm'''
+    env_path = util.smart_path(f'node_modules/slm-env-{env_name}/build/{env_name}')
+    env_dir = os.path.dirname(env_path)
+    assert os.path.exists(env_dir), f'Missing {env_path}. See README to install from yarn.'
+    return env_path
 
 
 def register_env(spec):
+    '''Register additional environments for OpenAI gym.'''
     env_name = spec['env'][0]['name']
 
     if env_name.lower() == 'vizdoom-v0':

--- a/slm_lab/env/unity.py
+++ b/slm_lab/env/unity.py
@@ -1,5 +1,6 @@
 from gym import spaces
 from slm_lab.env.base import BaseEnv, ENV_DATA_NAMES, set_gym_space_attr
+from slm_lab.env.registration import get_env_path
 from slm_lab.lib import logger, util
 from slm_lab.lib.decorator import lab_api
 from unityagents import brain, UnityEnvironment
@@ -47,7 +48,7 @@ class UnityEnv(BaseEnv):
         super(UnityEnv, self).__init__(spec, e, env_space)
         util.set_attr(self, self.env_spec, ['unity'])
         worker_id = int(f'{os.getpid()}{self.e+int(ps.unique_id())}'[-4:])
-        self.u_env = UnityEnvironment(file_name=util.get_env_path(self.name), worker_id=worker_id)
+        self.u_env = UnityEnvironment(file_name=get_env_path(self.name), worker_id=worker_id)
         self.patch_gym_spaces(self.u_env)
         self._set_attr_from_u_env(self.u_env)
         if env_space is None:  # singleton mode

--- a/slm_lab/experiment/monitor.py
+++ b/slm_lab/experiment/monitor.py
@@ -400,25 +400,3 @@ class InfoSpace:
     def get_random_seed(self):
         '''Standard method to get random seed for a session'''
         return int(1e5 * (self.get('trial') or 0) + 1e3 * (self.get('session') or 0))
-
-
-class Monitor:
-    '''
-    Monitors agents, environments, sessions, trials, experiments, evolutions.
-    Has standardized input/output data structure, methods.
-    Persists data to DB, and to viz module for plots or Tensorboard.
-    Pipes data to Controller for evolution.
-    TODO Possibly unify this with logger module.
-    TODO shove monitor reporting into control loop
-    '''
-
-    def __init__(self):
-        logger.debug('Monitor initialized.')
-
-    def update_stage(self, axis):
-        pass
-
-    def update(self):
-        # TODO hook monitor to agent, env, then per update, auto fetches all that is in background
-        # TODO call update in session, trial, experiment loops to collect data visible there too, for unit_data
-        return

--- a/slm_lab/lib/logger.py
+++ b/slm_lab/lib/logger.py
@@ -45,14 +45,6 @@ else:
     lab_logger.setLevel('INFO')
 
 
-class DedentFormatter(logging.Formatter):
-    '''The formatter to dedent broken python multiline string'''
-
-    def format(self, record):
-        record.msg = util.dedent(record.msg)
-        return super(DedentFormatter, self).format(record)
-
-
 def to_init(spec, info_space):
     '''
     Whether the lab's logger had been initialized:

--- a/slm_lab/lib/util.py
+++ b/slm_lab/lib/util.py
@@ -20,7 +20,6 @@ NUM_CPUS = mp.cpu_count()
 DF_FILE_EXT = ['.csv', '.xlsx', '.xls']
 FILE_TS_FORMAT = '%Y_%m_%d_%H%M%S'
 RE_FILE_TS = re.compile(r'(\d{4}_\d{2}_\d{2}_\d{6})')
-RE_INDENT = re.compile('(^\n)|(?!\n)\s{2,}|(\n\s+)$')
 SPACE_PATH = ['agent', 'agent_space', 'aeb_space', 'env_space', 'env']
 
 
@@ -98,11 +97,6 @@ def count_nonan(arr):
         return np.count_nonzero(~np.isnan(arr))
     except Exception:
         return len(filter_nonan(arr))
-
-
-def dedent(string):
-    '''Method to dedent the broken python multiline string'''
-    return RE_INDENT.sub('', string)
 
 
 def downcast_float32(df):

--- a/slm_lab/lib/util.py
+++ b/slm_lab/lib/util.py
@@ -203,14 +203,6 @@ def get_class_attr(obj):
     return attr_dict
 
 
-def get_env_path(env_name):
-    '''Get the path to Unity env binaries distributed via npm'''
-    env_path = smart_path(f'node_modules/slm-env-{env_name}/build/{env_name}')
-    env_dir = os.path.dirname(env_path)
-    assert os.path.exists(env_dir), f'Missing {env_path}. See README to install from yarn.'
-    return env_path
-
-
 def get_file_ext(data_path):
     return os.path.splitext(data_path)[-1]
 

--- a/slm_lab/lib/util.py
+++ b/slm_lab/lib/util.py
@@ -67,11 +67,6 @@ def cast_list(val):
         return [val]
 
 
-def compact_dict(d):
-    '''Return dict without None or np.nan values'''
-    return {k: v for k, v in d.items() if not gen_isnan(v)}
-
-
 def concat_batches(batches):
     '''
     Concat batch objects from body.memory.sample() into one batch, when all bodies experience similar envs
@@ -158,11 +153,6 @@ def nanflatten(arr):
     '''Flatten np array while ignoring nan, like np.nansum etc.'''
     flat_arr = arr.reshape(-1)
     return filter_nonan(flat_arr)
-
-
-def flatten_once(arr):
-    '''Flatten np array only once instead if all the way by flatten()'''
-    return arr.reshape(-1, *arr.shape[2:])
 
 
 def gen_isnan(v):
@@ -656,11 +646,6 @@ def to_torch_batch(batch, device, is_episodic):
             batch[k] = np.array(batch[k])
         batch[k] = torch.from_numpy(batch[k].astype('float32')).to(device)
     return batch
-
-
-def to_tuple_list(l):
-    '''Returns a copy of the list with its elements as tuples'''
-    return [tuple(row) for row in l]
 
 
 def try_set_cuda_id(spec, info_space):

--- a/slm_lab/lib/viz.py
+++ b/slm_lab/lib/viz.py
@@ -8,7 +8,6 @@ from plotly import (
     tools,
 )
 from slm_lab.lib import logger, util
-from xvfbwrapper import Xvfb
 import colorlover as cl
 import math
 import os
@@ -22,11 +21,6 @@ os.makedirs(PLOT_FILEDIR, exist_ok=True)
 if util.is_jupyter():
     py.init_notebook_mode(connected=True)
 logger = logger.get_logger(__name__)
-
-# launch xvfb for Plotly if not on MacOSX
-if sys.platform != 'darwin':
-    vdisplay = Xvfb()
-    vdisplay.start()
 
 
 def create_label(

--- a/slm_lab/lib/viz.py
+++ b/slm_lab/lib/viz.py
@@ -16,6 +16,7 @@ import plotly.io as pio
 import pydash as ps
 import sys
 
+
 PLOT_FILEDIR = util.smart_path('data')
 os.makedirs(PLOT_FILEDIR, exist_ok=True)
 if util.is_jupyter():

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -96,18 +96,6 @@ def test_str():
     return data
 
 
-@pytest.fixture
-def test_multiline_str():
-    data = '''
-        lorem ipsum dolor
-        sit amet
-
-        consectetur adipiscing elit
-        '''
-    assert isinstance(data, str)
-    return data
-
-
 @pytest.fixture(scope="class", params=[
     (
         MLPNet,

--- a/test/env/test_registration.py
+++ b/test/env/test_registration.py
@@ -1,0 +1,6 @@
+from slm_lab.env.registration import get_env_path
+
+
+def test_get_env_path():
+    assert 'node_modules/slm-env-3dball/build/3dball' in get_env_path(
+        '3dball')

--- a/test/lib/test_logger.py
+++ b/test/lib/test_logger.py
@@ -1,10 +1,10 @@
 from slm_lab.lib import logger
 
 
-def test_logger(test_multiline_str):
-    logger.critical(test_multiline_str)
-    logger.debug(test_multiline_str)
-    logger.error(test_multiline_str)
-    logger.exception(test_multiline_str)
-    logger.info(test_multiline_str)
-    logger.warn(test_multiline_str)
+def test_logger(test_str):
+    logger.critical(test_str)
+    logger.debug(test_str)
+    logger.error(test_str)
+    logger.exception(test_str)
+    logger.info(test_str)
+    logger.warn(test_str)

--- a/test/lib/test_util.py
+++ b/test/lib/test_util.py
@@ -52,11 +52,6 @@ def test_count_nonan(arr, arr_len):
     assert util.count_nonan(np.array(arr)) == arr_len
 
 
-def test_dedent(test_multiline_str):
-    dedented_string = util.dedent(test_multiline_str)
-    assert dedented_string == 'lorem ipsum dolor\nsit amet\n\nconsectetur adipiscing elit'
-
-
 @pytest.mark.parametrize('d,flat_d', [
     ({'a': 1}, {'a': 1}),
     ({'a': {'b': 1}}, {'a.b': 1}),

--- a/test/lib/test_util.py
+++ b/test/lib/test_util.py
@@ -121,11 +121,6 @@ def test_gen_isnan(v, isnan):
     assert util.gen_isnan(v) == isnan
 
 
-def test_get_env_path():
-    assert 'node_modules/slm-env-3dball/build/3dball' in util.get_env_path(
-        '3dball')
-
-
 def test_get_fn_list():
     fn_list = util.get_fn_list(Agent)
     assert 'reset' in fn_list

--- a/test/lib/test_util.py
+++ b/test/lib/test_util.py
@@ -31,15 +31,6 @@ def test_cast_list(test_list, test_str):
     assert ps.is_list(util.cast_list(test_str))
 
 
-@pytest.mark.parametrize('d,res_d', [
-    ({'a': 0, 'b': 1}, {'a': 0, 'b': 1}),
-    ({'a': None, 'b': 1}, {'b': 1}),
-    ({'a': np.nan, 'b': 1}, {'b': 1}),
-])
-def test_compact_dict(d, res_d):
-    assert util.compact_dict(d) == res_d
-
-
 @pytest.mark.parametrize('arr,arr_len', [
     ([0, 1, 2], 3),
     ([0, 1, 2, None], 3),


### PR DESCRIPTION
## Fix Xvfb zombie processes
- Xvfb was used as virtual display to save plotly graphs on headless server. It gets started, but doesn't die when the process quits. When running many trials this creates many zombie processes.
- Fix it by wrapping it cleanly on top level main process context (also means other functions can use it), which automatically shuts down when process ends.

## Cleanups
- move `get_env_path` to env `registration.py`
- cleanup unused methods
