### PR TITLE
Make epi start from 0 instead of 1

### DIFF
--- a/slm_lab/agent/algorithm/actor_critic.py
+++ b/slm_lab/agent/algorithm/actor_critic.py
@@ -227,7 +227,7 @@ class ActorCritic(Reinforce):
             # reset
             self.to_train = 0
             self.body.flush()
-            logger.debug(f'Trained {self.name} at epi: {clock.get("epi")}, total_t: {clock.get("total_t")}, t: {clock.get("t")}, total_reward so far: {self.body.memory.total_reward}, loss: {loss:.8f}')
+            logger.debug(f'Trained {self.name} at epi: {clock.epi}, total_t: {clock.total_t}, t: {clock.t}, total_reward so far: {self.body.memory.total_reward}, loss: {loss:.8f}')
 
             return loss.item()
         else:

--- a/slm_lab/agent/algorithm/dqn.py
+++ b/slm_lab/agent/algorithm/dqn.py
@@ -148,7 +148,7 @@ class VanillaDQN(SARSA):
             # reset
             self.to_train = 0
             self.body.flush()
-            logger.debug(f'Trained {self.name} at epi: {clock.get("epi")}, total_t: {clock.get("total_t")}, t: {clock.get("t")}, total_reward so far: {self.body.memory.total_reward}, loss: {loss:.8f}')
+            logger.debug(f'Trained {self.name} at epi: {clock.epi}, total_t: {clock.total_t}, t: {clock.t}, total_reward so far: {self.body.memory.total_reward}, loss: {loss:.8f}')
             return loss.item()
         else:
             return np.nan
@@ -214,7 +214,7 @@ class DQNBase(VanillaDQN):
         return q_loss
 
     def update_nets(self):
-        total_t = self.body.env.clock.get('total_t')
+        total_t = self.body.env.clock.total_t
         if self.net.update_type == 'replace':
             if total_t % self.net.update_frequency == 0:
                 logger.debug('Updating target_net by replacing')
@@ -295,7 +295,7 @@ class DoubleDQN(DQN):
 
     def update_nets(self):
         res = super(DoubleDQN, self).update_nets()
-        total_t = self.body.env.clock.get('total_t')
+        total_t = self.body.env.clock.total_t
         if self.net.update_type == 'replace':
             if total_t % self.net.update_frequency == 0:
                 self.online_net = self.net

--- a/slm_lab/agent/algorithm/hydra_dqn.py
+++ b/slm_lab/agent/algorithm/hydra_dqn.py
@@ -120,7 +120,7 @@ class HydraDQN(DQN):
             self.to_train = 0
             for body in self.agent.nanflat_body_a:
                 body.flush()
-            logger.debug(f'Trained {self.name} at epi: {clock.get("epi")}, total_t: {clock.get("total_t")}, t: {clock.get("t")}, total_reward so far: {self.body.memory.total_reward}, loss: {loss:.8f}')
+            logger.debug(f'Trained {self.name} at epi: {clock.epi}, total_t: {clock.total_t}, t: {clock.t}, total_reward so far: {self.body.memory.total_reward}, loss: {loss:.8f}')
 
             return loss.item()
         else:

--- a/slm_lab/agent/algorithm/ppo.py
+++ b/slm_lab/agent/algorithm/ppo.py
@@ -174,7 +174,7 @@ class PPO(ActorCritic):
             # reset
             self.to_train = 0
             self.body.flush()
-            logger.debug(f'Trained {self.name} at epi: {clock.get("epi")}, total_t: {clock.get("total_t")}, t: {clock.get("t")}, total_reward so far: {self.body.memory.total_reward}, loss: {loss:.8f}')
+            logger.debug(f'Trained {self.name} at epi: {clock.epi}, total_t: {clock.total_t}, t: {clock.t}, total_reward so far: {self.body.memory.total_reward}, loss: {loss:.8f}')
 
             return loss.item()
         else:
