### PR TITLE
Optimize best-checkpointing; update enjoy mode

### DIFF
--- a/run_lab.py
+++ b/run_lab.py
@@ -60,10 +60,6 @@ def run_by_mode(spec_file, spec_name, lab_mode):
         prepath = lab_mode.split('@')[1]
         spec, info_space = util.prepath_to_spec_info_space(prepath)
         Session(spec, info_space).run()
-    elif lab_mode.startswith('enjoy'):
-        prepath = lab_mode.split('@')[1]
-        spec, info_space = util.prepath_to_spec_info_space(prepath)
-        Session(spec, info_space).run()
     elif lab_mode == 'dev':
         spec = util.override_dev_spec(spec)
         info_space.tick('trial')

--- a/slm_lab/agent/algorithm/base.py
+++ b/slm_lab/agent/algorithm/base.py
@@ -113,6 +113,11 @@ class Algorithm(ABC):
             logger.info('No net declared in self.net_names in init_nets(); no models to load.')
         else:
             net_util.load_algorithm(self)
+        # set decayable variables to final values
+        for k, v in vars(self).items():
+            if k.endswith('_scheduler'):
+                var_name = k.replace('_scheduler', '')
+                setattr(self.body, var_name, v.end_val)
 
     # NOTE optional extension for multi-agent-env
 

--- a/slm_lab/agent/algorithm/policy_util.py
+++ b/slm_lab/agent/algorithm/policy_util.py
@@ -320,7 +320,7 @@ class VarScheduler:
             'start_step',
             'end_step',
         ])
-        if not 'end_val':
+        if not getattr(self, 'end_val', None):
             self.end_val = self.start_val
 
     def update(self, algorithm, clock):

--- a/slm_lab/agent/algorithm/policy_util.py
+++ b/slm_lab/agent/algorithm/policy_util.py
@@ -320,7 +320,7 @@ class VarScheduler:
             'start_step',
             'end_step',
         ])
-        if 'end_val' not in var_decay_spec:
+        if not 'end_val':
             self.end_val = self.start_val
 
     def update(self, algorithm, clock):

--- a/slm_lab/agent/algorithm/policy_util.py
+++ b/slm_lab/agent/algorithm/policy_util.py
@@ -199,8 +199,6 @@ def random(state, algorithm, body):
 
 def epsilon_greedy(state, algorithm, body):
     '''Epsilon-greedy policy: with probability epsilon, do random action, otherwise do default sampling.'''
-    if util.get_lab_mode() == 'enjoy':
-        return default(state, algorithm, body)
     epsilon = body.explore_var
     if epsilon > np.random.rand():
         return random(state, algorithm, body)
@@ -212,8 +210,6 @@ def boltzmann(state, algorithm, body):
     '''
     Boltzmann policy: adjust pdparam with temperature tau; the higher the more randomness/noise in action.
     '''
-    if util.get_lab_mode() == 'enjoy':
-        return default(state, algorithm, body)
     tau = body.explore_var
     ActionPD, pdparam, body = init_action_pd(state, algorithm, body)
     pdparam /= tau
@@ -262,8 +258,6 @@ def multi_random(states, algorithm, body_list, pdparam):
 def multi_epsilon_greedy(states, algorithm, body_list, pdparam):
     '''Apply epsilon-greedy policy body-wise'''
     assert len(pdparam) > 1 and len(pdparam) == len(body_list), f'pdparam shape: {pdparam.shape}, bodies: {len(body_list)}'
-    if util.get_lab_mode() == 'enjoy':
-        return multi_default(states, algorithm, body_list, pdparam)
     action_list, action_pd_a = [], []
     for idx, sub_pdparam in enumerate(pdparam):
         body = body_list[idx]
@@ -284,8 +278,6 @@ def multi_boltzmann(states, algorithm, body_list, pdparam):
     '''Apply Boltzmann policy body-wise'''
     # pdparam.squeeze_(dim=0)
     assert len(pdparam) > 1 and len(pdparam) == len(body_list), f'pdparam shape: {pdparam.shape}, bodies: {len(body_list)}'
