### PR TITLE
Fix retro eval mode

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -46,7 +46,7 @@ dependencies:
     - atari-py==0.1.1
     - box2d-py==2.3.8
     - cloudpickle==0.5.2
-    - git+https://github.com/jackparmer/colorlover.git@d63b098530458223a985bef804ded0c9be9b00b2
+    - colorlover==0.3.0
     - deap==1.2.2
     - gym==0.10.9
     - gym[atari]

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "debug": "LOG_LEVEL=DEBUG python run_lab.py",
     "debug2": "LOG_LEVEL=DEBUG2 python run_lab.py",
     "debug3": "LOG_LEVEL=DEBUG3 python run_lab.py",
-    "analyze": "python -c 'import sys; from slm_lab.experiment import analysis; analysis.retro_analyze(sys.argv[1])'",
+    "retro_analyze": "python -c 'import sys; from slm_lab.experiment import analysis; analysis.retro_analyze(sys.argv[1])'",
     "retro_eval": "python -c 'import sys; from slm_lab.experiment import analysis; analysis.retro_eval(sys.argv[1])'",
     "reset": "rm -rf data/* .cache __pycache__ */__pycache__ *egg-info .pytest* htmlcov .coverage* *.xml",
     "kill": "pkill -f run_lab; pkill -f slm-env; pkill -f ipykernel; pkill -f ray; pkill -f orca; pkill -f Xvfb",

--- a/slm_lab/experiment/analysis.py
+++ b/slm_lab/experiment/analysis.py
@@ -734,7 +734,7 @@ def retro_analyze(predir):
     This method has no side-effects, i.e. doesn't overwrite data it should not.
     @example
 
-    yarn run analyze data/reinforce_cartpole_2018_01_22_211751
+    yarn run retro_analyze data/reinforce_cartpole_2018_01_22_211751
     '''
     os.environ['PREPATH'] = f'{predir}/retro_analyze'  # to prevent overwriting log file
     logger.info(f'Retro-analyzing {predir}')
@@ -765,9 +765,9 @@ def retro_eval(predir, session_index=None):
         return
 
     logger.info(f'Starting retro eval')
+    np.random.shuffle(prepaths)  # so that CUDA_ID by trial/session index is spread out
     rand_spec = util.prepath_to_spec(prepaths[0])  # get any prepath, read its max session
     max_session = rand_spec['meta']['max_session']
-    # TODO figure out a way to cycle CUDA id
     util.parallelize_fn(run_wait_eval, prepaths, num_cpus=max_session)
 
 

--- a/slm_lab/experiment/analysis.py
+++ b/slm_lab/experiment/analysis.py
@@ -765,7 +765,10 @@ def retro_eval(predir, session_index=None):
         return
 
     logger.info(f'Starting retro eval')
-    util.parallelize_fn(run_wait_eval, prepaths)
+    rand_spec = util.prepath_to_spec(prepaths[0])  # get any prepath, read its max session
+    max_session = rand_spec['meta']['max_session']
+    # TODO figure out a way to cycle CUDA id
+    util.parallelize_fn(run_wait_eval, prepaths, num_cpus=max_session)
 
 
 def session_retro_eval(session):

--- a/slm_lab/experiment/monitor.py
+++ b/slm_lab/experiment/monitor.py
@@ -94,6 +94,7 @@ class Body:
         self.last_loss = np.nan  # the last non-nan loss, for printing
         # for action policy exploration, so be set in algo during init_algorithm_params()
         self.explore_var = np.nan
+        # body data for analysis.analyze_session, inherently episodic
         self.df = pd.DataFrame(columns=[
             'epi', 'total_t', 't', 'reward', 'loss', 'explore_var',
             'lr', 'action_ent', 'ent_coef', 'grad_norm'])

--- a/slm_lab/lib/util.py
+++ b/slm_lab/lib/util.py
@@ -524,6 +524,7 @@ def session_df_to_data(session_df):
     aeb_list = get_df_aeb_list(session_df)
     for aeb in aeb_list:
         aeb_df = session_df.loc[:, aeb]
+        aeb_df.reset_index(inplace=True)  # guard for eval append-row
         session_data[aeb] = aeb_df
     return session_data
 


### PR DESCRIPTION
## Fix
- add guard to reset index in retro eval trial analysis
- set consistent `max_session` from random spec, shuffle prepaths to spread out `CUDA_ID`

## misc
- rename `yarn run retro_analyze` for consistency
- update colorlover installation