@@ -195,7 +195,7 @@ class PPO(ActorCritic):
             # reset
             self.to_train = 0
             self.body.flush()
-            logger.debug(f'Trained {self.name} at epi: {clock.get("epi")}, total_t: {clock.get("total_t")}, t: {clock.get("t")}, total_reward so far: {self.body.memory.total_reward}, loss: {loss:.8f}')
+            logger.debug(f'Trained {self.name} at epi: {clock.epi}, total_t: {clock.total_t}, t: {clock.t}, total_reward so far: {self.body.memory.total_reward}, loss: {loss:.8f}')
 
             return loss.item()
         else:

--- a/slm_lab/agent/algorithm/reinforce.py
+++ b/slm_lab/agent/algorithm/reinforce.py
@@ -141,7 +141,7 @@ class Reinforce(Algorithm):
             # reset
             self.to_train = 0
             self.body.flush()
-            logger.debug(f'Trained {self.name} at epi: {clock.get("epi")}, total_t: {clock.get("total_t")}, t: {clock.get("t")}, total_reward so far: {self.body.memory.total_reward}, loss: {loss:.8f}')
+            logger.debug(f'Trained {self.name} at epi: {clock.epi}, total_t: {clock.total_t}, t: {clock.t}, total_reward so far: {self.body.memory.total_reward}, loss: {loss:.8f}')
 
             return loss.item()
         else:

--- a/slm_lab/agent/algorithm/sarsa.py
+++ b/slm_lab/agent/algorithm/sarsa.py
@@ -153,7 +153,7 @@ class SARSA(Algorithm):
             # reset
             self.to_train = 0
             self.body.flush()
-            logger.debug(f'Trained {self.name} at epi: {clock.get("epi")}, total_t: {clock.get("total_t")}, t: {clock.get("t")}, total_reward so far: {self.body.memory.total_reward}, loss: {loss:.8f}')
+            logger.debug(f'Trained {self.name} at epi: {clock.epi}, total_t: {clock.total_t}, t: {clock.t}, total_reward so far: {self.body.memory.total_reward}, loss: {loss:.8f}')
 
             return loss.item()
         else:

--- a/slm_lab/agent/algorithm/sil.py
+++ b/slm_lab/agent/algorithm/sil.py
@@ -151,7 +151,7 @@ class SIL(ActorCritic):
                     total_sil_loss += sil_loss
             sil_loss = total_sil_loss / self.training_epoch
             loss = super_loss + sil_loss
-            logger.debug(f'Trained {self.name} at epi: {clock.get("epi")}, total_t: {clock.get("total_t")}, t: {clock.get("t")}, total_reward so far: {self.body.memory.total_reward}, loss: {loss:.8f}')
+            logger.debug(f'Trained {self.name} at epi: {clock.epi}, total_t: {clock.total_t}, t: {clock.t}, total_reward so far: {self.body.memory.total_reward}, loss: {loss:.8f}')
 
             return loss.item()
         else:
@@ -176,7 +176,7 @@ class SIL(ActorCritic):
                     total_sil_loss += sil_policy_loss + sil_val_loss
             sil_loss = total_sil_loss / self.training_epoch
             loss = super_loss + sil_loss
-            logger.debug(f'Trained {self.name} at epi: {clock.get("epi")}, total_t: {clock.get("total_t")}, t: {clock.get("t")}, total_reward so far: {self.body.memory.total_reward}, loss: {loss:.8f}')
+            logger.debug(f'Trained {self.name} at epi: {clock.epi}, total_t: {clock.total_t}, t: {clock.t}, total_reward so far: {self.body.memory.total_reward}, loss: {loss:.8f}')
 
             return loss.item()
         else:

--- a/slm_lab/env/base.py
+++ b/slm_lab/env/base.py
@@ -29,14 +29,14 @@ def set_gym_space_attr(gym_space):
 
 
 class Clock:
