### PR TITLE
online eval

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,7 +217,7 @@ Deep Reinforcement Learning is highly empirical. The lab enables rapid and massi
     conda activate lab
     ```
 
->Alternatively, run the content of `bin/setup_macOS` or `bin/setup_ubuntu` on your terminal manually.
+>Alternatively, run the content of [`bin/setup_macOS` or `bin/setup_ubuntu`](https://github.com/kengz/SLM-Lab/tree/master/bin) on your terminal manually.
 >Docker image and Dockerfile with instructions are also available
 
 >Useful reference: [Debugging](https://kengz.gitbooks.io/slm-lab/content/installation/debugging.html)
@@ -269,8 +269,8 @@ It is `DQN` in `CartPole-v0`:
     conda activate lab
     python run_lab.py
     ```
+    >To run any lab commands, conda environment must be activated first. See [Installation](#installation) for more.
     >Alternatively, use the shorthand command `yarn start` to replace the last line
-    >To access GUI from remove server, use `-X` flag during ssh like so `ssh -X foo@bar`. See [Debugging](https://kengz.gitbooks.io/slm-lab/content/installation/debugging.html) for more.
 
 4. This demo will run a single trial using the default parameters, and render the environment. After completion, check the output for data `data/dqn_cartpole_2018_06_16_214527/` (timestamp will differ). You should see some healthy graphs.
 

--- a/README.md
+++ b/README.md
@@ -282,7 +282,7 @@ It is `DQN` in `CartPole-v0`:
 
 5. Enjoy mode - when a session ends, a model file will automatically save. You can find the session `prepath` that ends in its trial and session numbers. The example above is trial 1 session 0, and you can see a pyotrch model saved at `data/dqn_cartpole_2018_06_16_214527/dqn_cartpole_t1_s0_model_net.pth`. Use the following command to run from the saved folder in `data/`:
     ```bash
-    yarn start data/dqn_cartpole_2018_06_16_214527/dqn_cartpole_spec.json dqn_cartpole enjoy@dqn_cartpole_t0_s0
+    yarn start data/dqn_cartpole_2018_06_16_214527/dqn_cartpole_spec.json dqn_cartpole enjoy@dqn_cartpole_t1_s0
     ```
     >Enjoy mode will automatically disable learning and exploration. Graphs will still save.
 

--- a/README.md
+++ b/README.md
@@ -280,15 +280,13 @@ It is `DQN` in `CartPole-v0`:
     ![](https://kengz.gitbooks.io/slm-lab/content/assets/demo_session_graph.png)
     >Session graph showing total rewards, exploration variable and loss for the episodes.
 
-5. Enjoy mode - when a session ends, a model file will automatically save. You can find the session `prepath` that ends in its trial and session numbers. The example above is trial 1 session 0, and you can see a pyotrch model saved at `data/dqn_cartpole_2018_06_16_214527/dqn_cartpole_t1_s0_model_net.pth`. Use the prepath at `config/experiments.json` to run enjoy mode:
-    ```json
-    "demo.json": {
-      "dqn_cartpole": "enjoy@data/dqn_cartpole_2018_06_16_214527/dqn_cartpole_t1_s0"
-    }
+5. Enjoy mode - when a session ends, a model file will automatically save. You can find the session `prepath` that ends in its trial and session numbers. The example above is trial 1 session 0, and you can see a pyotrch model saved at `data/dqn_cartpole_2018_06_16_214527/dqn_cartpole_t1_s0_model_net.pth`. Use the following command to run from the saved folder in `data/`:
+    ```bash
+    yarn start data/dqn_cartpole_2018_06_16_214527/dqn_cartpole_spec.json dqn_cartpole enjoy@dqn_cartpole_t0_s0
     ```
     >Enjoy mode will automatically disable learning and exploration. Graphs will still save.
 
-    >To run the best model, use the best saved checkpoint `enjoy@data/dqn_cartpole_2018_06_16_214527/dqn_cartpole_t1_s0_ckptbest`
+    >To run the best model, use the best saved checkpoint `enjoy@dqn_cartpole_t1_s0_ckptbest`
 
 6. Next, change the run mode from `"train"` to `"search"`  `config/experiments.json`, and rerun. This runs experiments of multiple trials with hyperparameter search. Environments will not be rendered.:
     ```json

--- a/run_lab.py
+++ b/run_lab.py
@@ -58,7 +58,7 @@ def run_old_mode(spec_file, spec_name, lab_mode):
         spec = util.override_enjoy_spec(spec)
         Session(spec, info_space).run()
     elif lab_mode == 'eval':
-        spec = util.override_eval_spec(spec)
+        spec = util.override_eval_spec(spec, num_eval_epi=analysis.NUM_EVAL_EPI)
         Session(spec, info_space).run()
         util.clear_periodic_ckpt(prepath)  # cleanup after itself
         analysis.analyze_eval_trial(spec, info_space, predir)

--- a/run_lab.py
+++ b/run_lab.py
@@ -39,7 +39,7 @@ def run_new_mode(spec_file, spec_name, lab_mode):
         info_space.tick('trial')
         Trial(spec, info_space).run()
     else:
-        logger.warn('Unrecognizable lab_mode not of `search, train, dev`')
+        raise ValueError('Unrecognizable lab_mode not of `search, train, dev`')
 
 
 def run_old_mode(spec_file, spec_name, lab_mode):
@@ -59,9 +59,9 @@ def run_old_mode(spec_file, spec_name, lab_mode):
         Session(spec, info_space).run()
     elif lab_mode == 'eval':
         spec = util.override_eval_spec(spec)
-        Trial(spec, info_space).run()
+        Session(spec, info_space).run()
     else:
-        logger.warn('Unrecognizable lab_mode not of `enjoy, eval`')
+        raise ValueError('Unrecognizable lab_mode not of `enjoy, eval`')
 
 
 def run_by_mode(spec_file, spec_name, lab_mode):

--- a/run_lab.py
+++ b/run_lab.py
@@ -51,17 +51,15 @@ def run_old_mode(spec_file, spec_name, lab_mode):
     prepath = f'{predir}/{prename}'
     spec, info_space = util.prepath_to_spec_info_space(prepath)
     info_space.ckpt = 'eval'
+    # to load specific model in eval mode
+    info_space.eval_model_prepath = prepath
 
     # no info_space.tick() as they are reconstructed
     if lab_mode == 'enjoy':
         spec = util.override_enjoy_spec(spec)
         Session(spec, info_space).run()
     elif lab_mode == 'eval':
-        # right. missing models to be loaded. Basicaly these conditions apply to loadable things
-        # TODO hack and set the eval model location inside info_space
-        # reconstruct existing spec and info_space
         spec = util.override_eval_spec(spec)
-        # no info_space.tick() because it is recovered
         Trial(spec, info_space).run()
     else:
         logger.warn('Unrecognizable lab_mode not of `enjoy, eval`')

--- a/run_lab.py
+++ b/run_lab.py
@@ -58,7 +58,9 @@ def run_by_mode(spec_file, spec_name, lab_mode):
             info_space.tick('trial')
         Trial(spec, info_space).run()
     elif lab_mode.startswith('enjoy'):
-        prepath = lab_mode.split('@')[1]
+        prename = lab_mode.split('@')[1]
+        predir, _, _, _, _, _ = util.prepath_split(spec_file)
+        prepath = f'{predir}/{prename}'
         new_info_space = deepcopy(info_space)
         spec, info_space = util.prepath_to_spec_info_space(prepath)
         new_spec = util.override_enjoy_spec(deepcopy(spec))
@@ -67,7 +69,9 @@ def run_by_mode(spec_file, spec_name, lab_mode):
         new_info_space.tick('session')
         Session(new_spec, new_info_space).run()
     elif lab_mode.startswith('eval'):
-        prepath = lab_mode.split('@')[1]
+        prename = lab_mode.split('@')[1]
+        predir, _, _, _, _, _ = util.prepath_split(spec_file)
+        prepath = f'{predir}/{prename}'
         new_info_space = deepcopy(info_space)
         spec, info_space = util.prepath_to_spec_info_space(prepath)
         new_spec = util.override_eval_spec(deepcopy(spec))

--- a/run_lab.py
+++ b/run_lab.py
@@ -43,7 +43,7 @@ def run_new_mode(spec_file, spec_name, lab_mode):
 
 
 def run_old_mode(spec_file, spec_name, lab_mode):
-    '''Run using existing data with `enjoy, eval`'''
+    '''Run using existing data with `enjoy, eval`. The eval mode is also what train mode's online eval runs in a subprocess via bash command'''
     # reconstruct spec and info_space from existing data
     lab_mode, prename = lab_mode.split('@')
     predir, _, _, _, _, _ = util.prepath_split(spec_file)

--- a/run_lab.py
+++ b/run_lab.py
@@ -60,6 +60,7 @@ def run_old_mode(spec_file, spec_name, lab_mode):
     elif lab_mode == 'eval':
         spec = util.override_eval_spec(spec)
         Session(spec, info_space).run()
+        util.clear_periodic_ckpt(prepath) # cleanup after itself
     else:
         raise ValueError('Unrecognizable lab_mode not of `enjoy, eval`')
 

--- a/run_lab.py
+++ b/run_lab.py
@@ -45,18 +45,19 @@ def run_by_mode(spec_file, spec_name, lab_mode):
 
     # '@' is reserved for 'enjoy@{prepath}'
     os.environ['lab_mode'] = lab_mode.split('@')[0]
-    os.environ['PREPATH'] = util.get_prepath(spec, info_space)
-    reload(logger)  # to set PREPATH properly
 
     if lab_mode == 'search':
         info_space.tick('experiment')
+        util.set_logger(spec, info_space, logger)
         Experiment(spec, info_space).run()
     elif lab_mode.startswith('train'):
         info_space.tick('trial')
+        util.set_logger(spec, info_space, logger)
         Trial(spec, info_space).run()
     elif lab_mode == 'dev':
         spec = util.override_dev_spec(spec)
         info_space.tick('trial')
+        util.set_logger(spec, info_space, logger)
         Trial(spec, info_space).run()
     elif lab_mode.startswith('enjoy'):
         prename = lab_mode.split('@')[1]
@@ -69,6 +70,7 @@ def run_by_mode(spec_file, spec_name, lab_mode):
         new_info_space.tick('trial')
         new_info_space.tick('session')
         Session(new_spec, new_info_space).run()
+        util.set_logger(spec, info_space, logger)
     elif lab_mode.startswith('eval'):
         prename = lab_mode.split('@')[1]
         predir, _, _, _, _, _ = util.prepath_split(spec_file)
@@ -78,6 +80,7 @@ def run_by_mode(spec_file, spec_name, lab_mode):
         new_spec = util.override_eval_spec(deepcopy(spec))
         util.prepare_directory(new_spec, new_info_space, spec, info_space, prepath)
         new_info_space.tick('trial')
+        util.set_logger(spec, new_info_space, logger)
         Trial(new_spec, new_info_space).run()
     else:
         logger.warn('lab_mode not recognized; must be one of `search, train, dev, enjoy, eval`.')

--- a/run_lab.py
+++ b/run_lab.py
@@ -40,6 +40,7 @@ def run_by_mode(spec_file, spec_name, lab_mode):
     logger.info(f'Running lab in mode: {lab_mode}')
     spec = spec_util.get(spec_file, spec_name)
     info_space = InfoSpace()
+    # TODO dont save in enjoy, eval
     analysis.save_spec(spec, info_space, unit='experiment')
 
     # '@' is reserved for 'enjoy@{prepath}'
@@ -51,11 +52,11 @@ def run_by_mode(spec_file, spec_name, lab_mode):
         info_space.tick('experiment')
         Experiment(spec, info_space).run()
     elif lab_mode.startswith('train'):
-        if '@' in lab_mode:
-            prepath = lab_mode.split('@')[1]
-            spec, info_space = util.prepath_to_spec_info_space(prepath)
-        else:
-            info_space.tick('trial')
+        info_space.tick('trial')
+        Trial(spec, info_space).run()
+    elif lab_mode == 'dev':
+        spec = util.override_dev_spec(spec)
+        info_space.tick('trial')
         Trial(spec, info_space).run()
     elif lab_mode.startswith('enjoy'):
         prename = lab_mode.split('@')[1]
@@ -78,12 +79,8 @@ def run_by_mode(spec_file, spec_name, lab_mode):
         util.prepare_directory(new_spec, new_info_space, spec, info_space, prepath)
         new_info_space.tick('trial')
         Trial(new_spec, new_info_space).run()
-    elif lab_mode == 'dev':
-        spec = util.override_dev_spec(spec)
-        info_space.tick('trial')
-        Trial(spec, info_space).run()
     else:
-        logger.warn('lab_mode not recognized; must be one of `search, train, enjoy, eval, benchmark, dev`.')
+        logger.warn('lab_mode not recognized; must be one of `search, train, dev, enjoy, eval`.')
 
 
 def main():

--- a/run_lab.py
+++ b/run_lab.py
@@ -49,8 +49,8 @@ def run_old_mode(spec_file, spec_name, lab_mode):
     predir, _, _, _, _, _ = util.prepath_split(spec_file)
     prepath = f'{predir}/{prename}'
     spec, info_space = util.prepath_to_spec_info_space(prepath)
+    # see InfoSpace def for more on these
     info_space.ckpt = 'eval'
-    # to load specific model in eval mode
     info_space.eval_model_prepath = prepath
 
     # no info_space.tick() as they are reconstructed

--- a/run_lab.py
+++ b/run_lab.py
@@ -3,7 +3,6 @@ The entry point of SLM Lab
 Specify what to run in `config/experiments.json`
 Then run `yarn start` or `python run_lab.py`
 '''
-from copy import deepcopy
 import os
 # NOTE increase if needed. Pytorch thread overusage https://github.com/pytorch/pytorch/issues/975
 os.environ['OMP_NUM_THREADS'] = '1'

--- a/run_lab.py
+++ b/run_lab.py
@@ -25,17 +25,6 @@ debug_level = 'DEBUG'
 logger.toggle_debug(debug_modules, debug_level)
 
 
-def run_benchmark(spec_file):
-    logger.info('Running benchmark')
-    spec_dict = util.read(f'{spec_util.SPEC_DIR}/{spec_file}')
-    for spec_name in spec_dict:
-        # run only if not already exist; benchmark mode only
-        if not any(spec_name in filename for filename in os.listdir('data')):
-            run_by_mode(spec_file, spec_name, 'search')
-        else:
-            logger.info(f'{spec_name} is already ran and present in data/')
-
-
 def run_by_mode(spec_file, spec_name, lab_mode):
     logger.info(f'Running lab in mode: {lab_mode}')
     spec = spec_util.get(spec_file, spec_name)
@@ -96,10 +85,7 @@ def main():
     experiments = util.read('config/experiments.json')
     for spec_file in experiments:
         for spec_name, lab_mode in experiments[spec_file].items():
-            if lab_mode == 'benchmark':
-                run_benchmark(spec_file)
-            else:
-                run_by_mode(spec_file, spec_name, lab_mode)
+            run_by_mode(spec_file, spec_name, lab_mode)
 
 
 if __name__ == '__main__':

--- a/run_lab.py
+++ b/run_lab.py
@@ -60,7 +60,8 @@ def run_old_mode(spec_file, spec_name, lab_mode):
     elif lab_mode == 'eval':
         spec = util.override_eval_spec(spec)
         Session(spec, info_space).run()
-        util.clear_periodic_ckpt(prepath) # cleanup after itself
+        util.clear_periodic_ckpt(prepath)  # cleanup after itself
+        analysis.analyze_eval_trial(spec, info_space, predir)
     else:
         raise ValueError('Unrecognizable lab_mode not of `enjoy, eval`')
 

--- a/run_lab.py
+++ b/run_lab.py
@@ -7,7 +7,6 @@ from copy import deepcopy
 import os
 # NOTE increase if needed. Pytorch thread overusage https://github.com/pytorch/pytorch/issues/975
 os.environ['OMP_NUM_THREADS'] = '1'
-from importlib import reload
 from slm_lab.experiment import analysis
 from slm_lab.experiment.control import Session, Trial, Experiment
 from slm_lab.experiment.monitor import InfoSpace
@@ -25,54 +24,58 @@ debug_level = 'DEBUG'
 logger.toggle_debug(debug_modules, debug_level)
 
 
-def run_by_mode(spec_file, spec_name, lab_mode):
-    logger.info(f'Running lab in mode: {lab_mode}')
+def run_new_mode(spec_file, spec_name, lab_mode):
+    '''Run to generate new data with `search, train, dev`'''
     spec = spec_util.get(spec_file, spec_name)
     info_space = InfoSpace()
-    # TODO dont save in enjoy, eval
-    analysis.save_spec(spec, info_space, unit='experiment')
-
-    # '@' is reserved for 'enjoy@{prepath}'
-    os.environ['lab_mode'] = lab_mode.split('@')[0]
-
+    analysis.save_spec(spec, info_space, unit='experiment')  # first save the new spec
     if lab_mode == 'search':
         info_space.tick('experiment')
-        util.set_logger(spec, info_space, logger)
         Experiment(spec, info_space).run()
     elif lab_mode.startswith('train'):
         info_space.tick('trial')
-        util.set_logger(spec, info_space, logger)
         Trial(spec, info_space).run()
     elif lab_mode == 'dev':
         spec = util.override_dev_spec(spec)
         info_space.tick('trial')
-        util.set_logger(spec, info_space, logger)
         Trial(spec, info_space).run()
-    elif lab_mode.startswith('enjoy'):
-        prename = lab_mode.split('@')[1]
-        predir, _, _, _, _, _ = util.prepath_split(spec_file)
-        prepath = f'{predir}/{prename}'
-        new_info_space = deepcopy(info_space)
-        spec, info_space = util.prepath_to_spec_info_space(prepath)
-        new_spec = util.override_enjoy_spec(deepcopy(spec))
-        util.prepare_directory(new_spec, new_info_space, spec, info_space, prepath)
-        new_info_space.tick('trial')
-        new_info_space.tick('session')
-        Session(new_spec, new_info_space).run()
-        util.set_logger(spec, info_space, logger)
-    elif lab_mode.startswith('eval'):
-        prename = lab_mode.split('@')[1]
-        predir, _, _, _, _, _ = util.prepath_split(spec_file)
-        prepath = f'{predir}/{prename}'
-        new_info_space = deepcopy(info_space)
-        spec, info_space = util.prepath_to_spec_info_space(prepath)
-        new_spec = util.override_eval_spec(deepcopy(spec))
-        util.prepare_directory(new_spec, new_info_space, spec, info_space, prepath)
-        new_info_space.tick('trial')
-        util.set_logger(spec, new_info_space, logger)
-        Trial(new_spec, new_info_space).run()
     else:
-        logger.warn('lab_mode not recognized; must be one of `search, train, dev, enjoy, eval`.')
+        logger.warn('Unrecognizable lab_mode not of `search, train, dev`')
+
+
+def run_old_mode(spec_file, spec_name, lab_mode):
+    '''Run using existing data with `enjoy, eval`'''
+    # reconstruct spec and info_space from existing data
+    lab_mode, prename = lab_mode.split('@')
+    predir, _, _, _, _, _ = util.prepath_split(spec_file)
+    prepath = f'{predir}/{prename}'
+    spec, info_space = util.prepath_to_spec_info_space(prepath)
+    info_space.ckpt = 'eval'
+
+    # no info_space.tick() as they are reconstructed
+    if lab_mode == 'enjoy':
+        spec = util.override_enjoy_spec(spec)
+        Session(spec, info_space).run()
+    elif lab_mode == 'eval':
+        # right. missing models to be loaded. Basicaly these conditions apply to loadable things
+        # TODO hack and set the eval model location inside info_space
+        # reconstruct existing spec and info_space
+        spec = util.override_eval_spec(spec)
+        # no info_space.tick() because it is recovered
+        Trial(spec, info_space).run()
+    else:
+        logger.warn('Unrecognizable lab_mode not of `enjoy, eval`')
+
+
+def run_by_mode(spec_file, spec_name, lab_mode):
+    '''The main run lab function for all lab_modes'''
+    logger.info(f'Running lab in mode: {lab_mode}')
+    # '@' is reserved for 'enjoy@{prename}'
+    os.environ['lab_mode'] = lab_mode.split('@')[0]
+    if lab_mode in ('search', 'train', 'dev'):
+        run_new_mode(spec_file, spec_name, lab_mode)
+    else:
+        run_old_mode(spec_file, spec_name, lab_mode)
 
 
 def main():

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,6 @@ class PyTest(TestCommand):
 
     def initialize_options(self):
         os.environ['PY_ENV'] = 'test'
-        os.environ['EVAL'] = 'false'
         TestCommand.initialize_options(self)
         self.pytest_args = test_args
 

--- a/setup.py
+++ b/setup.py
@@ -25,6 +25,7 @@ class PyTest(TestCommand):
 
     def initialize_options(self):
         os.environ['PY_ENV'] = 'test'
+        os.environ['EVAL'] = 'false'
         TestCommand.initialize_options(self)
         self.pytest_args = test_args
 

--- a/slm_lab/agent/__init__.py
+++ b/slm_lab/agent/__init__.py
@@ -82,14 +82,15 @@ class Agent:
     @lab_api
     def save(self, ckpt=None):
         '''Save agent'''
+        if util.get_lab_mode() in ('enjoy', 'eval'):
+            # eval does not save new models
+            return
         self.algorithm.save(ckpt=ckpt)
 
     @lab_api
     def close(self):
         '''Close and cleanup agent at the end of a session, e.g. save model'''
-        # No need to save a model in eval mode since a model will always have been loaded and not updated
-        if not util.get_lab_mode() == 'eval':
-            self.save()
+        self.save()
 
     @lab_api
     def space_init(self, agent_space, body_a, global_nets):

--- a/slm_lab/agent/__init__.py
+++ b/slm_lab/agent/__init__.py
@@ -41,6 +41,7 @@ class Agent:
         self.a = a or 0  # for compatibility with agent_space
         self.agent_spec = spec['agent'][self.a]
         self.name = self.agent_spec['name']
+        assert not ps.is_list(global_nets), f'single agent global_nets must be a dict, got {global_nets}'
         if agent_space is None:  # singleton mode
             self.body = body
             body.agent = self
@@ -161,6 +162,7 @@ class AgentSpace:
         aeb_space.agent_space = self
         self.info_space = aeb_space.info_space
         self.aeb_shape = aeb_space.aeb_shape
+        assert not ps.is_dict(global_nets), f'multi agent global_nets must be a list of dicts, got {global_nets}'
         assert ps.is_list(self.spec['agent'])
         self.agents = []
         for a in range(len(self.spec['agent'])):

--- a/slm_lab/agent/algorithm/policy_util.py
+++ b/slm_lab/agent/algorithm/policy_util.py
@@ -327,7 +327,7 @@ class VarScheduler:
 
     def update(self, algorithm, clock):
         '''Get an updated value for var'''
-        if (util.get_lab_mode() in ['enjoy', 'eval']) or self._updater_name == 'no_decay':
+        if (util.get_lab_mode() in ('enjoy', 'eval')) or self._updater_name == 'no_decay':
             return self.end_val
         step = clock.get(clock.max_tick_unit)
         val = self._updater(self.start_val, self.end_val, self.start_step, self.end_step, step)

--- a/slm_lab/agent/memory/prioritized.py
+++ b/slm_lab/agent/memory/prioritized.py
@@ -138,7 +138,7 @@ class PrioritizedReplay(Replay):
 
     def get_priority(self, error):
         '''Takes in the error of one or more examples and returns the proportional priority'''
-        p = torch.pow(error.detach() + self.epsilon, self.alpha)
+        p = torch.pow(error.cpu().detach() + self.epsilon, self.alpha)
         return p.squeeze_().detach().numpy()
 
     def sample_idxs(self, batch_size):

--- a/slm_lab/agent/memory/prioritized.py
+++ b/slm_lab/agent/memory/prioritized.py
@@ -185,4 +185,20 @@ class PrioritizedReplay(Replay):
 
 class AtariPrioritizedReplay(PrioritizedReplay, AtariReplay):
     '''Make a Prioritized AtariReplay via nice multi-inheritance (python magic)'''
-    pass
+
+    def __init__(self, memory_spec, body):
+        util.set_attr(self, memory_spec, [
+            'alpha',
+            'epsilon',
+            'batch_size',
+            'max_size',
+            'use_cer',
+        ])
+        AtariReplay.__init__(self, memory_spec, body)
+        self.epsilon = torch.full((1,), self.epsilon)
+        self.alpha = torch.full((1,), self.alpha)
+        # adds a 'priorities' scalar to the data_keys and call reset again
+        self.data_keys = ['states', 'actions', 'rewards', 'next_states', 'dones', 'priorities']
+        self.reset()
+        self.states_shape = self.scalar_shape
+        self.states = [None] * self.max_size

--- a/slm_lab/agent/net/net_util.py
+++ b/slm_lab/agent/net/net_util.py
@@ -183,7 +183,11 @@ def load_algorithm(algorithm):
     '''Save all the nets for an algorithm'''
     agent = algorithm.agent
     net_names = algorithm.net_names
-    prepath = util.get_prepath(agent.spec, agent.info_space, unit='session')
+    if util.get_lab_mode() in ('enjoy', 'eval'):
+        # load specific model in eval mode
+        prepath = agent.info_space.eval_model_prepath
+    else:
+        prepath = util.get_prepath(agent.spec, agent.info_space, unit='session')
     logger.info(f'Loading algorithm {util.get_class_name(algorithm)} nets {net_names}')
     for net_name in net_names:
         net = getattr(algorithm, net_name)

--- a/slm_lab/agent/net/net_util.py
+++ b/slm_lab/agent/net/net_util.py
@@ -1,10 +1,8 @@
 from functools import partial
 from slm_lab import ROOT_DIR
 from slm_lab.lib import logger, util
-from subprocess import DEVNULL
 import os
 import pydash as ps
-import subprocess
 import torch
 import torch.nn as nn
 
@@ -165,11 +163,6 @@ def save_algorithm(algorithm, ckpt=None):
         save(net, model_path)
         optim_path = f'{prepath}_{net_name}_optim.pth'
         save(net.optim, optim_path)
-
-    if ckpt is None:  # remove checkpoint files at the end
-        ckpt_path = f'{prepath}_ckptlast*.pth'
-        subprocess.run(f'rm {ckpt_path}', cwd=ROOT_DIR, shell=True, stderr=DEVNULL, stdout=DEVNULL, close_fds=True)
-        logger.info(f'Removed all checkpoint model files {ckpt_path}')
 
 
 def load(net, model_path):

--- a/slm_lab/agent/net/net_util.py
+++ b/slm_lab/agent/net/net_util.py
@@ -155,7 +155,7 @@ def save_algorithm(algorithm, ckpt=None):
     net_names = algorithm.net_names
     prepath = util.get_prepath(agent.spec, agent.info_space, unit='session')
     if ckpt is not None:
-        prepath = f'{prepath}_ckpt{ckpt}'
+        prepath = f'{prepath}_ckpt-{ckpt}'
     logger.info(f'Saving algorithm {util.get_class_name(algorithm)} nets {net_names}')
     for net_name in net_names:
         net = getattr(algorithm, net_name)

--- a/slm_lab/experiment/analysis.py
+++ b/slm_lab/experiment/analysis.py
@@ -204,13 +204,13 @@ Checkpoint and early termination analysis
 
 def get_reward_mas(agent, name='current_reward_ma'):
     '''Return array of the named reward_ma for all of an agent's bodies.'''
-    bodies = getattr(agent, 'nanflat_body_a', None) or [agent.body]
+    bodies = getattr(agent, 'nanflat_body_a', [agent.body])
     return np.array([getattr(body, name) for body in bodies], dtype=np.float16)
 
 
 def get_std_epi_rewards(agent):
     '''Return array of std_epi_reward for each of the environments.'''
-    bodies = getattr(agent, 'nanflat_body_a', None) or [agent.body]
+    bodies = getattr(agent, 'nanflat_body_a', [agent.body])
     return np.array([ps.get(FITNESS_STD, f'{body.env.name}.std_epi_reward') for body in bodies], dtype=np.float16)
 
 
@@ -220,7 +220,7 @@ def new_best(agent):
     current_reward_mas = get_reward_mas(agent, 'current_reward_ma')
     new_best = (current_reward_mas >= best_reward_mas).all()
     if new_best:
-        bodies = getattr(agent, 'nanflat_body_a', None) or [agent.body]
+        bodies = getattr(agent, 'nanflat_body_a', [agent.body])
         for body in bodies:
             body.best_reward_ma = body.current_reward_ma
     return new_best

--- a/slm_lab/experiment/analysis.py
+++ b/slm_lab/experiment/analysis.py
@@ -357,6 +357,10 @@ def gather_aeb_rewards_df(aeb, session_datas, graph_x):
         aeb_reward_sr.index = aeb_df[graph_x]
         aeb_session_rewards[s] = aeb_reward_sr
     aeb_rewards_df = pd.DataFrame(aeb_session_rewards)
+    if util.get_lab_mode() in ('enjoy', 'eval'):
+        # guard for eval appending possibly not ordered, and multiindex df is hard to sort
+        aeb_rewards_df = aeb_rewards_df[~aeb_rewards_df.index.duplicated(keep='first')]
+        aeb_rewards_df.sort_index(inplace=True)
     return aeb_rewards_df
 
 
@@ -562,6 +566,10 @@ Retro analysis
 
 
 def run_online_eval(spec, info_space, ckpt):
+    '''
+    Calls a subprocess to run lab in eval mode with the constructed ckpt prepath, same as how one would manually run the bash cmd
+    e.g. python run_lab.py data/dqn_cartpole_2018_12_19_224811/dqn_cartpole_t0_spec.json dqn_cartpole eval@dqn_cartpole_t0_s1_ckpt-epi10-totalt1000
+    '''
     prepath_t = util.get_prepath(spec, info_space, unit='trial')
     prepath_s = util.get_prepath(spec, info_space, unit='session')
     predir, _, prename, spec_name, _, _ = util.prepath_split(prepath_s)

--- a/slm_lab/experiment/analysis.py
+++ b/slm_lab/experiment/analysis.py
@@ -567,7 +567,7 @@ def run_online_eval(spec, info_space, ckpt):
     prepath_s = util.get_prepath(spec, info_space, unit='session')
     predir, _, prename, spec_name, _, _ = util.prepath_split(prepath_s)
     cmd = f'python run_lab.py {prepath_t}_spec.json {spec_name} eval@{prename}_ckpt-{ckpt}'
-    logger.info(f'Running online eval for ckpt-{ckpt}. Cmd: \n+ {cmd}')
+    logger.info(f'Running online eval for ckpt-{ckpt}')
     util.run_cmd(cmd, wait=False)
 
 

--- a/slm_lab/experiment/analysis.py
+++ b/slm_lab/experiment/analysis.py
@@ -491,7 +491,7 @@ def save_trial_data(spec, info_space, trial_fitness_df, trial_fig):
     logger.info(f'Saving trial data to {prepath}')
     util.write(trial_fitness_df, f'{prepath}_trial_fitness_df.csv')
     viz.save_image(trial_fig, f'{prepath}_trial_graph.png')
-    if util.get_lab_mode() in ('train', 'eval'):
+    if util.get_lab_mode() == 'train':
         predir, _, _, _, _, _ = util.prepath_split(prepath)
         shutil.make_archive(predir, 'zip', predir)
         logger.info(f'All trial data zipped to {predir}.zip')

--- a/slm_lab/experiment/analysis.py
+++ b/slm_lab/experiment/analysis.py
@@ -565,6 +565,14 @@ Retro analysis
 '''
 
 
+def analyze_eval_trial(spec, info_space, predir):
+    '''Create a trial and run analysis to get the trial graph and other trial data'''
+    from slm_lab.experiment.control import Trial
+    trial = Trial(spec, info_space)
+    trial.session_data_dict = session_data_dict_from_file(predir, trial.index)
+    analyze_trial(trial)
+
+
 def run_online_eval(spec, info_space, ckpt, wait=False):
     '''
     Calls a subprocess to run lab in eval mode with the constructed ckpt prepath, same as how one would manually run the bash cmd

--- a/slm_lab/experiment/analysis.py
+++ b/slm_lab/experiment/analysis.py
@@ -561,6 +561,15 @@ Retro analysis
 '''
 
 
+def run_online_eval(spec, info_space, ckpt):
+    prepath_t = util.get_prepath(spec, info_space, unit='trial')
+    prepath_s = util.get_prepath(spec, info_space, unit='session')
+    predir, _, prename, spec_name, _, _ = util.prepath_split(prepath_s)
+    cmd = f'python run_lab.py {prepath_t}_spec.json {spec_name} eval@{prename}_ckpt-{ckpt}'
+    logger.info(f'Running online eval for ckpt-{ckpt}. Cmd: \n+ {cmd}')
+    util.run_cmd(cmd, wait=False)
+
+
 def session_data_from_file(predir, trial_index, session_index):
     '''Build session.session_data from file'''
     ckpt_str = '_ckpt-eval' if util.get_lab_mode() in ('enjoy', 'eval') else ''

--- a/slm_lab/experiment/analysis.py
+++ b/slm_lab/experiment/analysis.py
@@ -467,7 +467,7 @@ def save_trial_data(spec, info_space, trial_fitness_df, trial_fig):
     logger.info(f'Saving trial data to {prepath}')
     util.write(trial_fitness_df, f'{prepath}_trial_fitness_df.csv')
     viz.save_image(trial_fig, f'{prepath}_trial_graph.png')
-    if util.get_lab_mode() == ('train', 'eval'):
+    if util.get_lab_mode() in ('train', 'eval'):
         predir, _, _, _, _, _ = util.prepath_split(prepath)
         shutil.make_archive(predir, 'zip', predir)
         logger.info(f'All trial data zipped to {predir}.zip')

--- a/slm_lab/experiment/analysis.py
+++ b/slm_lab/experiment/analysis.py
@@ -481,8 +481,7 @@ def save_session_data(spec, info_space, session_data, session_fitness_df, sessio
     logger.info(f'Saving session data to {prepath}')
     if 'retro_analyze' not in os.environ['PREPATH']:
         save_session_df(session_data, prepath, info_space)
-    if util.get_lab_mode() not in ('enjoy', 'eval'):
-        util.write(session_fitness_df, f'{prepath}_session_fitness_df.csv')
+    util.write(session_fitness_df, f'{prepath}_session_fitness_df.csv')
     viz.save_image(session_fig, f'{prepath}_session_graph.png')
 
 

--- a/slm_lab/experiment/analysis.py
+++ b/slm_lab/experiment/analysis.py
@@ -11,12 +11,6 @@ import pandas as pd
 import pydash as ps
 import shutil
 
-DATA_AGG_FNS = {
-    't': 'sum',
-    'reward': 'sum',
-    'loss': 'mean',
-    'explore_var': 'mean',
-}
 FITNESS_COLS = ['strength', 'speed', 'stability', 'consistency']
 # TODO improve to make it work with any reward mean
 FITNESS_STD = util.read('slm_lab/spec/_fitness_std.json')
@@ -188,7 +182,7 @@ def calc_aeb_fitness_sr(aeb_df, env_name):
     if std is None:
         std = FITNESS_STD.get('template')
         logger.warn(f'The fitness standard for env {env_name} is not built yet. Contact author. Using a template standard for now.')
-    aeb_df['total_t'] = aeb_df['t'].cumsum()
+    aeb_df['total_t'] = aeb_df['total_t']
     aeb_df['strength'] = calc_strength(aeb_df, std['rand_epi_reward'], std['std_epi_reward'])
     aeb_df['strength_ma'] = aeb_df['strength'].rolling(MA_WINDOW).mean()
     aeb_df['strength_mono_inc'] = is_noisy_mono_inc(aeb_df['strength']).astype(int)
@@ -455,7 +449,7 @@ def save_session_data(spec, info_space, session_data, session_fitness_df, sessio
     Save the session data: session_df, session_fitness_df, session_graph.
     session_data is saved as session_df; multi-indexed with (a,e,b), 3 extra levels
     to read, use:
-    session_df = util.read(filepath, header=[0, 1, 2, 3])
+    session_df = util.read(filepath, header=[0, 1, 2, 3], index_col=0)
     session_data = util.session_df_to_data(session_df)
     '''
     prepath = util.get_prepath(spec, info_space, unit='session')

--- a/slm_lab/experiment/analysis.py
+++ b/slm_lab/experiment/analysis.py
@@ -565,7 +565,7 @@ Retro analysis
 '''
 
 
-def run_online_eval(spec, info_space, ckpt):
+def run_online_eval(spec, info_space, ckpt, wait=False):
     '''
     Calls a subprocess to run lab in eval mode with the constructed ckpt prepath, same as how one would manually run the bash cmd
     e.g. python run_lab.py data/dqn_cartpole_2018_12_19_224811/dqn_cartpole_t0_spec.json dqn_cartpole eval@dqn_cartpole_t0_s1_ckpt-epi10-totalt1000
@@ -575,7 +575,7 @@ def run_online_eval(spec, info_space, ckpt):
     predir, _, prename, spec_name, _, _ = util.prepath_split(prepath_s)
     cmd = f'python run_lab.py {prepath_t}_spec.json {spec_name} eval@{prename}_ckpt-{ckpt}'
     logger.info(f'Running online eval for ckpt-{ckpt}')
-    util.run_cmd(cmd, wait=False)
+    util.run_cmd(cmd, wait=wait)
 
 
 def session_data_from_file(predir, trial_index, session_index):

--- a/slm_lab/experiment/analysis.py
+++ b/slm_lab/experiment/analysis.py
@@ -592,7 +592,7 @@ def analyze_eval_trial(spec, info_space, predir):
     analyze_trial(trial)
 
 
-def run_online_eval(spec, info_space, ckpt, wait=False):
+def run_online_eval(spec, info_space, ckpt):
     '''
     Calls a subprocess to run lab in eval mode with the constructed ckpt prepath, same as how one would manually run the bash cmd
     e.g. python run_lab.py data/dqn_cartpole_2018_12_19_224811/dqn_cartpole_t0_spec.json dqn_cartpole eval@dqn_cartpole_t0_s1_ckpt-epi10-totalt1000
@@ -602,7 +602,7 @@ def run_online_eval(spec, info_space, ckpt, wait=False):
     predir, _, prename, spec_name, _, _ = util.prepath_split(prepath_s)
     cmd = f'python run_lab.py {prepath_t}_spec.json {spec_name} eval@{prename}_ckpt-{ckpt}'
     logger.info(f'Running online eval for ckpt-{ckpt}')
-    util.run_cmd(cmd, wait=wait)
+    return util.run_cmd(cmd)
 
 
 def session_data_from_file(predir, trial_index, session_index):

--- a/slm_lab/experiment/analysis.py
+++ b/slm_lab/experiment/analysis.py
@@ -458,13 +458,11 @@ def save_session_df(session_data, prepath, info_space):
         ckpt = util.find_ckpt(info_space.eval_model_prepath)
         epi = int(re.search('epi(\d+)', ckpt)[1])
         totalt = int(re.search('totalt(\d+)', ckpt)[1])
-        for aeb in session_data:
-            aeb_df = session_data[aeb]
-            # override to know which ckpt eval is for
-            aeb_df['epi'] = epi
-            aeb_df['total_t'] = totalt
         session_df = pd.concat(session_data, axis=1)
         eval_session_df = pd.DataFrame(data=[session_df.mean()])
+        for aeb in util.get_df_aeb_list(eval_session_df):
+            eval_session_df.loc[:, aeb + ('epi',)] = epi
+            eval_session_df.loc[:, aeb + ('total_t',)] = totalt
         # if eval, save with append mode
         header = not os.path.exists(filepath)
         with open(filepath, 'a') as f:

--- a/slm_lab/experiment/analysis.py
+++ b/slm_lab/experiment/analysis.py
@@ -539,8 +539,9 @@ Retro analysis
 
 def session_data_from_file(predir, trial_index, session_index):
     '''Build session.session_data from file'''
+    ckpt_str = '_ckpteval' if util.get_lab_mode() in ('enjoy', 'eval') else ''
     for filename in os.listdir(predir):
-        if filename.endswith(f'_t{trial_index}_s{session_index}_session_df.csv'):
+        if filename.endswith(f'_t{trial_index}_s{session_index}{ckpt_str}_session_df.csv'):
             filepath = f'{predir}/{filename}'
             session_df = util.read(filepath, header=[0, 1, 2, 3], index_col=0)
             session_data = util.session_df_to_data(session_df)
@@ -559,9 +560,10 @@ def session_datas_from_file(predir, trial_spec, trial_index):
 
 def session_data_dict_from_file(predir, trial_index):
     '''Build trial.session_data_dict from file'''
+    ckpt_str = '_ckpteval' if util.get_lab_mode() in ('enjoy', 'eval') else ''
     session_data_dict = {}
     for filename in os.listdir(predir):
-        if f'_t{trial_index}_' in filename and filename.endswith('_session_fitness_df.csv'):
+        if f'_t{trial_index}_' in filename and filename.endswith(f'{ckpt_str}_session_fitness_df.csv'):
             filepath = f'{predir}/{filename}'
             fitness_df = util.read(filepath, header=[0, 1, 2, 3], index_col=0, dtype=np.float32)
             util.fix_multi_index_dtype(fitness_df)

--- a/slm_lab/experiment/analysis.py
+++ b/slm_lab/experiment/analysis.py
@@ -322,7 +322,7 @@ def plot_session(session_spec, info_space, session_data):
     graph_x = session_spec['meta'].get('graph_x', 'epi')
     aeb_count = len(session_data)
     palette = viz.get_palette(aeb_count)
-    fig = viz.tools.make_subplots(rows=3, cols=1, shared_xaxes=True)
+    fig = viz.tools.make_subplots(rows=3, cols=1, shared_xaxes=True, print_grid=False)
     for idx, (a, e, b) in enumerate(session_data):
         aeb_str = f'{a}{e}{b}'
         aeb_df = session_data[(a, e, b)]
@@ -417,7 +417,7 @@ def plot_experiment(experiment_spec, experiment_df):
     y_cols = ['fitness'] + FITNESS_COLS
     x_cols = ps.difference(experiment_df.columns.tolist(), y_cols)
 
-    fig = viz.tools.make_subplots(rows=len(y_cols), cols=len(x_cols), shared_xaxes=True, shared_yaxes=True)
+    fig = viz.tools.make_subplots(rows=len(y_cols), cols=len(x_cols), shared_xaxes=True, shared_yaxes=True, print_grid=False)
     fitness_sr = experiment_df['fitness']
     min_fitness = fitness_sr.values.min()
     max_fitness = fitness_sr.values.max()

--- a/slm_lab/experiment/analysis.py
+++ b/slm_lab/experiment/analysis.py
@@ -355,12 +355,12 @@ def gather_aeb_rewards_df(aeb, session_datas, graph_x):
         aeb_df = session_data[aeb]
         aeb_reward_sr = aeb_df['reward']
         aeb_reward_sr.index = aeb_df[graph_x]
+        if util.get_lab_mode() in ('enjoy', 'eval'):
+            # guard for eval appending possibly not ordered, and multiindex df is hard to sort
+            aeb_reward_sr = aeb_reward_sr[~aeb_reward_sr.index.duplicated(keep='first')]
+            aeb_reward_sr.sort_index(inplace=True)
         aeb_session_rewards[s] = aeb_reward_sr
     aeb_rewards_df = pd.DataFrame(aeb_session_rewards)
-    if util.get_lab_mode() in ('enjoy', 'eval'):
-        # guard for eval appending possibly not ordered, and multiindex df is hard to sort
-        aeb_rewards_df = aeb_rewards_df[~aeb_rewards_df.index.duplicated(keep='first')]
-        aeb_rewards_df.sort_index(inplace=True)
     return aeb_rewards_df
 
 

--- a/slm_lab/experiment/analysis.py
+++ b/slm_lab/experiment/analysis.py
@@ -445,13 +445,13 @@ def plot_experiment(experiment_spec, experiment_df):
     return fig
 
 
-def save_session_df(prepath, session_data):
+def save_session_df(session_data, prepath, info_space):
     '''Save session_df, and if is in eval mode, modify it and save with append'''
     filepath = f'{prepath}_session_df.csv'
     if util.get_lab_mode() in ('enjoy', 'eval'):
-        ckpt = util.find_ckpt(prepath)
-        epi = re.search('epi(\d+)', ckpt)[1]
-        totalt = re.search('totalt(\d+)', ckpt)[1]
+        ckpt = util.find_ckpt(info_space.eval_model_prepath)
+        epi = int(re.search('epi(\d+)', ckpt)[1])
+        totalt = int(re.search('totalt(\d+)', ckpt)[1])
         for aeb in session_data:
             aeb_df = session_data[aeb]
             # override to know which ckpt eval is for
@@ -479,7 +479,7 @@ def save_session_data(spec, info_space, session_data, session_fitness_df, sessio
     prepath = util.get_prepath(spec, info_space, unit='session')
     logger.info(f'Saving session data to {prepath}')
     if 'retro_analyze' not in os.environ['PREPATH']:
-        save_session_df(prepath, session_data)
+        save_session_df(session_data, prepath, info_space)
     util.write(session_fitness_df, f'{prepath}_session_fitness_df.csv')
     viz.save_image(session_fig, f'{prepath}_session_graph.png')
 

--- a/slm_lab/experiment/analysis.py
+++ b/slm_lab/experiment/analysis.py
@@ -17,6 +17,7 @@ FITNESS_COLS = ['strength', 'speed', 'stability', 'consistency']
 FITNESS_STD = util.read('slm_lab/spec/_fitness_std.json')
 NOISE_WINDOW = 0.05
 NORM_ORDER = 1  # use L1 norm in fitness vector norm
+NUM_EVAL_EPI = 100  # set the number of episodes to eval a model ckpt
 MA_WINDOW = 100
 logger = logger.get_logger(__name__)
 

--- a/slm_lab/experiment/analysis.py
+++ b/slm_lab/experiment/analysis.py
@@ -450,8 +450,8 @@ def save_session_df(prepath, session_data):
     filepath = f'{prepath}_session_df.csv'
     if util.get_lab_mode() in ('enjoy', 'eval'):
         ckpt = util.find_ckpt(prepath)
-        epi = re.search('epi(\d+)', ckpt_str)[1]
-        totalt = re.search('totalt(\d+)', ckpt_str)[1]
+        epi = re.search('epi(\d+)', ckpt)[1]
+        totalt = re.search('totalt(\d+)', ckpt)[1]
         for aeb in session_data:
             aeb_df = session_data[aeb]
             # override to know which ckpt eval is for

--- a/slm_lab/experiment/analysis.py
+++ b/slm_lab/experiment/analysis.py
@@ -184,7 +184,6 @@ def calc_aeb_fitness_sr(aeb_df, env_name):
     if std is None:
         std = FITNESS_STD.get('template')
         logger.warn(f'The fitness standard for env {env_name} is not built yet. Contact author. Using a template standard for now.')
-    aeb_df['total_t'] = aeb_df['total_t']
     aeb_df['strength'] = calc_strength(aeb_df, std['rand_epi_reward'], std['std_epi_reward'])
     aeb_df['strength_ma'] = aeb_df['strength'].rolling(MA_WINDOW).mean()
     aeb_df['strength_mono_inc'] = is_noisy_mono_inc(aeb_df['strength']).astype(int)

--- a/slm_lab/experiment/analysis.py
+++ b/slm_lab/experiment/analysis.py
@@ -481,7 +481,8 @@ def save_session_data(spec, info_space, session_data, session_fitness_df, sessio
     logger.info(f'Saving session data to {prepath}')
     if 'retro_analyze' not in os.environ['PREPATH']:
         save_session_df(session_data, prepath, info_space)
-    util.write(session_fitness_df, f'{prepath}_session_fitness_df.csv')
+    if util.get_lab_mode() not in ('enjoy', 'eval'):
+        util.write(session_fitness_df, f'{prepath}_session_fitness_df.csv')
     viz.save_image(session_fig, f'{prepath}_session_graph.png')
 
 

--- a/slm_lab/experiment/control.py
+++ b/slm_lab/experiment/control.py
@@ -9,6 +9,7 @@ from slm_lab.env import EnvSpace, make_env
 from slm_lab.experiment import analysis, search
 from slm_lab.experiment.monitor import AEBSpace, Body, enable_aeb_space
 from slm_lab.lib import logger, util
+import os
 import pydash as ps
 import torch.multiprocessing as mp
 
@@ -46,7 +47,7 @@ class Session:
         tick = clock.get(env.max_tick_unit)
         if util.get_lab_mode() in ('enjoy', 'eval'):
             to_ckpt = False
-        elif (env.max_tick_unit == 'epi' and tick == 1) or (tick == 0):
+        elif os.environ.get('PY_ENV') != 'test' and ((env.max_tick_unit == 'epi' and tick == 1) or (tick == 0)):
             to_ckpt = True  # ckpt at beginning, but epi starts at 1
         elif hasattr(env, 'save_frequency') and 0 < tick <= env.max_tick:
             if env.max_tick_unit == 'epi':

--- a/slm_lab/experiment/control.py
+++ b/slm_lab/experiment/control.py
@@ -9,11 +9,7 @@ from slm_lab.env import EnvSpace, make_env
 from slm_lab.experiment import analysis, search
 from slm_lab.experiment.monitor import AEBSpace, Body, enable_aeb_space
 from slm_lab.lib import logger, util
-import numpy as np
-import os
-import pandas as pd
 import pydash as ps
-import torch
 import torch.multiprocessing as mp
 
 

--- a/slm_lab/experiment/control.py
+++ b/slm_lab/experiment/control.py
@@ -30,7 +30,7 @@ class Session:
         self.spec = spec
         self.info_space = info_space
         self.index = self.info_space.get('session')
-        util.set_session_logger(self.spec, self.info_space, logger)
+        util.set_logger(self.spec, self.info_space, logger, 'session')
         self.data = None
 
         # init singleton agent and env
@@ -101,7 +101,7 @@ class SpaceSession(Session):
         self.spec = spec
         self.info_space = info_space
         self.index = self.info_space.get('session')
-        util.set_session_logger(self.spec, self.info_space, logger)
+        util.set_logger(self.spec, self.info_space, logger, 'session')
         self.data = None
 
         self.aeb_space = AEBSpace(self.spec, self.info_space)

--- a/slm_lab/experiment/control.py
+++ b/slm_lab/experiment/control.py
@@ -60,6 +60,7 @@ class Session:
             if analysis.new_best(agent):
                 agent.save(ckpt='best')
             analysis.analyze_session(self)
+            # run online eval for this session once ckpt is ready
             analysis.run_online_eval(self.spec, self.info_space, ckpt)
 
     def run_episode(self):

--- a/slm_lab/experiment/control.py
+++ b/slm_lab/experiment/control.py
@@ -34,7 +34,6 @@ class Session:
         body = Body(self.env, self.spec['agent'])
         util.set_rand_seed(self.info_space.get_random_seed(), self.env)
         util.try_set_cuda_id(self.spec, self.info_space)
-        assert not ps.is_list(global_nets), f'single agent global_nets must be a dict, got {global_nets}'
         self.agent = Agent(self.spec, self.info_space, body=body, global_nets=global_nets)
 
         enable_aeb_space(self)  # to use lab's data analysis framework
@@ -108,7 +107,6 @@ class SpaceSession(Session):
         self.aeb_space.init_body_space()
         util.set_rand_seed(self.info_space.get_random_seed(), self.env_space)
         util.try_set_cuda_id(self.spec, self.info_space)
-        assert not ps.is_dict(global_nets), f'multi agent global_nets must be a list of dicts, got {global_nets}'
         self.agent_space = AgentSpace(self.spec, self.aeb_space, global_nets)
 
         logger.info(util.self_desc(self))

--- a/slm_lab/experiment/control.py
+++ b/slm_lab/experiment/control.py
@@ -1,6 +1,6 @@
 '''
 The control module
-Creates and controls the units of SLM lab: EvolutionGraph, Experiment, Trial, Session
+Creates and controls the units of SLM lab: Experiment, Trial, Session
 '''
 from copy import deepcopy
 from importlib import reload
@@ -300,16 +300,3 @@ class Experiment:
         self.data = analysis.analyze_experiment(self)
         self.close()
         return self.data
-
-
-class EvolutionGraph:
-    '''
-    The biggest unit of Lab.
-    The evolution graph keeps track of all experiments as nodes of experiment data, with fitness metrics, evolution links, traits,
-    which could be used to aid graph analysis on the traits, fitness metrics,
-    to suggest new experiment via node creation, mutation or combination (no DAG restriction).
-    There could be a high level evolution module that guides and optimizes the evolution graph and experiments to achieve SLM.
-    '''
-
-    def __init__(self, spec, info_space):
-        raise NotImplementedError

--- a/slm_lab/experiment/control.py
+++ b/slm_lab/experiment/control.py
@@ -48,7 +48,9 @@ class Session:
     def save_if_ckpt(self, agent, env):
         '''Save for agent, env if episode is at checkpoint'''
         tick = env.clock.get(env.max_tick_unit)
-        if hasattr(env, 'save_frequency') and 0 < tick < env.max_tick:
+        if util.get_lab_mode() in ('enjoy', 'eval'):
+            to_save = False
+        elif hasattr(env, 'save_frequency') and 0 < tick < env.max_tick:
             if env.max_tick_unit == 'epi':
                 to_save = (env.done and tick % env.save_frequency == 0)
             else:

--- a/slm_lab/experiment/control.py
+++ b/slm_lab/experiment/control.py
@@ -61,7 +61,7 @@ class Session:
             agent.save(ckpt=ckpt)
             if analysis.new_best(agent):
                 agent.save(ckpt='best')
-            if util.get_lab_mode() == 'train':
+            if util.get_lab_mode() == 'train' and os.environ.get('EVAL', 'false') == 'true':
                 # (only for train mode) spawn online eval for this session once ckpt is ready
                 analysis.run_online_eval(self.spec, self.info_space, ckpt, wait)
             if tick > 0:  # nothing to analyze at start

--- a/slm_lab/experiment/control.py
+++ b/slm_lab/experiment/control.py
@@ -180,6 +180,8 @@ class Trial:
         self.spec = spec
         self.info_space = info_space
         self.index = self.info_space.get('trial')
+        info_space.set('session', None)  # Session starts anew for new trial
+        util.set_logger(self.spec, self.info_space, logger, 'trial')
         self.session_data_dict = {}
         self.data = None
         analysis.save_spec(spec, info_space, unit='trial')
@@ -273,6 +275,7 @@ class Experiment:
         self.spec = spec
         self.info_space = info_space
         self.index = self.info_space.get('experiment')
+        util.set_logger(self.spec, self.info_space, logger, 'trial')
         self.trial_data_dict = {}
         self.data = None
         analysis.save_spec(spec, info_space, unit='experiment')

--- a/slm_lab/experiment/control.py
+++ b/slm_lab/experiment/control.py
@@ -83,6 +83,7 @@ class Session:
         '''
         self.agent.close()
         self.env.close()
+        util.clear_ckpt(self.agent)
         logger.info('Session done and closed.')
 
     def run(self):

--- a/slm_lab/experiment/control.py
+++ b/slm_lab/experiment/control.py
@@ -55,7 +55,8 @@ class Session:
             to_ckpt = False
 
         if to_ckpt:
-            agent.save(ckpt='last')
+            ckpt = f'epi{clock.get("epi")}-totalt{clock.get("total_t")}'
+            agent.save(ckpt=ckpt)
             if analysis.new_best(agent):
                 agent.save(ckpt='best')
             analysis.analyze_session(self)

--- a/slm_lab/experiment/control.py
+++ b/slm_lab/experiment/control.py
@@ -61,8 +61,9 @@ class Session:
             agent.save(ckpt=ckpt)
             if analysis.new_best(agent):
                 agent.save(ckpt='best')
-            # run online eval for this session once ckpt is ready
-            analysis.run_online_eval(self.spec, self.info_space, ckpt, wait)
+            if util.get_lab_mode() == 'train':
+                # (only for train mode) spawn online eval for this session once ckpt is ready
+                analysis.run_online_eval(self.spec, self.info_space, ckpt, wait)
             if tick > 0:  # nothing to analyze at start
                 analysis.analyze_session(self)
 

--- a/slm_lab/experiment/control.py
+++ b/slm_lab/experiment/control.py
@@ -62,7 +62,7 @@ class Session:
             agent.save(ckpt=ckpt)
             if analysis.new_best(agent):
                 agent.save(ckpt='best')
-            if util.get_lab_mode() == 'train' and os.environ.get('EVAL', 'false') == 'true':
+            if util.get_lab_mode() == 'train' and self.spec['meta'].get('training_eval', False):
                 # (only for train mode) spawn online eval for this session once ckpt is ready
                 analysis.run_online_eval(self.spec, self.info_space, ckpt, wait)
             if tick > 0:  # nothing to analyze at start

--- a/slm_lab/experiment/control.py
+++ b/slm_lab/experiment/control.py
@@ -48,7 +48,7 @@ class Session:
             to_ckpt = False
         elif (env.max_tick_unit == 'epi' and tick == 1) or (tick == 0):
             to_ckpt = True  # ckpt at beginning, but epi starts at 1
-        elif hasattr(env, 'save_frequency') and 0 < tick < env.max_tick:
+        elif hasattr(env, 'save_frequency') and 0 < tick:
             if env.max_tick_unit == 'epi':
                 to_ckpt = (env.done and tick % env.save_frequency == 0)
             else:

--- a/slm_lab/experiment/control.py
+++ b/slm_lab/experiment/control.py
@@ -55,13 +55,12 @@ class Session:
             to_ckpt = False
 
         if to_ckpt:
-            util.clear_ckpt(self.agent) # clear previous
             ckpt = f'epi{clock.get("epi")}-totalt{clock.get("total_t")}'
             agent.save(ckpt=ckpt)
             if analysis.new_best(agent):
                 agent.save(ckpt='best')
             analysis.analyze_session(self)
-            # TODO eval call using eval_model_prepath
+            analysis.run_online_eval(self.spec, self.info_space, ckpt)
 
     def run_episode(self):
         self.env.clock.tick('epi')
@@ -83,7 +82,6 @@ class Session:
         '''
         self.agent.close()
         self.env.close()
-        util.clear_ckpt(self.agent)
         logger.info('Session done and closed.')
 
     def run(self):

--- a/slm_lab/experiment/control.py
+++ b/slm_lab/experiment/control.py
@@ -48,7 +48,7 @@ class Session:
             to_ckpt = False
         elif (env.max_tick_unit == 'epi' and tick == 1) or (tick == 0):
             to_ckpt = True  # ckpt at beginning, but epi starts at 1
-        elif hasattr(env, 'save_frequency') and 0 < tick:
+        elif hasattr(env, 'save_frequency') and 0 < tick <= env.max_tick:
             if env.max_tick_unit == 'epi':
                 to_ckpt = (env.done and tick % env.save_frequency == 0)
             else:

--- a/slm_lab/experiment/control.py
+++ b/slm_lab/experiment/control.py
@@ -55,6 +55,7 @@ class Session:
             to_ckpt = False
 
         if to_ckpt:
+            util.clear_ckpt(self.agent) # clear previous
             ckpt = f'epi{clock.get("epi")}-totalt{clock.get("total_t")}'
             agent.save(ckpt=ckpt)
             if analysis.new_best(agent):

--- a/slm_lab/experiment/monitor.py
+++ b/slm_lab/experiment/monitor.py
@@ -25,7 +25,6 @@ from slm_lab.agent.algorithm import policy_util
 from slm_lab.env import ENV_DATA_NAMES
 from slm_lab.lib import logger, util
 from slm_lab.spec import spec_util
-from statistics import mean
 import numpy as np
 import pandas as pd
 import pydash as ps

--- a/slm_lab/experiment/monitor.py
+++ b/slm_lab/experiment/monitor.py
@@ -398,8 +398,9 @@ class InfoSpace:
         self.covered_space = []
         # used to id experiment sharing the same spec name
         self.experiment_ts = util.get_ts()
+        # ckpt gets appened to extend prepath using util.get_prepath for saving models, e.g. ckpt_str = ckpt-epi10-totalt1000
+        # ckpt = 'eval' is special for eval mode, so data files will save with `ckpt-eval`; no models will be saved, but to load models with normal ckpt it will find them using eval_model_prepath
         self.ckpt = None
-        # to load specific model in eval mode
         self.eval_model_prepath = None
 
     def reset_lower_axes(cls, coor, axis):

--- a/slm_lab/experiment/monitor.py
+++ b/slm_lab/experiment/monitor.py
@@ -96,7 +96,7 @@ class Body:
         # for action policy exploration, so be set in algo during init_algorithm_params()
         self.explore_var = np.nan
         self.df = pd.DataFrame(columns=[
-            'epi', 't', 'reward', 'loss', 'explore_var',
+            'epi', 'total_t', 't', 'reward', 'loss', 'explore_var',
             'lr', 'action_ent', 'ent_coef', 'grad_norm'])
 
         # diagnostics variables/stats from action_policy prob. dist.
@@ -148,7 +148,7 @@ class Body:
         '''Update to append data at the end of an episode (when env.done is true)'''
         assert self.env.done
         clock = self.env.clock
-        row = {k: self.env.clock.get(k) for k in ['epi', 't']}
+        row = {k: self.env.clock.get(k) for k in ['epi', 'total_t', 't']}
         row.update({
             'reward': self.memory.total_reward,
             'loss': self.last_loss,

--- a/slm_lab/experiment/monitor.py
+++ b/slm_lab/experiment/monitor.py
@@ -400,6 +400,8 @@ class InfoSpace:
         # used to id experiment sharing the same spec name
         self.experiment_ts = util.get_ts()
         self.ckpt = None
+        # to load specific model in eval mode
+        self.eval_model_prepath = None
 
     def reset_lower_axes(cls, coor, axis):
         '''Reset the axes lower than the given axis in coor'''

--- a/slm_lab/experiment/monitor.py
+++ b/slm_lab/experiment/monitor.py
@@ -400,7 +400,9 @@ class InfoSpace:
         self.experiment_ts = util.get_ts()
         # ckpt gets appened to extend prepath using util.get_prepath for saving models, e.g. ckpt_str = ckpt-epi10-totalt1000
         # ckpt = 'eval' is special for eval mode, so data files will save with `ckpt-eval`; no models will be saved, but to load models with normal ckpt it will find them using eval_model_prepath
+        # e.g. 'epi24-totalt1000', 'eval', 'best'
         self.ckpt = None
+        # e.g. 'data/dqn_cartpole_2018_12_19_085843/dqn_cartpole_t0_s0_ckpt-epi24-totalt1000'
         self.eval_model_prepath = None
 
     def reset_lower_axes(cls, coor, axis):

--- a/slm_lab/lib/util.py
+++ b/slm_lab/lib/util.py
@@ -244,13 +244,13 @@ def get_prepath(spec, info_space, unit='experiment'):
     spec_name = spec['name']
     predir = f'data/{spec_name}_{info_space.experiment_ts}'
     prename = f'{spec_name}'
-    ckpt = ps.get(info_space, 'ckpt')
     trial_index = info_space.get('trial')
     session_index = info_space.get('session')
     if unit == 'trial':
         prename += f'_t{trial_index}'
     elif unit == 'session':
         prename += f'_t{trial_index}_s{session_index}'
+    ckpt = ps.get(info_space, 'ckpt')
     if ckpt is not None:
         prename += f'_ckpt{ckpt}'
     prepath = f'{predir}/{prename}'

--- a/slm_lab/lib/util.py
+++ b/slm_lab/lib/util.py
@@ -363,13 +363,10 @@ def override_dev_spec(spec):
 
 def override_enjoy_spec(spec):
     spec['meta']['max_session'] = 1
-    spec['meta']['max_trial'] = 1
     return spec
 
 
 def override_eval_spec(spec):
-    spec['meta']['max_session'] = 6
-    spec['meta']['max_trial'] = 1
     for agent_spec in spec['agent']:
         if 'max_size' in agent_spec['memory']:
             agent_spec['memory']['max_size'] = 1000

--- a/slm_lab/lib/util.py
+++ b/slm_lab/lib/util.py
@@ -17,7 +17,6 @@ import ujson
 import yaml
 
 NUM_CPUS = mp.cpu_count()
-NUM_EVAL_EPISODES = 100
 FILE_TS_FORMAT = '%Y_%m_%d_%H%M%S'
 RE_FILE_TS = re.compile(r'(\d{4}_\d{2}_\d{2}_\d{6})')
 SPACE_PATH = ['agent', 'agent_space', 'aeb_space', 'env_space', 'env']
@@ -339,7 +338,7 @@ def override_enjoy_spec(spec):
     return spec
 
 
-def override_eval_spec(spec):
+def override_eval_spec(spec, num_eval_epi=100):
     for agent_spec in spec['agent']:
         if 'max_size' in agent_spec['memory']:
             agent_spec['memory']['max_size'] = 100
@@ -347,7 +346,7 @@ def override_eval_spec(spec):
         # evaluate on episode basis
         if 'max_total_t' in env_spec:
             del env_spec['max_total_t']
-        env_spec['max_epi'] = NUM_EVAL_EPISODES
+        env_spec['max_epi'] = num_eval_epi
     return spec
 
 

--- a/slm_lab/lib/util.py
+++ b/slm_lab/lib/util.py
@@ -69,7 +69,7 @@ def cast_list(val):
 def clear_periodic_ckpt(prepath):
     '''Clear periodic (with -epi) ckpt files in prepath'''
     if '-epi' in prepath:
-        run_cmd(f'rm {prepath}*', wait=False)
+        run_cmd(f'rm {prepath}*')
 
 
 def concat_batches(batches):
@@ -524,25 +524,22 @@ def read_as_plain(data_path, **kwargs):
     return data
 
 
-def run_cmd(cmd, wait=False):
-    '''Run shell command, with wait or without'''
-    if wait:
-        stdout = subprocess.PIPE
-        stderr = subprocess.STDOUT
-    else:
-        stdout = stderr = subprocess.DEVNULL
+def run_cmd(cmd):
+    '''Run shell command'''
     print(f'+ {cmd}')
-    proc = subprocess.Popen(cmd, cwd=ROOT_DIR, shell=True, stdout=stdout, stderr=stderr, close_fds=True)
-    if wait:
-        for line in proc.stdout:
-            print(line.decode(), end='')
-        output = proc.communicate()[0]
-        if proc.returncode != 0:
-            raise subprocess.CalledProcessError(cmd, proc.returncode, output)
-        else:
-            return output
+    proc = subprocess.Popen(cmd, cwd=ROOT_DIR, shell=True, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, close_fds=True)
+    return proc
+
+
+def run_cmd_wait(proc):
+    '''Wait on a running process created by util.run_cmd and print its stdout'''
+    for line in proc.stdout:
+        print(line.decode(), end='')
+    output = proc.communicate()[0]
+    if proc.returncode != 0:
+        raise subprocess.CalledProcessError(proc.args, proc.returncode, output)
     else:
-        return proc
+        return output
 
 
 def s_get(cls, attr_path):

--- a/slm_lab/lib/util.py
+++ b/slm_lab/lib/util.py
@@ -80,7 +80,7 @@ def clear_ckpt(agent):
         f'rm {prepath}_ckpt-eval*spec*',
     ]
     for cmd in cmds:
-        subprocess.run(cmd, cwd=ROOT_DIR, shell=True, stderr=subprocess.DEVNULL, stdout=subprocess.DEVNULL, close_fds=True)
+        run_cmd(cmd, wait=True)
 
 
 def concat_batches(batches):
@@ -577,6 +577,26 @@ def read_as_plain(data_path, **kwargs):
         data = open_file.read()
     open_file.close()
     return data
+
+
+def run_cmd(cmd, wait=False):
+    '''Run shell command, with wait or without'''
+    if wait:
+        stdout = subprocess.PIPE
+        stderr = subprocess.STDOUT
+    else:
+        stdout = stderr = None
+    proc = subprocess.Popen(cmd, cwd=ROOT_DIR, shell=True, stdout=stdout, stderr=stderr, close_fds=True)
+    if wait:
+        for line in proc.stdout:
+            print(line.decode(), end='')
+        output = proc.communicate()[0]
+        if proc.returncode != 0:
+            raise subprocess.CalledProcessError(cmd, proc.returncode, output)
+        else:
+            return output
+    else:
+        return proc
 
 
 def s_get(cls, attr_path):

--- a/slm_lab/lib/util.py
+++ b/slm_lab/lib/util.py
@@ -369,8 +369,9 @@ def override_enjoy_spec(spec):
 def override_eval_spec(spec):
     for agent_spec in spec['agent']:
         if 'max_size' in agent_spec['memory']:
-            agent_spec['memory']['max_size'] = 1000
+            agent_spec['memory']['max_size'] = 100
     for env_spec in spec['env']:
+        # evaluate on episode basis
         if 'max_total_t' in env_spec:
             del env_spec['max_total_t']
         env_spec['max_epi'] = NUM_EVAL_EPISODES

--- a/slm_lab/lib/util.py
+++ b/slm_lab/lib/util.py
@@ -69,18 +69,10 @@ def cast_list(val):
         return [val]
 
 
-def clear_ckpt(agent):
-    '''Clear ckpt{last} files in prepath'''
-    prepath = get_prepath(agent.spec, agent.info_space, unit='session')
-    cmds = [
-        # remove all normal ckpt with the form ckpt-epi10-totalt-1000
-        f'rm {prepath}_ckpt-epi*',
-        # remove useless eval byproducts
-        f'rm {prepath}_ckpt-eval*fitness*',
-        f'rm {prepath}_ckpt-eval*spec*',
-    ]
-    for cmd in cmds:
-        run_cmd(cmd, wait=True)
+def clear_periodic_ckpt(prepath):
+    '''Clear periodic (with -epi) ckpt files in prepath'''
+    if '-epi' in prepath:
+        run_cmd(f'rm {prepath}*', wait=False)
 
 
 def concat_batches(batches):
@@ -586,6 +578,7 @@ def run_cmd(cmd, wait=False):
         stderr = subprocess.STDOUT
     else:
         stdout = stderr = None
+    print(f'+ {cmd}')
     proc = subprocess.Popen(cmd, cwd=ROOT_DIR, shell=True, stdout=stdout, stderr=stderr, close_fds=True)
     if wait:
         for line in proc.stdout:

--- a/slm_lab/lib/util.py
+++ b/slm_lab/lib/util.py
@@ -638,9 +638,9 @@ def set_rand_seed(random_seed, env_space):
             pass
 
 
-def set_session_logger(spec, info_space, logger):
-    '''Set the logger for a session give its spec and info_space'''
-    os.environ['PREPATH'] = get_prepath(spec, info_space, unit='session')
+def set_logger(spec, info_space, logger, unit=None):
+    '''Set the logger for a lab unit give its spec and info_space'''
+    os.environ['PREPATH'] = get_prepath(spec, info_space, unit=unit)
     reload(logger)  # to set session-specific logger
 
 

--- a/slm_lab/lib/util.py
+++ b/slm_lab/lib/util.py
@@ -70,6 +70,13 @@ def cast_list(val):
         return [val]
 
 
+def clear_ckpt(agent):
+    '''Clear ckpt{last} files in prepath'''
+    prepath = get_prepath(agent.spec, agent.info_space, unit='session')
+    ckpt_path = f'{prepath}_ckptlast*'
+    subprocess.run(f'rm {ckpt_path}', cwd=ROOT_DIR, shell=True, stderr=subprocess.DEVNULL, stdout=subprocess.DEVNULL, close_fds=True)
+
+
 def concat_batches(batches):
     '''
     Concat batch objects from body.memory.sample() into one batch, when all bodies experience similar envs

--- a/slm_lab/lib/util.py
+++ b/slm_lab/lib/util.py
@@ -75,6 +75,9 @@ def clear_ckpt(agent):
     cmds = [
         # remove all normal ckpt with the form ckpt-epi10-totalt-1000
         f'rm {prepath}_ckpt-epi*',
+        # remove useless eval byproducts
+        f'rm {prepath}_ckpt-eval*fitness*',
+        f'rm {prepath}_ckpt-eval*spec*',
     ]
     for cmd in cmds:
         subprocess.run(cmd, cwd=ROOT_DIR, shell=True, stderr=subprocess.DEVNULL, stdout=subprocess.DEVNULL, close_fds=True)
@@ -481,8 +484,10 @@ def prepath_to_idxs(prepath):
 def prepath_to_spec(prepath):
     '''Create spec from prepath such that it returns the same prepath with info_space'''
     predir, _, prename, _, _, _ = prepath_split(prepath)
-    prename_no_s = '_'.join(prename.split('_')[:-1])
-    spec_path = f'{predir}/{prename_no_s}_spec.json'
+    sidx_res = re.search('_s\d+', prename)
+    if sidx_res:  # replace the _s0 if any
+        prename = prename.replace(sidx_res[0], '')
+    spec_path = f'{predir}/{prename}_spec.json'
     # read the spec of prepath
     spec = read(spec_path)
     return spec

--- a/slm_lab/lib/util.py
+++ b/slm_lab/lib/util.py
@@ -149,6 +149,16 @@ def downcast_float32(df):
     return df
 
 
+def find_ckpt(prepath):
+    '''Find the ckpt-lorem-ipsum in a string and return lorem-ipsum'''
+    if 'ckpt' in prepath:
+        ckpt_str = ps.find(prepath.split('_'), lambda s: s.startswith('ckpt'))
+        ckpt = ckpt_str.replace('ckpt-', '')
+    else:
+        ckpt = None
+    return ckpt
+
+
 def flatten_dict(obj, delim='.'):
     '''Missing pydash method to flatten dict'''
     nobj = {}
@@ -435,17 +445,15 @@ def prepath_split(prepath):
     prename: dqn_pong_t0_s0
     spec_name: dqn_pong
     experiment_ts: 2018_12_02_082510
-    ckpt: ckptbest of dqn_pong_t0_s0_ckptbest if available
+    ckpt: ckpt-best of dqn_pong_t0_s0_ckpt-best if available
     '''
     prepath = prepath.strip('_')
     tail = prepath.split('data/')[-1]
-    if '_ckpt' in tail:
-        ckpt_chunk = ps.find(tail.split('_'), lambda s: s.startswith('ckpt'))
-        tail = tail.replace(f'_{ckpt_chunk}', '')
-        ckpt = ckpt_chunk.replace('ckpt', '')
-    else:
-        ckpt = None
-    if '/' in tail:
+    ckpt = find_ckpt(tail)
+    if ckpt is not None:  # separate ckpt
+        tail = tail.replace(f'_{ckpt_str}', '')
+
+    if '/' in tail:  # tail = prefolder/prename
         prefolder, prename = tail.split('/')
     else:
         prefolder, prename = tail, None

--- a/slm_lab/lib/util.py
+++ b/slm_lab/lib/util.py
@@ -577,7 +577,7 @@ def run_cmd(cmd, wait=False):
         stdout = subprocess.PIPE
         stderr = subprocess.STDOUT
     else:
-        stdout = stderr = None
+        stdout = stderr = subprocess.DEVNULL
     print(f'+ {cmd}')
     proc = subprocess.Popen(cmd, cwd=ROOT_DIR, shell=True, stdout=stdout, stderr=stderr, close_fds=True)
     if wait:

--- a/slm_lab/lib/util.py
+++ b/slm_lab/lib/util.py
@@ -375,7 +375,6 @@ def override_enjoy_spec(spec):
 def override_eval_spec(spec):
     spec['meta']['max_session'] = 6
     spec['meta']['max_trial'] = 1
-    spec['meta']['graph_x'] = 'epi'
     for agent_spec in spec['agent']:
         if 'max_size' in agent_spec['memory']:
             agent_spec['memory']['max_size'] = 1000

--- a/slm_lab/lib/util.py
+++ b/slm_lab/lib/util.py
@@ -4,7 +4,6 @@ from slm_lab import ROOT_DIR
 import cv2
 import glob
 import json
-import math
 import numpy as np
 import operator
 import os

--- a/slm_lab/lib/util.py
+++ b/slm_lab/lib/util.py
@@ -272,7 +272,7 @@ def get_prepath(spec, info_space, unit='experiment'):
         prename += f'_t{trial_index}_s{session_index}'
     ckpt = ps.get(info_space, 'ckpt')
     if ckpt is not None:
-        prename += f'_ckpt{ckpt}'
+        prename += f'_ckpt-{ckpt}'
     prepath = f'{predir}/{prename}'
     return prepath
 
@@ -450,8 +450,7 @@ def prepath_split(prepath):
     tail = prepath.split('data/')[-1]
     ckpt = find_ckpt(tail)
     if ckpt is not None:  # separate ckpt
-        tail = tail.replace(f'_{ckpt_str}', '')
-
+        tail = tail.replace(f'_ckpt-{ckpt}', '')
     if '/' in tail:  # tail = prefolder/prename
         prefolder, prename = tail.split('/')
     else:

--- a/slm_lab/lib/util.py
+++ b/slm_lab/lib/util.py
@@ -407,7 +407,9 @@ def prepare_directory(new_spec, new_info_space, original_spec, original_info_spa
     new_predir, _, _, _, _, _ = prepath_split(new_prepath)
     new_trial_name = f'{new_prepath}_t0'
     original_trial_name = f'{predir}/{spec_name}_t{trial}'
-    original_session_name = f'{original_trial_name}_s{session}_ckpt{ckpt}'
+    original_session_name = f'{original_trial_name}_s{session}'
+    if ckpt is not None:
+        original_session_name = f'{original_session_name}_ckpt{ckpt}'
     copy_spec(original_trial_name, new_trial_name)
     copy_original_models(original_session_name, predir, new_predir)
     copy_models(original_session_name, new_trial_name, new_spec['meta']['max_session'])

--- a/slm_lab/lib/util.py
+++ b/slm_lab/lib/util.py
@@ -73,9 +73,8 @@ def clear_ckpt(agent):
     '''Clear ckpt{last} files in prepath'''
     prepath = get_prepath(agent.spec, agent.info_space, unit='session')
     cmds = [
-        f'rm {prepath}_ckptlast*',
-        f'rm {prepath}_ckpteval*spec*',
-        f'rm {prepath}_ckpteval*fitness*',
+        # remove all normal ckpt with the form ckpt-epi10-totalt-1000
+        f'rm {prepath}_ckpt-epi*',
     ]
     for cmd in cmds:
         subprocess.run(cmd, cwd=ROOT_DIR, shell=True, stderr=subprocess.DEVNULL, stdout=subprocess.DEVNULL, close_fds=True)

--- a/slm_lab/lib/util.py
+++ b/slm_lab/lib/util.py
@@ -72,8 +72,13 @@ def cast_list(val):
 def clear_ckpt(agent):
     '''Clear ckpt{last} files in prepath'''
     prepath = get_prepath(agent.spec, agent.info_space, unit='session')
-    ckpt_path = f'{prepath}_ckptlast*'
-    subprocess.run(f'rm {ckpt_path}', cwd=ROOT_DIR, shell=True, stderr=subprocess.DEVNULL, stdout=subprocess.DEVNULL, close_fds=True)
+    cmds = [
+        f'rm {prepath}_ckptlast*',
+        f'rm {prepath}_ckpteval*spec*',
+        f'rm {prepath}_ckpteval*fitness*',
+    ]
+    for cmd in cmds:
+        subprocess.run(cmd, cwd=ROOT_DIR, shell=True, stderr=subprocess.DEVNULL, stdout=subprocess.DEVNULL, close_fds=True)
 
 
 def concat_batches(batches):

--- a/slm_lab/lib/viz.py
+++ b/slm_lab/lib/viz.py
@@ -221,7 +221,7 @@ def save_image(figure, filepath=None):
         logger.info(f'Graph saved to {filepath}')
     except Exception as e:
         logger.warn(
-            '{e}\nFailed to generate graph. Fix the issue and run retro-analysis to generate graphs.')
+            f'{e}\nFailed to generate graph. Fix the issue and run retro-analysis to generate graphs.')
 
 
 def stack_cumsum(df, y_col):

--- a/slm_lab/spec/demo.json
+++ b/slm_lab/spec/demo.json
@@ -64,6 +64,7 @@
       "max_trial": 4,
       "max_session": 4,
       "graph_x": "total_t",
+      "training_eval": false,
       "search": "RandomSearch",
       "resources": {
         "num_cpus": 4,

--- a/slm_lab/spec/demo.json
+++ b/slm_lab/spec/demo.json
@@ -52,8 +52,8 @@
     "env": [{
       "name": "CartPole-v0",
       "max_t": null,
-      "max_total_t": 20000,
-      "save_frequency": 10000
+      "max_total_t": 10000,
+      "save_frequency": 2000
     }],
     "body": {
       "product": "outer",

--- a/slm_lab/spec/demo.json
+++ b/slm_lab/spec/demo.json
@@ -61,9 +61,9 @@
     },
     "meta": {
       "distributed": false,
-      "graph_x": "epi",
       "max_trial": 4,
       "max_session": 4,
+      "graph_x": "total_t",
       "search": "RandomSearch",
       "resources": {
         "num_cpus": 4,

--- a/slm_lab/spec/experimental/ddqn_beamrider.json
+++ b/slm_lab/spec/experimental/ddqn_beamrider.json
@@ -70,6 +70,7 @@
       "graph_x": "total_t",
       "max_session": 1,
       "max_trial": 16,
+      "training_eval": true,
       "search": "RandomSearch",
       "resources": {
         "num_cpus": 16

--- a/slm_lab/spec/experimental/ddqn_breakout.json
+++ b/slm_lab/spec/experimental/ddqn_breakout.json
@@ -70,6 +70,7 @@
       "graph_x": "total_t",
       "max_session": 1,
       "max_trial": 16,
+      "training_eval": true,
       "search": "RandomSearch",
       "resources": {
         "num_cpus": 16

--- a/slm_lab/spec/experimental/ddqn_enduro.json
+++ b/slm_lab/spec/experimental/ddqn_enduro.json
@@ -70,6 +70,7 @@
       "graph_x": "total_t",
       "max_session": 1,
       "max_trial": 16,
+      "training_eval": true,
       "search": "RandomSearch",
       "resources": {
         "num_cpus": 16

--- a/slm_lab/spec/experimental/ddqn_pong.json
+++ b/slm_lab/spec/experimental/ddqn_pong.json
@@ -70,6 +70,7 @@
       "graph_x": "total_t",
       "max_session": 1,
       "max_trial": 16,
+      "training_eval": true,
       "search": "RandomSearch",
       "resources": {
         "num_cpus": 16

--- a/slm_lab/spec/experimental/ddqn_qbert.json
+++ b/slm_lab/spec/experimental/ddqn_qbert.json
@@ -70,6 +70,7 @@
       "graph_x": "total_t",
       "max_session": 1,
       "max_trial": 16,
+      "training_eval": true,
       "search": "RandomSearch",
       "resources": {
         "num_cpus": 16

--- a/slm_lab/spec/experimental/ddqn_seaquest.json
+++ b/slm_lab/spec/experimental/ddqn_seaquest.json
@@ -70,6 +70,7 @@
       "graph_x": "total_t",
       "max_session": 1,
       "max_trial": 16,
+      "training_eval": true,
       "search": "RandomSearch",
       "resources": {
         "num_cpus": 16

--- a/slm_lab/spec/experimental/ddqn_spaceinvaders.json
+++ b/slm_lab/spec/experimental/ddqn_spaceinvaders.json
@@ -70,6 +70,7 @@
       "graph_x": "total_t",
       "max_session": 1,
       "max_trial": 16,
+      "training_eval": true,
       "search": "RandomSearch",
       "resources": {
         "num_cpus": 16

--- a/slm_lab/spec/experimental/dqn_beamrider.json
+++ b/slm_lab/spec/experimental/dqn_beamrider.json
@@ -61,7 +61,7 @@
     "env": [{
       "name": "BeamRiderNoFrameskip-v4",
       "max_t": null,
-      "max_total_t": 20000000,
+      "max_total_t": 10000000,
       "save_frequency": 100000
     }],
     "body": {
@@ -152,7 +152,7 @@
     "env": [{
       "name": "BeamRiderNoFrameskip-v4",
       "max_t": null,
-      "max_total_t": 20000000,
+      "max_total_t": 10000000,
       "save_frequency": 100000
     }],
     "body": {

--- a/slm_lab/spec/experimental/dqn_beamrider.json
+++ b/slm_lab/spec/experimental/dqn_beamrider.json
@@ -164,6 +164,7 @@
       "graph_x": "total_t",
       "max_session": 1,
       "max_trial": 12,
+      "training_eval": true,
       "search": "RandomSearch",
       "resources": {
         "num_cpus": 12

--- a/slm_lab/spec/experimental/dqn_beamrider.json
+++ b/slm_lab/spec/experimental/dqn_beamrider.json
@@ -25,7 +25,10 @@
         "batch_size": 32,
         "max_size": 250000,
         "stack_len": 4,
-        "use_cer": false
+        "use_cer": false,
+        "alpha": 0.6,
+        "epsilon": 1e-6,
+
       },
       "net": {
         "type": "ConvNet",
@@ -58,7 +61,7 @@
     "env": [{
       "name": "BeamRiderNoFrameskip-v4",
       "max_t": null,
-      "max_total_t": 10000000,
+      "max_total_t": 20000000,
       "save_frequency": 100000
     }],
     "body": {
@@ -69,11 +72,113 @@
       "distributed": false,
       "graph_x": "total_t",
       "max_session": 1,
-      "max_trial": 16,
+      "max_trial": 12,
       "search": "RandomSearch",
       "resources": {
-        "num_cpus": 16
+        "num_cpus": 12
       }
+    },
+    "search": {
+      "agent": [{
+        "net": {
+          "init_fn__choice": [null, "orthogonal_"],
+        },
+        "memory": {
+          "name__choice": ["AtariPrioritizedReplay", "AtariReplay"],
+          "batch_size__choice": [32, 64],
+        },
+      }]
+    }
+  },
+  "dqn_beamrider_polyak": {
+    "agent": [{
+      "name": "DQN",
+      "algorithm": {
+        "name": "DQN",
+        "action_pdtype": "Argmax",
+        "action_policy": "epsilon_greedy",
+        "explore_var_spec": {
+          "name": "linear_decay",
+          "start_val": 1.0,
+          "end_val": 0.05,
+          "start_step": 30000,
+          "end_step": 1000000
+        },
+        "gamma": 0.99,
+        "training_batch_epoch": 1,
+        "training_epoch": 1,
+        "training_frequency": 4,
+        "training_start_step": 30000,
+        "normalize_state": false
+      },
+      "memory": {
+        "name": "AtariReplay",
+        "batch_size": 32,
+        "max_size": 250000,
+        "stack_len": 4,
+        "use_cer": false,
+        "alpha": 0.6,
+        "epsilon": 1e-6,
+
+      },
+      "net": {
+        "type": "ConvNet",
+        "conv_hid_layers": [
+          [32, 8, 4, 0, 1],
+          [64, 4, 2, 0, 1],
+          [64, 3, 1, 0, 1]
+        ],
+        "fc_hid_layers": [512],
+        "hid_layers_activation": "relu",
+        "init_fn": null,
+        "batch_norm": false,
+        "clip_grad_val": 1.0,
+        "loss_spec": {
+          "name": "SmoothL1Loss"
+        },
+        "optim_spec": {
+          "name": "RMSprop",
+          "lr": 2.5e-4,
+          "alpha": 0.95,
+          "eps": 1e-1,
+          "momentum": 0.95
+        },
+        "lr_scheduler_spec": null,
+        "update_type": "polyak",
+        "polyak_coef": 0.9993,
+        "gpu": true
+      }
+    }],
+    "env": [{
+      "name": "BeamRiderNoFrameskip-v4",
+      "max_t": null,
+      "max_total_t": 20000000,
+      "save_frequency": 100000
+    }],
+    "body": {
+      "product": "outer",
+      "num": 1
+    },
+    "meta": {
+      "distributed": false,
+      "graph_x": "total_t",
+      "max_session": 1,
+      "max_trial": 12,
+      "search": "RandomSearch",
+      "resources": {
+        "num_cpus": 12
+      }
+    },
+    "search": {
+      "agent": [{
+        "net": {
+          "init_fn__choice": [null, "orthogonal_"],
+        },
+        "memory": {
+          "name__choice": ["AtariPrioritizedReplay", "AtariReplay"],
+          "batch_size__choice": [32, 64],
+        },
+      }]
     }
   }
 }

--- a/slm_lab/spec/experimental/dqn_breakout.json
+++ b/slm_lab/spec/experimental/dqn_breakout.json
@@ -70,6 +70,7 @@
       "graph_x": "total_t",
       "max_session": 1,
       "max_trial": 16,
+      "training_eval": true,
       "search": "RandomSearch",
       "resources": {
         "num_cpus": 16

--- a/slm_lab/spec/experimental/dqn_enduro.json
+++ b/slm_lab/spec/experimental/dqn_enduro.json
@@ -70,6 +70,7 @@
       "graph_x": "total_t",
       "max_session": 1,
       "max_trial": 16,
+      "training_eval": true,
       "search": "RandomSearch",
       "resources": {
         "num_cpus": 16

--- a/slm_lab/spec/experimental/dqn_pong.json
+++ b/slm_lab/spec/experimental/dqn_pong.json
@@ -70,6 +70,7 @@
       "graph_x": "total_t",
       "max_session": 1,
       "max_trial": 16,
+      "training_eval": true,
       "search": "RandomSearch",
       "resources": {
         "num_cpus": 16

--- a/slm_lab/spec/experimental/dqn_qbert.json
+++ b/slm_lab/spec/experimental/dqn_qbert.json
@@ -70,6 +70,7 @@
       "graph_x": "total_t",
       "max_session": 1,
       "max_trial": 16,
+      "training_eval": true,
       "search": "RandomSearch",
       "resources": {
         "num_cpus": 16

--- a/slm_lab/spec/experimental/dqn_seaquest.json
+++ b/slm_lab/spec/experimental/dqn_seaquest.json
@@ -70,6 +70,7 @@
       "graph_x": "total_t",
       "max_session": 1,
       "max_trial": 16,
+      "training_eval": true,
       "search": "RandomSearch",
       "resources": {
         "num_cpus": 16

--- a/slm_lab/spec/experimental/dqn_spaceinvaders.json
+++ b/slm_lab/spec/experimental/dqn_spaceinvaders.json
@@ -70,6 +70,7 @@
       "graph_x": "total_t",
       "max_session": 1,
       "max_trial": 16,
+      "training_eval": true,
       "search": "RandomSearch",
       "resources": {
         "num_cpus": 16

--- a/slm_lab/spec/spec_util.py
+++ b/slm_lab/spec/spec_util.py
@@ -113,11 +113,16 @@ def get(spec_file, spec_name):
 
     spec = spec_util.get('base.json', 'base_case_openai')
     '''
-    spec_dict = util.read(f'{SPEC_DIR}/{spec_file}')
-    assert spec_name in spec_dict, f'spec_name {spec_name} is not in spec_file {spec_file}. Choose from:\n {ps.join(spec_dict.keys(), ",")}'
-    spec = spec_dict[spec_name]
-    spec['name'] = spec_name
-    spec['git_SHA'] = util.get_git_sha()
+    if 'data/' in spec_file:
+        assert spec_name in spec_file, 'spec_file in data/ must be lab-generated and contains spec_name'
+        spec = util.read(spec_file)
+    else:
+        spec_file = f'{SPEC_DIR}/{spec_file}'  # allow direct filename
+        spec_dict = util.read(spec_file)
+        assert spec_name in spec_dict, f'spec_name {spec_name} is not in spec_file {spec_file}. Choose from:\n {ps.join(spec_dict.keys(), ",")}'
+        spec = spec_dict[spec_name]
+        spec['name'] = spec_name
+        spec['git_SHA'] = util.get_git_sha()
     check(spec)
     return spec
 


### PR DESCRIPTION
## Add online eval during train mode
- enabled by meta spec `'training_eval'`
- configure `NUM_EVAL_EPI` in `analysis.py`
- update `enjoy` and `eval` mode syntax. see README.
- change ckpt behavior to use e.g. tag `ckpt-epi10-totalt1000`
- add new `eval` mode to lab. runs on a checkpoint file. see below

### Eval Session
- add a proper eval Session which loads from the ckpt like above, and does not interfere with existing files. This can be ran on terminal, and it's also used by the internal eval logic, e.g. command `python run_lab.py data/dqn_cartpole_2018_12_20_214412/dqn_cartpole_t0_spec.json dqn_cartpole eval@dqn_cartpole_t0_s2_ckpt-epi10-totalt1000`
- when eval session is done, it will average all of its ran episodes and append to a row in an `eval_session_df.csv`
- after that it will delete the ckpt files it had just used (to prevent large storage)
- then, it will run a trial analysis to update `eval_trial_graph.png`, and an accompanying `trial_df` as average of all `session_df`s

### How eval mode works
- checkpoint will save the models using the scheme which records its `epi` and `total_t`. This allows one to eval using the ckpt model
- after creating ckpt files, if `spec.meta.training_eval in `train` mode, a subprocess will launch using the ckpt prepath to run an eval Session, using the same way above `python run_lab.py data/dqn_cartpole_2018_12_20_214412/dqn_cartpole_t0_spec.json dqn_cartpole eval@dqn_cartpole_t0_s2_ckpt-epi10-totalt1000`
- eval session runs as above. ckpt will now run at the starting timestep, ckpt timestep, and at the end
- the main Session will wait for the final eval session and it's final eval trial to finish before closing, to ensure that other processes like zipping wait for them.

Example eval trial graph:

![dqn_cartpole_t0_ckpt-eval_trial_graph](https://user-images.githubusercontent.com/8209263/50327674-eaaf1080-04a4-11e9-8586-1ca025aec3e0.png)

## fix PER
- minor fix for PER