### PR TITLE
fix eval mode plot graph axis conflict

### DIFF
--- a/README.md
+++ b/README.md
@@ -241,7 +241,7 @@ Run the demo to quickly see the lab in action (and to test your installation).
 
 It is `DQN` in `CartPole-v0`:
 
-1. see `slm_lab/spec/demo.json` for example spec:
+1. See `slm_lab/spec/demo.json` for example spec:
     ```json
     "dqn_cartpole": {
       "agent": [{
@@ -256,23 +256,16 @@ It is `DQN` in `CartPole-v0`:
     }
     ```
 
-2. see `config/experiments.json` to schedule experiments:
-    ```json
-    "demo.json": {
-      "dqn_cartpole": "dev"
-    }
-    ```
-    > To run faster, change lab mode from "dev" to "train" above and rendering will be disabled.
-
-3. launch terminal in the repo directory, run the lab:
+2. Launch terminal in the repo directory, run the lab with the demo spec in `dev` lab mode:
     ```shell
     conda activate lab
-    python run_lab.py
+    yarn start demo.json dqn_cartpole dev
     ```
     >To run any lab commands, conda environment must be activated first. See [Installation](#installation) for more.
-    >Alternatively, use the shorthand command `yarn start` to replace the last line
 
-4. This demo will run a single trial using the default parameters, and render the environment. After completion, check the output for data `data/dqn_cartpole_2018_06_16_214527/` (timestamp will differ). You should see some healthy graphs.
+    >`yarn start` is a shorthand for `python run_lab.py`
+
+3. This demo will run a single trial using the default parameters, and render the environment. After completion, check the output for data `data/dqn_cartpole_2018_06_16_214527/` (timestamp will differ). You should see some healthy graphs.
 
     ![](https://kengz.gitbooks.io/slm-lab/content/assets/demo_trial_graph.png)
     >Trial graph showing average envelope of repeated sessions.
@@ -280,7 +273,7 @@ It is `DQN` in `CartPole-v0`:
     ![](https://kengz.gitbooks.io/slm-lab/content/assets/demo_session_graph.png)
     >Session graph showing total rewards, exploration variable and loss for the episodes.
 
-5. Enjoy mode - when a session ends, a model file will automatically save. You can find the session `prepath` that ends in its trial and session numbers. The example above is trial 1 session 0, and you can see a pyotrch model saved at `data/dqn_cartpole_2018_06_16_214527/dqn_cartpole_t1_s0_model_net.pth`. Use the following command to run from the saved folder in `data/`:
+4. Enjoy mode - when a session ends, a model file will automatically save. You can find the session `prepath` that ends in its trial and session numbers. The example above is trial 1 session 0, and you can see a pytorch model saved at `data/dqn_cartpole_2018_06_16_214527/dqn_cartpole_t1_s0_model_net.pth`. Use the following command to run from the saved folder in `data/`:
     ```bash
     yarn start data/dqn_cartpole_2018_06_16_214527/dqn_cartpole_spec.json dqn_cartpole enjoy@dqn_cartpole_t1_s0
     ```
@@ -288,7 +281,12 @@ It is `DQN` in `CartPole-v0`:
 
     >To run the best model, use the best saved checkpoint `enjoy@dqn_cartpole_t1_s0_ckptbest`
 
-6. Next, change the run mode from `"train"` to `"search"`  `config/experiments.json`, and rerun. This runs experiments of multiple trials with hyperparameter search. Environments will not be rendered.:
+5. The above was in `dev` mode. To run in proper training mode, which is faster without rendering, change the `dev` lab mode to `train`, and the same data is produced.
+    ```shell
+    yarn start demo.json dqn_cartpole train
+    ```
+
+6. Next, perform a hyperparameter search using the lab mode `search`. This runs experiments of multiple trials with hyperparameter search, defined at the bottom section of the demo spec.
     ```json
     "demo.json": {
       "dqn_cartpole": "search"

--- a/README.md
+++ b/README.md
@@ -287,11 +287,10 @@ It is `DQN` in `CartPole-v0`:
     ```
 
 6. Next, perform a hyperparameter search using the lab mode `search`. This runs experiments of multiple trials with hyperparameter search, defined at the bottom section of the demo spec.
-    ```json
-    "demo.json": {
-      "dqn_cartpole": "search"
-    }
+    ```bash
+    yarn start demo.json dqn_cartpole search
     ```
+
     When it ends, refer to `{prepath}_experiment_graph.png` and `{prepath}_experiment_df.csv` to find the best trials.
 
 >If the demo fails, consult [Debugging](https://kengz.gitbooks.io/slm-lab/content/debugging.html).

--- a/package.json
+++ b/package.json
@@ -4,17 +4,17 @@
   "description": "Modular Deep Reinforcement Learning framework in PyTorch.",
   "main": "index.js",
   "scripts": {
-    "start": "python3 run_lab.py",
-    "debug": "LOG_LEVEL=DEBUG python3 run_lab.py",
-    "debug2": "LOG_LEVEL=DEBUG2 python3 run_lab.py",
-    "debug3": "LOG_LEVEL=DEBUG3 python3 run_lab.py",
-    "analyze": "python3 -c 'import sys; from slm_lab.experiment import analysis; analysis.retro_analyze(sys.argv[1])'",
+    "start": "python run_lab.py",
+    "debug": "LOG_LEVEL=DEBUG python run_lab.py",
+    "debug2": "LOG_LEVEL=DEBUG2 python run_lab.py",
+    "debug3": "LOG_LEVEL=DEBUG3 python run_lab.py",
+    "analyze": "python -c 'import sys; from slm_lab.experiment import analysis; analysis.retro_analyze(sys.argv[1])'",
     "reset": "rm -rf data/* .cache __pycache__ */__pycache__ *egg-info .pytest* htmlcov .coverage* *.xml",
     "kill": "pkill -f run_lab; pkill -f slm-env; pkill -f ipykernel; pkill -f ray; pkill -f orca; pkill -f Xvfb",
     "update": "conda env update -f environment.yml; yarn install;",
     "export-env": "conda env export > environment.yml",
     "build": "docker build -t kengz/slm_lab:latest -t kengz/slm_lab:v$v .",
-    "test": "python3 setup.py test"
+    "test": "python setup.py test"
   },
   "repository": "https://github.com/kengz/SLM-Lab.git",
   "author": "kengz <kengzwl@gmail.com>, lgraesser",

--- a/run_lab.py
+++ b/run_lab.py
@@ -58,7 +58,7 @@ def run_old_mode(spec_file, spec_name, lab_mode):
         spec = spec_util.override_enjoy_spec(spec)
         Session(spec, info_space).run()
     elif lab_mode == 'eval':
-        spec = spec_util.override_eval_spec(spec, num_eval_epi=analysis.NUM_EVAL_EPI)
+        spec = spec_util.override_eval_spec(spec)
         Session(spec, info_space).run()
         util.clear_periodic_ckpt(prepath)  # cleanup after itself
         analysis.analyze_eval_trial(spec, info_space, predir)

--- a/slm_lab/env/base.py
+++ b/slm_lab/env/base.py
@@ -1,5 +1,6 @@
 from abc import ABC, abstractmethod
 from gym import spaces
+from slm_lab.experiment import analysis
 from slm_lab.lib import logger, util
 from slm_lab.lib.decorator import lab_api
 import numpy as np
@@ -100,6 +101,11 @@ class BaseEnv(ABC):
             'save_frequency',
             'reward_scale',
         ])
+        if util.get_lab_mode() == 'eval':
+            # override for eval, offset so epi is 0 - (num_eval_epi - 1)
+            logger.info(f'Override max_tick for eval mode to {analysis.NUM_EVAL_EPI} epi')
+            self.max_tick = analysis.NUM_EVAL_EPI - 1
+            self.max_tick_unit = 'epi'
         # set max_tick info to clock
         self.clock.max_tick = self.max_tick
         self.clock.max_tick_unit = self.max_tick_unit

--- a/slm_lab/env/base.py
+++ b/slm_lab/env/base.py
@@ -1,11 +1,11 @@
 from abc import ABC, abstractmethod
 from gym import spaces
-from slm_lab.experiment import analysis
 from slm_lab.lib import logger, util
 from slm_lab.lib.decorator import lab_api
 import numpy as np
 
 ENV_DATA_NAMES = ['reward', 'state', 'done']
+NUM_EVAL_EPI = 100  # set the number of episodes to eval a model ckpt
 logger = logger.get_logger(__name__)
 
 
@@ -103,8 +103,8 @@ class BaseEnv(ABC):
         ])
         if util.get_lab_mode() == 'eval':
             # override for eval, offset so epi is 0 - (num_eval_epi - 1)
-            logger.info(f'Override max_tick for eval mode to {analysis.NUM_EVAL_EPI} epi')
-            self.max_tick = analysis.NUM_EVAL_EPI - 1
+            logger.info(f'Override max_tick for eval mode to {NUM_EVAL_EPI} epi')
+            self.max_tick = NUM_EVAL_EPI - 1
             self.max_tick_unit = 'epi'
         # set max_tick info to clock
         self.clock.max_tick = self.max_tick

--- a/slm_lab/experiment/analysis.py
+++ b/slm_lab/experiment/analysis.py
@@ -18,7 +18,6 @@ FITNESS_COLS = ['strength', 'speed', 'stability', 'consistency']
 FITNESS_STD = util.read('slm_lab/spec/_fitness_std.json')
 NOISE_WINDOW = 0.05
 NORM_ORDER = 1  # use L1 norm in fitness vector norm
-NUM_EVAL_EPI = 100  # set the number of episodes to eval a model ckpt
 MA_WINDOW = 100
 logger = logger.get_logger(__name__)
 

--- a/slm_lab/experiment/control.py
+++ b/slm_lab/experiment/control.py
@@ -55,7 +55,7 @@ class Session:
         if to_ckpt:
             if analysis.new_best(agent):
                 agent.save(ckpt='best')
-            # run online eval for train mode using model saved above
+            # run online eval for train mode
             if util.get_lab_mode() == 'train' and self.spec['meta'].get('training_eval', False):
                 ckpt = f'epi{clock.epi}-totalt{clock.total_t}'
                 agent.save(ckpt=ckpt)

--- a/slm_lab/experiment/control.py
+++ b/slm_lab/experiment/control.py
@@ -46,12 +46,9 @@ class Session:
         '''Try to checkpoint agent and run_online_eval at the start, save_freq, and the end'''
         clock = env.clock
         tick = clock.get(env.max_tick_unit)
-        if util.get_lab_mode() in ('enjoy', 'eval'):
-            to_ckpt = False
-        elif tick <= env.max_tick:
+        to_ckpt = False
+        if util.get_lab_mode() not in ('enjoy', 'eval') and tick <= env.max_tick:
             to_ckpt = (tick % env.save_frequency == 0) or tick == env.max_tick
-        else:
-            to_ckpt = False
         if env.max_tick_unit == 'epi':  # extra condition for epi
             to_ckpt = to_ckpt and env.done
 

--- a/slm_lab/experiment/control.py
+++ b/slm_lab/experiment/control.py
@@ -49,7 +49,7 @@ class Session:
         if util.get_lab_mode() in ('enjoy', 'eval'):
             to_ckpt = False
         elif tick <= env.max_tick:
-            to_ckpt = tick % env.save_frequency == 0
+            to_ckpt = (tick % env.save_frequency == 0) or tick == env.max_tick
         else:
             to_ckpt = False
         if env.max_tick_unit == 'epi':  # extra condition for epi

--- a/slm_lab/spec/spec_util.py
+++ b/slm_lab/spec/spec_util.py
@@ -160,14 +160,11 @@ def override_enjoy_spec(spec):
     return spec
 
 
-def override_eval_spec(spec, num_eval_epi=100):
+def override_eval_spec(spec):
     for agent_spec in spec['agent']:
         if 'max_size' in agent_spec['memory']:
             agent_spec['memory']['max_size'] = 100
-    for env_spec in spec['env']:
-        # evaluate by episode; offset so epi is 0 - (num_eval_epi - 1)
-        env_spec['max_tick'] = num_eval_epi - 1
-        env_spec['max_tick_unit'] = 'epi'
+    # evaluate by episode is set in env clock init in env/base.py
     return spec
 
 


### PR DESCRIPTION
## Feature / Fix
- Eval mode plot uses the overridden `max_tick_unit` to plot and analyze. Change the logic such that the override for eval happens only in clock as it is meant to be, and other logic remains consistent.
- FIx checkpoint at the end too, instead of just basing on frequency
