### PR TITLE
REINFORCE LunarLander benchmark

### DIFF
--- a/slm_lab/spec/lunar.json
+++ b/slm_lab/spec/lunar.json
@@ -22,7 +22,7 @@
       "net": {
         "type": "MLPNet",
         "hid_layers": [400, 200],
-        "hid_layers_activation": "relu",
+        "hid_layers_activation": "selu",
         "clip_grad": false,
         "clip_grad_val": 1.0,
         "loss_spec": {
@@ -30,7 +30,7 @@
         },
         "optim_spec": {
           "name": "Adam",
-          "lr": 0.01
+          "lr": 0.0005
         },
         "lr_decay": "linear_decay",
         "lr_decay_frequency": 80000,


### PR DESCRIPTION
# Experiment Result

>*See [PR #180](https://github.com/kengz/SLM-Lab/pull/180) for an example*

>*The data files to upload below are all created automatically in the `data/` folder.*

>*Github does not support `.json` and `.csv` upload, but `.txt`. Please rename those files `.txt` before uploading.*

## Abstract

REINFORCE Lunar Lander benchmark.

## Methods

simple tuning, run more trials.

### To Reproduce

1. JSON spec: 
[reinforce_mlp_lunar_spec.txt](https://github.com/kengz/SLM-Lab/files/2569087/reinforce_mlp_lunar_spec.txt)

2. git SHA (contained in the file above): 573720890b3a7488205261f25eac48c2fec92d56

## Results

*All the results contributed will be added to the [benchmark](BENCHMARK.md), and made [publicly available on Dropbox.](https://www.dropbox.com/sh/y738zvzj3nxthn1/AAAg1e6TxXVf3krD81TD5V0Ra?dl=0)*

- [x] 1. full experiment data zip: *(please find our contact in README and request a "Dropbox file request" to upload it to the public benchmark folder.)*
- [x] 2. experiment graph: 
![reinforce_mlp_lunar_experiment_graph](https://user-images.githubusercontent.com/8209263/48309472-bf451780-e52f-11e8-878b-e6bc50adfec1.png)

- [x] 3. max fitness score and experiment_df: 0.77, 
[reinforce_mlp_lunar_experiment_df.txt](https://github.com/kengz/SLM-Lab/files/2569088/reinforce_mlp_lunar_experiment_df.txt)

- [x] 4. best trial JSON spec: [reinforce_mlp_lunar_t3_spec.txt](https://github.com/kengz/SLM-Lab/files/2569085/reinforce_mlp_lunar_t3_spec.txt)
- [x] 5. best trial graph: 
![reinforce_mlp_lunar_t3_trial_graph](https://user-images.githubusercontent.com/8209263/48309473-c5d38f00-e52f-11e8-85b5-488f5f7e0377.png)

- [x] 6. [optional] best session graph: 
![reinforce_mlp_lunar_t3_s0_session_graph](https://user-images.githubusercontent.com/8209263/48309477-d7b53200-e52f-11e8-957b-d0de7bb4c3bb.png)


## Discussion (optional)

As expected, REINFORCE is less stable as seen in the session graph. But it can solve the problem. With some tuning, stability may be improved.