-    if util.get_lab_mode() == 'enjoy':
-        return multi_default(states, algorithm, body_list, pdparam)
     action_list, action_pd_a = [], []
     for idx, sub_pdparam in enumerate(pdparam):
         body = body_list[idx]
@@ -328,11 +320,13 @@ class VarScheduler:
             'start_step',
             'end_step',
         ])
+        if 'end_val' not in var_decay_spec:
+            self.end_val = self.start_val
 
     def update(self, algorithm, clock):
         '''Get an updated value for var'''
-        if self._updater_name == 'no_decay':
-            return self.start_val
+        if util.get_lab_mode() == 'enjoy' or self._updater_name == 'no_decay':
+            return self.end_val
         step = clock.get(clock.max_tick_unit)
         val = self._updater(self.start_val, self.end_val, self.start_step, self.end_step, step)
         return val

--- a/slm_lab/agent/net/net_util.py
+++ b/slm_lab/agent/net/net_util.py
@@ -164,7 +164,7 @@ def save_algorithm(algorithm, ckpt=None):
         optim_path = f'{prepath}_{net_name}_optim.pth'
         save(net.optim, optim_path)
 
-    if ckpt != 'last':  # remove checkpoint files at the end
+    if ckpt is None:  # remove checkpoint files at the end
         ckpt_path = f'{prepath}_ckptlast*.pth'
         subprocess.run(f'rm {ckpt_path}', cwd=ROOT_DIR, shell=True, stderr=DEVNULL, stdout=DEVNULL, close_fds=True)
         logger.info(f'Removed all checkpoint model files {ckpt_path}')
@@ -172,7 +172,8 @@ def save_algorithm(algorithm, ckpt=None):
 
 def load(net, model_path):
     '''Save model weights from a path into a net module'''
-    net.load_state_dict(torch.load(util.smart_path(model_path)))
+    device = None if torch.cuda.is_available() else 'cpu'
+    net.load_state_dict(torch.load(util.smart_path(model_path), map_location=device))
     logger.info(f'Loaded model from {model_path}')
 
 

--- a/slm_lab/agent/net/net_util.py
+++ b/slm_lab/agent/net/net_util.py
@@ -151,27 +151,18 @@ def save(net, model_path):
 
 def save_algorithm(algorithm, ckpt=None):
     '''Save all the nets for an algorithm'''
-    from slm_lab.experiment import analysis
     agent = algorithm.agent
     net_names = algorithm.net_names
     prepath = util.get_prepath(agent.spec, agent.info_space, unit='session')
-    new_best = analysis.current_epi_is_new_best(algorithm, update_saved_best=True)[0]
     if ckpt is not None:
         prepath = f'{prepath}_ckpt{ckpt}'
     logger.info(f'Saving algorithm {util.get_class_name(algorithm)} nets {net_names}')
-    if new_best:
-        logger.info(f'New best reward_ma. Saving algorithm {util.get_class_name(algorithm)} nets {net_names} to *_best.pth')
     for net_name in net_names:
         net = getattr(algorithm, net_name)
         model_path = f'{prepath}_{net_name}_model.pth'
         save(net, model_path)
         optim_path = f'{prepath}_{net_name}_optim.pth'
         save(net.optim, optim_path)
-        if new_best:
-            model_path = f'{prepath}_{net_name}_model_best.pth'
-            save(net, model_path)
-            optim_path = f'{prepath}_{net_name}_optim_best.pth'
-            save(net.optim, optim_path)
 
     if ckpt != 'last':  # remove checkpoint files at the end
         ckpt_path = f'{prepath}_ckptlast*.pth'

--- a/slm_lab/experiment/analysis.py
+++ b/slm_lab/experiment/analysis.py
@@ -393,7 +393,7 @@ def build_aeb_reward_fig(aeb_rewards_df, aeb_str, color):
 def plot_trial(trial_spec, info_space):
     '''Plot the trial graph, 1 pane: mean and error envelope of reward graphs from all sessions. Each aeb_df gets its own color'''
     prepath = util.get_prepath(trial_spec, info_space)
-    predir = util.prepath_to_predir(prepath)
+    predir, _, _, _, _ = util.prepath_split(prepath)
     session_datas = session_datas_from_file(predir, trial_spec, info_space.get('trial'))
 
     aeb_count = len(session_datas[0])
