### PR TITLE
DQN Lunar Benchmark

### DIFF
--- a/slm_lab/spec/benchmark/dqn_lunar.json
+++ b/slm_lab/spec/benchmark/dqn_lunar.json
@@ -1,0 +1,78 @@
+{
+  "dqn_lunar": {
+    "agent": [{
+      "name": "DQN",
+      "algorithm": {
+        "name": "DQN",
+        "action_pdtype": "Argmax",
+        "action_policy": "epsilon_greedy",
+        "explore_var_spec": {
+          "name": "linear_decay",
+          "start_val": 1.0,
+          "end_val": 0.08,
+          "start_step": 0,
+          "end_step": 12000
+        },
+        "gamma": 0.99,
+        "training_batch_epoch": 3,
+        "training_epoch": 4,
+        "training_frequency": 4,
+        "training_start_step": 32,
+        "normalize_state": false
+      },
+      "memory": {
+        "name": "Replay",
+        "batch_size": 32,
+        "max_size": 100000,
+        "use_cer": false,
+        "concat_len": 4
+      },
+      "net": {
+        "type": "MLPNet",
+        "hid_layers": [
+          400,
+          200
+        ],
+        "hid_layers_activation": "relu",
+        "clip_grad_val": null,
+        "loss_spec": {
+          "name": "MSELoss"
+        },
+        "optim_spec": {
+          "name": "Adam",
+          "lr": 0.002
+        },
+        "lr_scheduler_spec": {
+          "name": "MultiStepLR",
+          "milestones": [
+            70000
+          ],
+          "gamma": 0.5
+        },
+        "update_type": "polyak",
+        "polyak_coef": 0.9,
+        "gpu": false
+      }
+    }],
+    "env": [{
+        "name": "LunarLander-v2",
+        "max_t": null,
+        "max_total_t": 250000,
+        "save_frequency": 10000
+      }],
+    "body": {
+      "product": "outer",
+      "num": 1
+    },
+    "meta": {
+      "distributed": false,
+      "graph_x": "total_t",
+      "max_session": 4,
+      "max_trial": 62,
+      "search": "RandomSearch",
+      "resources": {
+        "num_cpus": 62
+      }
+    },
+  }
+}


### PR DESCRIPTION
# Experiment Result

>*See [PR #180](https://github.com/kengz/SLM-Lab/pull/180) for an example*

>*The data files to upload below are all created automatically in the `data/` folder.*

>*Github does not support `.json` and `.csv` upload, but `.txt`. Please rename those files `.txt` before uploading.*

## Abstract

DQN benchmark on the Lunar Lander environment

## Methods

- epsilon greedy exploration
- target network
- polyak (weighted average) update for the target network

### To Reproduce

1. JSON spec: [dqn_epsilon_poly_lunar_spec.txt](https://github.com/kengz/SLM-Lab/files/2661891/dqn_epsilon_poly_lunar_spec.txt)

2. git SHA (contained in the file above): eb1c17187b658bd5c7c9d9654d9e7f6fa85608a0

## Results

*All the results contributed will be added to the [benchmark](BENCHMARK.md), and made [publicly available on Dropbox.](https://www.dropbox.com/sh/y738zvzj3nxthn1/AAAg1e6TxXVf3krD81TD5V0Ra?dl=0)*

- [ ] 1. full experiment data zip: *(please find our contact in README and request a "Dropbox file request" to upload it to the public benchmark folder.)*
- [x] 2. experiment graph: 
![dqn_epsilon_poly_lunar_experiment_graph](https://user-images.githubusercontent.com/5512945/49716004-2f19f100-fc07-11e8-9eb0-54ab488dc00e.png)
- [x] 3. max fitness score and experiment_df: 1.15, [dqn_epsilon_poly_lunar_experiment_df.txt](https://github.com/kengz/SLM-Lab/files/2661885/dqn_epsilon_poly_lunar_experiment_df.txt)
- [x] 4. best trial JSON spec: [dqn_epsilon_poly_lunar_t10_spec.txt](https://github.com/kengz/SLM-Lab/files/2661880/dqn_epsilon_poly_lunar_t10_spec.txt)
- [x] 5. best trial graph: 
![dqn_epsilon_poly_lunar_t10_trial_graph](https://user-images.githubusercontent.com/5512945/49716104-8ae47a00-fc07-11e8-9dd3-7865624d5152.png)
- [x] 6. [optional] best session graph: 
![dqn_epsilon_poly_lunar_t10_s3_session_graph](https://user-images.githubusercontent.com/5512945/49716125-9e8fe080-fc07-11e8-820c-b072a2bea05e.png)
![dqn_epsilon_poly_lunar_t10_s2_session_graph](https://user-images.githubusercontent.com/5512945/49716131-a51e5800-fc07-11e8-9a93-63a0d320a6d9.png)
