### PR TITLE
Fix index in eval_session_df breaking online trial eval

### DIFF
--- a/slm_lab/experiment/analysis.py
+++ b/slm_lab/experiment/analysis.py
@@ -477,7 +477,10 @@ def save_session_df(session_data, prepath, info_space):
         epi = int(re.search('epi(\d+)', ckpt)[1])
         totalt = int(re.search('totalt(\d+)', ckpt)[1])
         session_df = pd.concat(session_data, axis=1)
-        eval_session_df = pd.DataFrame(data=[session_df.mean()])
+        mean_sr = session_df.mean()
+        mean_sr.name = totalt  # set index to prevent all being the same
+        eval_session_df = pd.DataFrame(data=[mean_sr])
+        # set sr name too, to total_t
         for aeb in util.get_df_aeb_list(eval_session_df):
             eval_session_df.loc[:, aeb + ('epi',)] = epi
             eval_session_df.loc[:, aeb + ('total_t',)] = totalt


### PR DESCRIPTION
## Feature / Fix
Online eval trial plot was broken. Turns out the issue was when trial analysis tries to read eval `session_fitness_df`, it encounter series with duplicate index (all of them are 0 because of the appending by row during session eval).

Error log:
```bash
Traceback (most recent call last):
  File "run_lab.py", line 100, in <module>
    main()
  File "run_lab.py", line 84, in main
    run_by_mode(*args)
  File "run_lab.py", line 77, in run_by_mode
    run_old_mode(spec_file, spec_name, lab_mode)
  File "run_lab.py", line 64, in run_old_mode
    analysis.analyze_eval_trial(spec, info_space, predir)
  File "/home/ubuntu/SLM-Lab/slm_lab/experiment/analysis.py", line 592, in analyze_eval_trial
    analyze_trial(trial)
  File "/home/ubuntu/SLM-Lab/slm_lab/experiment/analysis.py", line 556, in analyze_trial
    trial_fig = plot_trial(trial.spec, trial.info_space)
  File "/home/ubuntu/SLM-Lab/slm_lab/experiment/analysis.py", line 426, in plot_trial
    aeb_rewards_df = gather_aeb_rewards_df(aeb, session_datas, max_tick_unit)
  File "/home/ubuntu/SLM-Lab/slm_lab/experiment/analysis.py", line 362, in gather_aeb_rewards_df
    aeb_rewards_df = pd.DataFrame(aeb_session_rewards)
  File "/home/ubuntu/anaconda3/envs/lab/lib/python3.6/site-packages/pandas/core/frame.py", line 330, in __init__
    mgr = self._init_dict(data, index, columns, dtype=dtype)
  File "/home/ubuntu/anaconda3/envs/lab/lib/python3.6/site-packages/pandas/core/frame.py", line 461, in _init_dict
    return _arrays_to_mgr(arrays, data_names, index, columns, dtype=dtype)
  File "/home/ubuntu/anaconda3/envs/lab/lib/python3.6/site-packages/pandas/core/frame.py", line 6168, in _arrays_to_mgr
    arrays = _homogenize(arrays, index, dtype)
  File "/home/ubuntu/anaconda3/envs/lab/lib/python3.6/site-packages/pandas/core/frame.py", line 6465, in _homogenize
    v = v.reindex(index, copy=False)
  File "/home/ubuntu/anaconda3/envs/lab/lib/python3.6/site-packages/pandas/core/series.py", line 2681, in reindex
    return super(Series, self).reindex(index=index, **kwargs)
  File "/home/ubuntu/anaconda3/envs/lab/lib/python3.6/site-packages/pandas/core/generic.py", line 3023, in reindex
    fill_value, copy).__finalize__(self)
  File "/home/ubuntu/anaconda3/envs/lab/lib/python3.6/site-packages/pandas/core/generic.py", line 3041, in _reindex_axes
    copy=copy, allow_dups=False)
  File "/home/ubuntu/anaconda3/envs/lab/lib/python3.6/site-packages/pandas/core/generic.py", line 3145, in _reindex_with_indexers
    copy=copy)
  File "/home/ubuntu/anaconda3/envs/lab/lib/python3.6/site-packages/pandas/core/internals.py", line 4139, in reindex_indexer
    self.axes[axis]._can_reindex(indexer)
  File "/home/ubuntu/anaconda3/envs/lab/lib/python3.6/site-packages/pandas/core/indexes/base.py", line 2944, in _can_reindex
    raise ValueError("cannot reindex from a duplicate axis")
ValueError: cannot reindex from a duplicate axis
```

Fix this by adding `totalt` as the index to append a row to `eval_session_df`