@@ -473,7 +473,7 @@ def save_trial_data(spec, info_space, trial_fitness_df, trial_fig):
     util.write(trial_fitness_df, f'{prepath}_trial_fitness_df.csv')
     viz.save_image(trial_fig, f'{prepath}_trial_graph.png')
     if util.get_lab_mode() == 'train':
-        predir = util.prepath_to_predir(prepath)
+        predir, _, _, _, _ = util.prepath_split(prepath)
         shutil.make_archive(predir, 'zip', predir)
         logger.info(f'All trial data zipped to {predir}.zip')
 
@@ -485,7 +485,7 @@ def save_experiment_data(spec, info_space, experiment_df, experiment_fig):
     util.write(experiment_df, f'{prepath}_experiment_df.csv')
     viz.save_image(experiment_fig, f'{prepath}_experiment_graph.png')
     # zip for ease of upload
-    predir = util.prepath_to_predir(prepath)
+    predir, _, _, _, _ = util.prepath_split(prepath)
     shutil.make_archive(predir, 'zip', predir)
     logger.info(f'All experiment data zipped to {predir}.zip')
 
@@ -578,7 +578,7 @@ def session_data_dict_from_file(predir, trial_index):
 def session_data_dict_for_dist(spec, info_space):
     '''Method to retrieve session_datas (fitness df, so the same as session_data_dict above) when a trial with distributed sessions is done, to avoid messy multiprocessing data communication'''
     prepath = util.get_prepath(spec, info_space)
-    predir = util.prepath_to_predir(prepath)
+    predir, _, _, _, _ = util.prepath_split(prepath)
     session_datas = session_data_dict_from_file(predir, info_space.get('trial'))
     session_datas = [session_datas[k] for k in sorted(session_datas.keys())]
     return session_datas
@@ -599,8 +599,7 @@ def trial_data_dict_from_file(predir):
 def mock_spec_info_space(predir, trial_index=None, session_index=None):
     '''Helper for retro analysis to build mock info_space and spec'''
     from slm_lab.experiment.monitor import InfoSpace
-    spec_name = util.prepath_to_spec_name(predir)
-    experiment_ts = util.prepath_to_experiment_ts(predir)
+    _, _, _, spec_name, experiment_ts = util.prepath_split(predir)
     info_space = InfoSpace()
     info_space.experiment_ts = experiment_ts
     info_space.set('experiment', 0)