-    '''Clock class for each env and space to keep track of relative time. Ticking and control loop is such that reset is at t=0, but epi begins at 1, env step begins at 1.'''
+    '''Clock class for each env and space to keep track of relative time. Ticking and control loop is such that reset is at t=0 and epi=0'''
 
     def __init__(self, clock_speed=1):
         self.clock_speed = int(clock_speed)
         self.ticks = 0  # multiple ticks make a timestep; used for clock speed
         self.t = 0
         self.total_t = 0
-        self.epi = 0
+        self.epi = -1  # offset so epi is 0 when it gets ticked at start
 
     def to_step(self):
         '''Step signal from clock_speed. Step only if the base unit of time in this clock has moved. Used to control if env of different clock_speed should step()'''

--- a/slm_lab/env/openai.py
+++ b/slm_lab/env/openai.py
@@ -72,7 +72,7 @@ class OpenAIEnv(BaseEnv):
         if util.to_render():
             self.u_env.render()
         if self.max_t is not None:
-            done = done or self.clock.get('t') > self.max_t
+            done = done or self.clock.t > self.max_t
         self.done = done
         logger.debug(f'Env {self.e} step reward: {reward}, state: {state}, done: {done}')
         return reward, state, done
@@ -115,7 +115,7 @@ class OpenAIEnv(BaseEnv):
         reward *= self.reward_scale
         if util.to_render():
             self.u_env.render()
-        self.done = done = done or self.clock.get('t') > self.max_t
+        self.done = done = done or self.clock.t > self.max_t
         reward_e, state_e, done_e = self.env_space.aeb_space.init_data_s(ENV_DATA_NAMES, e=self.e)
         for ab, body in util.ndenumerate_nonan(self.body_e):
             reward_e[ab] = reward

--- a/slm_lab/env/unity.py
+++ b/slm_lab/env/unity.py
@@ -141,7 +141,7 @@ class UnityEnv(BaseEnv):
         reward = env_info_a.rewards[b] * self.reward_scale
         state = env_info_a.states[b]
         done = env_info_a.local_done[b]
-        self.done = done = done or self.clock.get('t') > self.max_t
+        self.done = done = done or self.clock.t > self.max_t
         logger.debug(f'Env {self.e} step reward: {reward}, state: {state}, done: {done}')
         return reward, state, done
 
@@ -187,6 +187,6 @@ class UnityEnv(BaseEnv):
             reward_e[(a, b)] = env_info_a.rewards[b] * self.reward_scale
             state_e[(a, b)] = env_info_a.states[b]
             done_e[(a, b)] = env_info_a.local_done[b]
-        self.done = (util.nonan_all(done_e) or self.clock.get('t') > self.max_t)
+        self.done = (util.nonan_all(done_e) or self.clock.t > self.max_t)
         logger.debug(f'Env {self.e} step reward_e: {reward_e}, state_e: {state_e}, done_e: {done_e}')
         return reward_e, state_e, done_e

--- a/slm_lab/experiment/control.py
+++ b/slm_lab/experiment/control.py
@@ -47,15 +47,12 @@ class Session:
         tick = clock.get(env.max_tick_unit)
         if util.get_lab_mode() in ('enjoy', 'eval'):
             to_ckpt = False
-        elif os.environ.get('PY_ENV') != 'test' and ((env.max_tick_unit == 'epi' and tick == 1) or (tick == 0)):
-            to_ckpt = True  # ckpt at beginning, but epi starts at 1
-        elif hasattr(env, 'save_frequency') and 0 < tick <= env.max_tick:
-            if env.max_tick_unit == 'epi':
-                to_ckpt = (env.done and tick % env.save_frequency == 0)
-            else:
-                to_ckpt = (tick % env.save_frequency == 0)
+        elif tick <= env.max_tick:
+            to_ckpt = tick % env.save_frequency == 0
         else:
             to_ckpt = False
