### PR TITLE
Pytorch 1.0 for parallel CUDA; switch variable control to timestep

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -37,7 +37,6 @@ dependencies:
   - scipy=1.0.0=py36_blas_openblas_201
   - setuptools=38.4.0=py36_0
   - six=1.11.0=py36_1
-  - torchvision=0.2.1
   - ujson=1.35=py36_0
   - urllib3=1.22=py36_0
   - wheel=0.30.0=py36_2

--- a/environment.yml
+++ b/environment.yml
@@ -30,7 +30,7 @@ dependencies:
   - pytest-timeout=1.2.1=py_0
   - pytest=3.6.0=py36_0
   - python=3.6.4=0
-  - pytorch=0.4.1
+  - pytorch-nightly=1.0.0.dev20181112
   - pyyaml=3.12=py36_1
   - regex=2017.12.12=py36_0
   - requests=2.18.4=py36_1

--- a/slm_lab/agent/algorithm/policy_util.py
+++ b/slm_lab/agent/algorithm/policy_util.py
@@ -343,7 +343,7 @@ def no_update(algorithm, body):
 
 def fn_decay_explore_var(algorithm, body, fn):
     '''Apply a function to decay explore_var'''
-    epi = body.env.clock.get('epi')
+    epi = body.env.clock.get('total_t')
     body.explore_var = fn(algorithm.explore_var_start, algorithm.explore_var_end, algorithm.explore_anneal_epi, epi)
     return body.explore_var
 

--- a/slm_lab/agent/net/convnet.py
+++ b/slm_lab/agent/net/convnet.py
@@ -233,6 +233,7 @@ class ConvNet(Net, nn.Module):
         return self(x)
 
     def update_lr(self, clock):
+        return
         assert 'lr' in self.optim_spec
         old_lr = self.optim_spec['lr']
         new_lr = self.lr_decay(self, clock)

--- a/slm_lab/spec/pong.json
+++ b/slm_lab/spec/pong.json
@@ -1,0 +1,73 @@
+{
+  "dqn_pong": {
+    "agent": [{
+      "name": "DQN",
+      "algorithm": {
+        "name": "DQN",
+        "action_pdtype": "Argmax",
+        "action_policy": "epsilon_greedy",
+        "action_policy_update": "linear_decay",
+        "explore_var_start": 1.0,
+        "explore_var_end": 0.02,
+        "explore_anneal_epi": 100000,
+        "gamma": 0.99,
+        "training_batch_epoch": 1,
+        "training_epoch": 4,
+        "training_frequency": 4,
+        "training_min_timestep": 10000,
+        "normalize_state": true
+      },
+      "memory": {
+        "name": "AtariReplay",
+        "batch_size": 32,
+        "max_size": 100000,
+        "stack_len": 4,
+        "use_cer": false
+      },
+      "net": {
+        "type": "ConvNet",
+        "hid_layers": [
+          [
+            [4, 32, [8, 8], 4, 0, [1, 1]],
+            [32, 64, [4, 4], 2, 0, [1, 1]],
+            [64, 64, [3, 3], 1, 0, [1, 1]]
+          ],
+          [512]
+        ],
+        "hid_layers_activation": "relu",
+        "init_fn": "orthogonal_",
+        "batch_norm": false,
+        "clip_grad": true,
+        "clip_grad_val": 1.0,
+        "loss_spec": {
+          "name": "SmoothL1Loss"
+        },
+        "optim_spec": {
+          "name": "Adam",
+          "lr": 1e-4,
+        },
+        "lr_decay": "no_decay",
+        "update_type": "replace",
+        "update_frequency": 1000,
+        "gpu": true
+      }
+    }],
+    "env": [{
+      "name": "PongNoFrameskip-v4",
+      "max_timestep": null,
+      "max_episode": 5000,
+      "save_epi_frequency": 100
+    }],
+    "body": {
+      "product": "outer",
+      "num": 1
+    },
+    "meta": {
+      "distributed": false,
+      "graph_x": "total_t",
+      "max_session": 1,
+      "max_trial": 1,
+      "search": "RandomSearch"
+    }
+  },
+}


### PR DESCRIPTION
## Pytorch 1.0
- Update to Pytorch 1.0 (dev) to fix 0.4.1 parallel CUDA issue
- [ ] add build instruction for older GPU

## Variable control to use timestep
- variables such as epsilon, entropy coef, to use timestep decay for better control
- note potential backward incompatibility

WIP