@@ -694,7 +693,7 @@ def plot_session_from_file(session_df_filepath):
     analysis.plot_session_from_file(filepath)
     '''
     from slm_lab.experiment.monitor import InfoSpace
-    spec_name = util.prepath_to_spec_name(session_df_filepath)
+    _, _, _, spec_name, _ = util.prepath_split(session_df_filepath)
     session_spec = {'name': spec_name}
     session_df = util.read(session_df_filepath, header=[0, 1, 2, 3], index_col=0, dtype=np.float32)
     session_data = util.session_df_to_data(session_df)

--- a/slm_lab/experiment/analysis.py
+++ b/slm_lab/experiment/analysis.py
@@ -393,7 +393,7 @@ def build_aeb_reward_fig(aeb_rewards_df, aeb_str, color):
 def plot_trial(trial_spec, info_space):
     '''Plot the trial graph, 1 pane: mean and error envelope of reward graphs from all sessions. Each aeb_df gets its own color'''
     prepath = util.get_prepath(trial_spec, info_space)
-    predir, _, _, _, _ = util.prepath_split(prepath)
+    predir, _, _, _, _, _ = util.prepath_split(prepath)
     session_datas = session_datas_from_file(predir, trial_spec, info_space.get('trial'))
 
     aeb_count = len(session_datas[0])
@@ -473,7 +473,7 @@ def save_trial_data(spec, info_space, trial_fitness_df, trial_fig):
     util.write(trial_fitness_df, f'{prepath}_trial_fitness_df.csv')
     viz.save_image(trial_fig, f'{prepath}_trial_graph.png')
     if util.get_lab_mode() == 'train':
-        predir, _, _, _, _ = util.prepath_split(prepath)
+        predir, _, _, _, _, _ = util.prepath_split(prepath)
         shutil.make_archive(predir, 'zip', predir)
         logger.info(f'All trial data zipped to {predir}.zip')
 
@@ -485,7 +485,7 @@ def save_experiment_data(spec, info_space, experiment_df, experiment_fig):
     util.write(experiment_df, f'{prepath}_experiment_df.csv')
     viz.save_image(experiment_fig, f'{prepath}_experiment_graph.png')
     # zip for ease of upload
-    predir, _, _, _, _ = util.prepath_split(prepath)
+    predir, _, _, _, _, _ = util.prepath_split(prepath)
     shutil.make_archive(predir, 'zip', predir)
     logger.info(f'All experiment data zipped to {predir}.zip')
 
@@ -578,7 +578,7 @@ def session_data_dict_from_file(predir, trial_index):
 def session_data_dict_for_dist(spec, info_space):
     '''Method to retrieve session_datas (fitness df, so the same as session_data_dict above) when a trial with distributed sessions is done, to avoid messy multiprocessing data communication'''
     prepath = util.get_prepath(spec, info_space)
-    predir, _, _, _, _ = util.prepath_split(prepath)
+    predir, _, _, _, _, _ = util.prepath_split(prepath)
     session_datas = session_data_dict_from_file(predir, info_space.get('trial'))
     session_datas = [session_datas[k] for k in sorted(session_datas.keys())]
     return session_datas
@@ -599,7 +599,7 @@ def trial_data_dict_from_file(predir):
 def mock_spec_info_space(predir, trial_index=None, session_index=None):
     '''Helper for retro analysis to build mock info_space and spec'''
     from slm_lab.experiment.monitor import InfoSpace
-    _, _, _, spec_name, experiment_ts = util.prepath_split(predir)
+    _, _, _, spec_name, experiment_ts, _ = util.prepath_split(predir)
     info_space = InfoSpace()
     info_space.experiment_ts = experiment_ts
     info_space.set('experiment', 0)
@@ -693,7 +693,7 @@ def plot_session_from_file(session_df_filepath):
     analysis.plot_session_from_file(filepath)
     '''
     from slm_lab.experiment.monitor import InfoSpace
-    _, _, _, spec_name, _ = util.prepath_split(session_df_filepath)
+    _, _, _, spec_name, _, _ = util.prepath_split(session_df_filepath)
     session_spec = {'name': spec_name}
     session_df = util.read(session_df_filepath, header=[0, 1, 2, 3], index_col=0, dtype=np.float32)
     session_data = util.session_df_to_data(session_df)

--- a/slm_lab/experiment/control.py
+++ b/slm_lab/experiment/control.py
@@ -57,6 +57,8 @@ class Session:
             to_save = False
         if to_save:
             agent.save(ckpt='last')
+            if analysis.new_best(agent):
+                agent.save(ckpt='best')
             analysis.analyze_session(self)
 
     def run_episode(self):
@@ -84,7 +86,7 @@ class Session:
     def run(self):
         while self.env.clock.get(self.env.max_tick_unit) < self.env.max_tick:
             self.run_episode()
-            if analysis.is_solved(self.agent.algorithm):
+            if analysis.all_solved(self.agent):
                 break
         self.data = analysis.analyze_session(self)  # session fitness
         self.close()

--- a/slm_lab/experiment/control.py
+++ b/slm_lab/experiment/control.py
@@ -86,7 +86,8 @@ class Session:
     def run(self):
         while self.env.clock.get(self.env.max_tick_unit) < self.env.max_tick:
             self.run_episode()
-            if analysis.all_solved(self.agent):
+            if util.get_lab_mode() != 'enjoy' and analysis.all_solved(self.agent):
+                logger.info('All environments solved. Early exit.')
                 break
         self.data = analysis.analyze_session(self)  # session fitness
         self.close()

--- a/slm_lab/experiment/control.py
+++ b/slm_lab/experiment/control.py
@@ -31,13 +31,13 @@ class Session:
         self.info_space = info_space
         self.index = self.info_space.get('session')
         util.set_session_logger(self.spec, self.info_space, logger)