+        if env.max_tick_unit == 'epi':  # extra condition for epi
+            to_ckpt = to_ckpt and env.done
 
         if to_ckpt:
             ckpt = f'epi{clock.get("epi")}-totalt{clock.get("total_t")}'

--- a/slm_lab/experiment/control.py
+++ b/slm_lab/experiment/control.py
@@ -55,7 +55,7 @@ class Session:
             to_ckpt = to_ckpt and env.done
 
         if to_ckpt:
-            ckpt = f'epi{clock.get("epi")}-totalt{clock.get("total_t")}'
+            ckpt = f'epi{clock.epi}-totalt{clock.total_t}'
             agent.save(ckpt=ckpt)
             if analysis.new_best(agent):
                 agent.save(ckpt='best')
@@ -68,7 +68,7 @@ class Session:
 
     def run_episode(self):
         self.env.clock.tick('epi')
-        logger.info(f'Running trial {self.info_space.get("trial")} session {self.index} episode {self.env.clock.get("epi")}')
+        logger.info(f'Running trial {self.info_space.get("trial")} session {self.index} episode {self.env.clock.epi}')
         reward, state, done = self.env.reset()
         self.agent.reset(state)
         while not done:

--- a/slm_lab/experiment/monitor.py
+++ b/slm_lab/experiment/monitor.py
@@ -383,7 +383,7 @@ class AEBSpace:
                 for body in env.nanflat_body_e:
                     body.log_summary()
             env.clock.tick(unit or ('epi' if env.done else 't'))
-            end_session = env.clock.get(env.max_tick_unit) > env.max_tick
+            end_session = not (env.clock.get(env.max_tick_unit) < env.max_tick)
             end_sessions.append(end_session)
         return all(end_sessions)
 

--- a/slm_lab/experiment/monitor.py
+++ b/slm_lab/experiment/monitor.py
@@ -137,7 +137,7 @@ class Body:
         Handles any body attribute reset at the start of an episode.
         This method is called automatically at base memory.epi_reset().
         '''
-        t = self.env.clock.get('t')
+        t = self.env.clock.t
         assert t == 0, f'aeb: {self.aeb}, t: {t}'
         if hasattr(self, 'aeb_space'):
             self.space_fix_stats()
@@ -193,7 +193,7 @@ class Body:
         spec = self.agent.spec
         info_space = self.agent.info_space
         clock = self.env.clock
-        prefix = f'{spec["name"]}_t{info_space.get("trial")}_s{info_space.get("session")}, aeb{self.aeb}, epi: {clock.get("epi")}, total_t: {clock.get("total_t")}, t: {clock.get("t")}'
+        prefix = f'{spec["name"]}_t{info_space.get("trial")}_s{info_space.get("session")}, aeb{self.aeb}, epi: {clock.epi}, total_t: {clock.total_t}, t: {clock.t}'
         return prefix
 
     def log_summary(self):

--- a/slm_lab/lib/util.py
+++ b/slm_lab/lib/util.py
@@ -346,7 +346,7 @@ def override_eval_spec(spec, num_eval_epi=100):
         # evaluate on episode basis
         if 'max_total_t' in env_spec:
             del env_spec['max_total_t']
-        env_spec['max_epi'] = num_eval_epi
+        env_spec['max_epi'] = num_eval_epi - 1  # offset so epi is 0 - (num_eval_epi - 1)
     return spec
 
 
@@ -360,6 +360,7 @@ def override_test_spec(spec):
     for env_spec in spec['env']:
         env_spec['max_epi'] = 3
         env_spec['max_t'] = 20
+        env_spec['save_frequency'] = 1000
     spec['meta']['max_session'] = 1
     spec['meta']['max_trial'] = 2
     return spec


### PR DESCRIPTION
## Feature / Fix
- make `epi` start from 0 instead of 1.
- this is to make consistent clock units, data indexing and graph indexing (plot from 0)
- remove the awkward logic to handle the previous epi starting from 1
- simplify `clock.get(<unit>)` to `clock.<unit>`