-        util.set_module_seed(self.info_space.get_random_seed())
-        util.try_set_cuda_id(self.spec, self.info_space)
         self.data = None
 
         # init singleton agent and env
         self.env = make_env(self.spec)
         body = Body(self.env, self.spec['agent'])
+        util.set_rand_seed(self.info_space.get_random_seed(), self.env)
+        util.try_set_cuda_id(self.spec, self.info_space)
         assert not ps.is_list(global_nets), f'single agent global_nets must be a dict, got {global_nets}'
         self.agent = Agent(self.spec, self.info_space, body=body, global_nets=global_nets)
 
@@ -102,13 +102,13 @@ class SpaceSession(Session):
         self.info_space = info_space
         self.index = self.info_space.get('session')
         util.set_session_logger(self.spec, self.info_space, logger)
-        util.set_module_seed(self.info_space.get_random_seed())
-        util.try_set_cuda_id(self.spec, self.info_space)
         self.data = None
 
         self.aeb_space = AEBSpace(self.spec, self.info_space)
         self.env_space = EnvSpace(self.spec, self.aeb_space)
         self.aeb_space.init_body_space()
+        util.set_rand_seed(self.info_space.get_random_seed(), self.env_space)
+        util.try_set_cuda_id(self.spec, self.info_space)
         assert not ps.is_dict(global_nets), f'multi agent global_nets must be a list of dicts, got {global_nets}'
         self.agent_space = AgentSpace(self.spec, self.aeb_space, global_nets)
 

--- a/slm_lab/experiment/monitor.py
+++ b/slm_lab/experiment/monitor.py
@@ -391,6 +391,7 @@ class InfoSpace:
         self.covered_space = []
         # used to id experiment sharing the same spec name
         self.experiment_ts = util.get_ts()
+        self.ckpt = None
 
     def reset_lower_axes(cls, coor, axis):
         '''Reset the axes lower than the given axis in coor'''

--- a/slm_lab/experiment/monitor.py
+++ b/slm_lab/experiment/monitor.py
@@ -23,7 +23,6 @@ from gym import spaces
 from slm_lab.agent import AGENT_DATA_NAMES
 from slm_lab.agent.algorithm import policy_util
 from slm_lab.env import ENV_DATA_NAMES
-from slm_lab.experiment.analysis import MA_WINDOW
 from slm_lab.lib import logger, util
 from slm_lab.spec import spec_util
 from statistics import mean
@@ -112,9 +111,8 @@ class Body:
         self.state_std_dev = np.nan
         self.state_n = 0
 
-        # store current and saved best reward_ma for model checkpointing
-        # and early termination if all the environments are solved
-        self.saved_best_reward_ma = -np.inf
+        # store current and best reward_ma for model checkpointing and early termination if all the environments are solved
+        self.best_reward_ma = -np.inf
         self.current_reward_ma = np.nan
 
         if aeb_space is None:  # singleton mode
@@ -161,8 +159,7 @@ class Body:
         # append efficiently to df
         self.df.loc[len(self.df)] = pd.Series(row, dtype=np.float32)
         # update current reward_ma
-        rewards = self.df['reward']
-        self.current_reward_ma = rewards.rolling(window=MA_WINDOW, min_periods=0, center=False).mean()[len(self.df) - 1]
+        self.current_reward_ma = self.memory.avg_total_reward
         return row
 
     def __str__(self):

--- a/slm_lab/lib/util.py
+++ b/slm_lab/lib/util.py
@@ -562,11 +562,17 @@ def set_attr(obj, attr_dict, keys=None):
     return obj
 
 
-def set_module_seed(random_seed):
+def set_rand_seed(random_seed, env_space):
     '''Set all the module random seeds'''
     torch.cuda.manual_seed_all(random_seed)
     torch.manual_seed(random_seed)
     np.random.seed(random_seed)
+    envs = env_space.envs if hasattr(env_space, 'envs') else [env_space]
+    for env in envs:
+        try:
+            env.u_env.seed(random_seed)
+        except Exception as e:
+            pass
 
 
 def set_session_logger(spec, info_space, logger):

--- a/slm_lab/lib/util.py
+++ b/slm_lab/lib/util.py
@@ -218,12 +218,15 @@ def get_prepath(spec, info_space, unit='experiment'):
     spec_name = spec['name']
     predir = f'data/{spec_name}_{info_space.experiment_ts}'
     prename = f'{spec_name}'
+    ckpt = ps.get(info_space, 'ckpt')
     trial_index = info_space.get('trial')
     session_index = info_space.get('session')
     if unit == 'trial':
         prename += f'_t{trial_index}'
     elif unit == 'session':
         prename += f'_t{trial_index}_s{session_index}'
+    if ckpt is not None:
+        prename += f'_ckpt{ckpt}'
     prepath = f'{predir}/{prename}'
     return prepath
 
@@ -358,9 +361,16 @@ def prepath_split(prepath):
     prename: dqn_pong_t0_s0
     spec_name: dqn_pong
     experiment_ts: 2018_12_02_082510
+    ckpt: ckptbest of dqn_pong_t0_s0_ckptbest if available
     '''
     prepath = prepath.strip('_')
     tail = prepath.split('data/')[-1]
+    if '_ckpt' in tail:
+        ckpt_chunk = ps.find(tail.split('_'), lambda s: s.startswith('ckpt'))
+        tail = tail.replace(f'_{ckpt_chunk}', '')
+        ckpt = ckpt_chunk.replace('ckpt', '')
+    else:
+        ckpt = None
     if '/' in tail:
         prefolder, prename = tail.split('/')
     else:
@@ -368,12 +378,12 @@ def prepath_split(prepath):
     predir = f'data/{prefolder}'
     spec_name = RE_FILE_TS.sub('', prefolder).strip('_')
     experiment_ts = RE_FILE_TS.findall(prefolder)[0]
-    return predir, prefolder, prename, spec_name, experiment_ts
+    return predir, prefolder, prename, spec_name, experiment_ts, ckpt
 
 
 def prepath_to_idxs(prepath):
     '''Extract trial index and session index from prepath if available'''
-    _, _, prename, spec_name, _ = prepath_split(prepath)
+    _, _, prename, spec_name, _, _ = prepath_split(prepath)
     idxs_tail = prename.replace(spec_name, '').strip('_')
     idxs_strs = idxs_tail.split('_')[:2]
     assert len(idxs_strs) > 0, 'No trial/session indices found in prepath'
@@ -391,10 +401,9 @@ def prepath_to_idxs(prepath):
 
 def prepath_to_spec(prepath):
     '''Create spec from prepath such that it returns the same prepath with info_space'''
-    prepath = prepath.strip('_')
-    splits = prepath.split('_')
-    pre_spec_path = '_'.join(splits[:-1])
-    spec_path = f'{pre_spec_path}_spec.json'
+    predir, _, prename, _, _, _ = prepath_split(prepath)
+    prename_no_s = '_'.join(prename.split('_')[:-1])
+    spec_path = f'{predir}/{prename_no_s}_spec.json'
     # read the spec of prepath
     spec = read(spec_path)
     return spec
@@ -403,11 +412,12 @@ def prepath_to_spec(prepath):
 def prepath_to_info_space(prepath):
     '''Create info_space from prepath such that it returns the same prepath with spec'''
     from slm_lab.experiment.monitor import InfoSpace
-    _, _, _, _, experiment_ts = prepath_split(prepath)
+    _, _, _, _, experiment_ts, ckpt = prepath_split(prepath)
     trial_index, session_index = prepath_to_idxs(prepath)
     # create info_space for prepath
     info_space = InfoSpace()
     info_space.experiment_ts = experiment_ts
+    info_space.ckpt = ckpt
     info_space.set('experiment', 0)
     info_space.set('trial', trial_index)
     info_space.set('session', session_index)


### PR DESCRIPTION
## Best-checkpointing
- speedup computation and simplify code

## Enjoy mode
- update naming scheme to work with enjoy mode
- unify and simplify prepath methods
- info_space now uses a `ckpt` for loading ckpt model. Example usage: `yarn start pong.json dqn_pong enjoy@data/dqn_cartpole_2018_12_02_124127/dqn_cartpole_t0_s0_ckptbest`
- update agent load and policy to properly set variables to `end_val` in enjoy mode
- random-seed env as well
