### PR TITLE
Eval mode rework; refactoring

### DIFF
--- a/run_lab.py
+++ b/run_lab.py
@@ -6,6 +6,7 @@ Then run `yarn start` or `python run_lab.py`
 import os
 # NOTE increase if needed. Pytorch thread overusage https://github.com/pytorch/pytorch/issues/975
 os.environ['OMP_NUM_THREADS'] = '1'
+from slm_lab import EVAL_MODES, TRAIN_MODES
 from slm_lab.experiment import analysis, retro_analysis
 from slm_lab.experiment.control import Session, Trial, Experiment
 from slm_lab.experiment.monitor import InfoSpace
@@ -39,7 +40,7 @@ def run_new_mode(spec_file, spec_name, lab_mode):
         info_space.tick('trial')
         Trial(spec, info_space).run()
     else:
-        raise ValueError('Unrecognizable lab_mode not of `search, train, dev`')
+        raise ValueError(f'Unrecognizable lab_mode not of {TRAIN_MODES}')
 
 
 def run_old_mode(spec_file, spec_name, lab_mode):
@@ -65,7 +66,7 @@ def run_old_mode(spec_file, spec_name, lab_mode):
         util.clear_periodic_ckpt(prepath)  # cleanup after itself
         retro_analysis.analyze_eval_trial(spec, info_space, predir)
     else:
-        raise ValueError('Unrecognizable lab_mode not of `enjoy, eval`')
+        raise ValueError(f'Unrecognizable lab_mode not of {EVAL_MODES}')
 
 
 def run_by_mode(spec_file, spec_name, lab_mode):
@@ -73,7 +74,7 @@ def run_by_mode(spec_file, spec_name, lab_mode):
     logger.info(f'Running lab in mode: {lab_mode}')
     # '@' is reserved for 'enjoy@{prename}'
     os.environ['lab_mode'] = lab_mode.split('@')[0]
-    if lab_mode in ('search', 'train', 'dev'):
+    if lab_mode in TRAIN_MODES:
         run_new_mode(spec_file, spec_name, lab_mode)
     else:
         run_old_mode(spec_file, spec_name, lab_mode)

--- a/slm_lab/__init__.py
+++ b/slm_lab/__init__.py
@@ -2,3 +2,7 @@ import os
 
 os.environ['PY_ENV'] = os.environ.get('PY_ENV') or 'development'
 ROOT_DIR = os.path.normpath(os.path.join(os.path.dirname(__file__), '..'))
+
+# valid lab_mode in SLM Lab
+EVAL_MODES = ('enjoy', 'eval')
+TRAIN_MODES = ('search', 'train', 'dev')

--- a/slm_lab/agent/__init__.py
+++ b/slm_lab/agent/__init__.py
@@ -84,7 +84,7 @@ class Agent:
     @lab_api
     def save(self, ckpt=None):
         '''Save agent'''
-        if util.get_lab_mode() in ('enjoy', 'eval'):
+        if util.in_eval_lab_modes():
             # eval does not save new models
             return
         self.algorithm.save(ckpt=ckpt)

--- a/slm_lab/agent/__init__.py
+++ b/slm_lab/agent/__init__.py
@@ -72,9 +72,9 @@ class Agent:
         '''Update per timestep after env transitions, e.g. memory, algorithm, update agent params, train net'''
         self.body.action_pd_update()
         self.body.memory.update(action, reward, state, done)
-        self.body.loss = loss = self.algorithm.train()
+        loss = self.algorithm.train()
         if not np.isnan(loss):  # set for log_summary()
-            self.body.last_loss = loss
+            self.body.loss = loss
         explore_var = self.algorithm.update()
         logger.debug(f'Agent {self.a} loss: {loss}, explore_var {explore_var}')
         if done:
@@ -140,9 +140,8 @@ class Agent:
         loss_a = self.algorithm.space_train()
         loss_a = util.guard_data_a(self, loss_a, 'loss')
         for eb, body in util.ndenumerate_nonan(self.body_a):
-            body.loss = loss_a[eb]
-            if not np.isnan(body.loss):  # set for log_summary()
-                body.last_loss = body.loss
+            if not np.isnan(loss_a[eb]):  # set for log_summary()
+                body.loss = loss_a[eb]
         explore_var_a = self.algorithm.space_update()
         explore_var_a = util.guard_data_a(self, explore_var_a, 'explore_var')
         logger.debug(f'Agent {self.a} loss: {loss_a}, explore_var_a {explore_var_a}')

--- a/slm_lab/agent/__init__.py
+++ b/slm_lab/agent/__init__.py
@@ -70,6 +70,7 @@ class Agent:
     @lab_api
     def update(self, action, reward, state, done):
         '''Update per timestep after env transitions, e.g. memory, algorithm, update agent params, train net'''
+        self.body.action_pd_update()
         self.body.memory.update(action, reward, state, done)
         self.body.loss = loss = self.algorithm.train()
         if not np.isnan(loss):  # set for log_summary()
@@ -134,6 +135,7 @@ class Agent:
     def space_update(self, action_a, reward_a, state_a, done_a):
         '''Update per timestep after env transitions, e.g. memory, algorithm, update agent params, train net'''
         for eb, body in util.ndenumerate_nonan(self.body_a):
+            body.action_pd_update()
             body.memory.update(action_a[eb], reward_a[eb], state_a[eb], done_a[eb])
         loss_a = self.algorithm.space_train()
         loss_a = util.guard_data_a(self, loss_a, 'loss')

--- a/slm_lab/agent/algorithm/actor_critic.py
+++ b/slm_lab/agent/algorithm/actor_critic.py
@@ -202,7 +202,7 @@ class ActorCritic(Reinforce):
     @lab_api
     def train(self):
         '''Trains the algorithm'''
-        if util.get_lab_mode() in ('enjoy', 'eval'):
+        if util.in_eval_lab_modes():
             self.body.flush()
             return np.nan
         if self.shared:

--- a/slm_lab/agent/algorithm/actor_critic.py
+++ b/slm_lab/agent/algorithm/actor_critic.py
@@ -345,7 +345,6 @@ class ActorCritic(Reinforce):
 
     @lab_api
     def update(self):
-        net_util.try_store_grad_norm(self)
         self.body.explore_var = self.explore_var_scheduler.update(self, self.body.env.clock)
         if self.entropy_coef_spec is not None:
             self.body.entropy_coef = self.entropy_coef_scheduler.update(self, self.body.env.clock)

--- a/slm_lab/agent/algorithm/actor_critic.py
+++ b/slm_lab/agent/algorithm/actor_critic.py
@@ -280,8 +280,6 @@ class ActorCritic(Reinforce):
         if self.entropy_coef_spec is not None:
             entropies = torch.stack(self.body.entropies)
             policy_loss += (-self.body.entropy_coef * entropies)
-            # Store mean entropy for debug logging
-            self.body.mean_entropy = torch.mean(torch.tensor(self.body.entropies)).item()
         policy_loss = torch.mean(policy_loss)
         logger.debug(f'Actor policy loss: {policy_loss:.4f}')
         return policy_loss

--- a/slm_lab/agent/algorithm/actor_critic.py
+++ b/slm_lab/agent/algorithm/actor_critic.py
@@ -227,8 +227,7 @@ class ActorCritic(Reinforce):
             # reset
             self.to_train = 0
             self.body.flush()
-            logger.debug(f'Trained {self.name} at epi: {clock.epi}, total_t: {clock.total_t}, t: {clock.t}, total_reward so far: {self.body.memory.total_reward}, loss: {loss:.8f}')
-
+            logger.debug(f'Trained {self.name} at epi: {clock.epi}, total_t: {clock.total_t}, t: {clock.t}, total_reward so far: {self.body.memory.total_reward}, loss: {loss:g}')
             return loss.item()
         else:
             return np.nan
@@ -246,7 +245,7 @@ class ActorCritic(Reinforce):
             # reset
             self.to_train = 0
             self.body.flush()
-            logger.debug(f'Trained {self.name}, loss: {loss:.4f}')
+            logger.debug(f'Trained {self.name}, loss: {loss:g}')
             return loss.item()
         else:
             return np.nan
@@ -281,7 +280,7 @@ class ActorCritic(Reinforce):
             entropies = torch.stack(self.body.entropies)
             policy_loss += (-self.body.entropy_coef * entropies)
         policy_loss = torch.mean(policy_loss)
-        logger.debug(f'Actor policy loss: {policy_loss:.4f}')
+        logger.debug(f'Actor policy loss: {policy_loss:g}')
         return policy_loss
 
     def calc_val_loss(self, batch, v_targets):
@@ -290,7 +289,7 @@ class ActorCritic(Reinforce):
         v_preds = self.calc_v(batch['states'], evaluate=False).unsqueeze_(dim=-1)
         assert v_preds.shape == v_targets.shape
         val_loss = self.val_loss_coef * self.net.loss_fn(v_preds, v_targets)
-        logger.debug(f'Critic value loss: {val_loss:.4f}')
+        logger.debug(f'Critic value loss: {val_loss:g}')
         return val_loss
 
     def calc_gae_advs_v_targets(self, batch):

--- a/slm_lab/agent/algorithm/base.py
+++ b/slm_lab/agent/algorithm/base.py
@@ -48,7 +48,7 @@ class Algorithm(ABC):
         Call at the end of init_nets() after setting self.net_names
         '''
         assert hasattr(self, 'net_names')
-        if util.get_lab_mode() in ('enjoy', 'eval'):
+        if util.in_eval_lab_modes():
             logger.info(f'Loaded algorithm models for lab_mode: {util.get_lab_mode()}')
             self.load()
         else:
@@ -88,7 +88,7 @@ class Algorithm(ABC):
     @lab_api
     def train(self):
         '''Implement algorithm train, or throw NotImplementedError'''
-        if util.get_lab_mode() in ('enjoy', 'eval'):
+        if util.in_eval_lab_modes():
             return np.nan
         raise NotImplementedError
 
@@ -149,7 +149,7 @@ class Algorithm(ABC):
 
     @lab_api
     def space_train(self):
-        if util.get_lab_mode() in ('enjoy', 'eval'):
+        if util.in_eval_lab_modes():
             return np.nan
         losses = []
         for body in self.agent.nanflat_body_a:

--- a/slm_lab/agent/algorithm/dqn.py
+++ b/slm_lab/agent/algorithm/dqn.py
@@ -130,7 +130,7 @@ class VanillaDQN(SARSA):
         For each of the batches, the target Q values (q_targets) are computed and a single training step is taken k times
         Otherwise this function does nothing.
         '''
-        if util.get_lab_mode() in ('enjoy', 'eval'):
+        if util.in_eval_lab_modes():
             self.body.flush()
             return np.nan
         clock = self.body.env.clock

--- a/slm_lab/agent/algorithm/dqn.py
+++ b/slm_lab/agent/algorithm/dqn.py
@@ -148,7 +148,7 @@ class VanillaDQN(SARSA):
             # reset
             self.to_train = 0
             self.body.flush()
-            logger.debug(f'Trained {self.name} at epi: {clock.epi}, total_t: {clock.total_t}, t: {clock.t}, total_reward so far: {self.body.memory.total_reward}, loss: {loss:.8f}')
+            logger.debug(f'Trained {self.name} at epi: {clock.epi}, total_t: {clock.total_t}, t: {clock.t}, total_reward so far: {self.body.memory.total_reward}, loss: {loss:g}')
             return loss.item()
         else:
             return np.nan

--- a/slm_lab/agent/algorithm/hydra_dqn.py
+++ b/slm_lab/agent/algorithm/hydra_dqn.py
@@ -54,10 +54,7 @@ class HydraDQN(DQN):
         # use multi-policy. note arg change
         action_a, action_pd_a = self.action_policy(states, self, self.agent.nanflat_body_a, pdparam)
         for idx, body in enumerate(self.agent.nanflat_body_a):
-            action_pd = action_pd_a[idx]
-            body.entropies.append(action_pd.entropy())
-            body.log_probs.append(action_pd.log_prob(action_a[idx].float()))
-            assert not torch.isnan(body.log_probs[-1])
+            body.action_tensor, body.action_pd = action_a[idx], action_pd_a[idx]  # used for body.action_pd_update later
         return action_a.cpu().numpy()
 
     @lab_api

--- a/slm_lab/agent/algorithm/hydra_dqn.py
+++ b/slm_lab/agent/algorithm/hydra_dqn.py
@@ -98,7 +98,7 @@ class HydraDQN(DQN):
         For each of the batches, the target Q values (q_targets) are computed and a single training step is taken k times
         Otherwise this function does nothing.
         '''
-        if util.get_lab_mode() in ('enjoy', 'eval'):
+        if util.in_eval_lab_modes():
             self.body.flush()
             return np.nan
         clock = self.body.env.clock  # main clock

--- a/slm_lab/agent/algorithm/hydra_dqn.py
+++ b/slm_lab/agent/algorithm/hydra_dqn.py
@@ -117,8 +117,7 @@ class HydraDQN(DQN):
             self.to_train = 0
             for body in self.agent.nanflat_body_a:
                 body.flush()
-            logger.debug(f'Trained {self.name} at epi: {clock.epi}, total_t: {clock.total_t}, t: {clock.t}, total_reward so far: {self.body.memory.total_reward}, loss: {loss:.8f}')
-
+            logger.debug(f'Trained {self.name} at epi: {clock.epi}, total_t: {clock.total_t}, t: {clock.t}, total_reward so far: {self.body.memory.total_reward}, loss: {loss:g}')
             return loss.item()
         else:
             return np.nan

--- a/slm_lab/agent/algorithm/policy_util.py
+++ b/slm_lab/agent/algorithm/policy_util.py
@@ -327,7 +327,7 @@ class VarScheduler:
 
     def update(self, algorithm, clock):
         '''Get an updated value for var'''
-        if (util.get_lab_mode() in ('enjoy', 'eval')) or self._updater_name == 'no_decay':
+        if (util.in_eval_lab_modes()) or self._updater_name == 'no_decay':
             return self.end_val
         step = clock.get(clock.max_tick_unit)
         val = self._updater(self.start_val, self.end_val, self.start_step, self.end_step, step)

--- a/slm_lab/agent/algorithm/ppo.py
+++ b/slm_lab/agent/algorithm/ppo.py
@@ -143,8 +143,6 @@ class PPO(ActorCritic):
         entropies = torch.stack(self.body.entropies)
         ent_penalty = torch.mean(-self.body.entropy_coef * entropies)
         logger.debug(f'ent_penalty: {ent_penalty}')
-        # Store mean entropy for debug logging
-        self.body.mean_entropy = torch.mean(torch.tensor(self.body.entropies)).item()
 
         policy_loss = clip_loss + ent_penalty
         logger.debug(f'PPO Actor policy loss: {policy_loss:.4f}')

--- a/slm_lab/agent/algorithm/ppo.py
+++ b/slm_lab/agent/algorithm/ppo.py
@@ -145,7 +145,7 @@ class PPO(ActorCritic):
         logger.debug(f'ent_penalty: {ent_penalty}')
 
         policy_loss = clip_loss + ent_penalty
-        logger.debug(f'PPO Actor policy loss: {policy_loss:.4f}')
+        logger.debug(f'PPO Actor policy loss: {policy_loss:g}')
         return policy_loss
 
     def train_shared(self):
@@ -172,8 +172,7 @@ class PPO(ActorCritic):
             # reset
             self.to_train = 0
             self.body.flush()
-            logger.debug(f'Trained {self.name} at epi: {clock.epi}, total_t: {clock.total_t}, t: {clock.t}, total_reward so far: {self.body.memory.total_reward}, loss: {loss:.8f}')
-
+            logger.debug(f'Trained {self.name} at epi: {clock.epi}, total_t: {clock.total_t}, t: {clock.t}, total_reward so far: {self.body.memory.total_reward}, loss: {loss:g}')
             return loss.item()
         else:
             return np.nan
@@ -193,8 +192,7 @@ class PPO(ActorCritic):
             # reset
             self.to_train = 0
             self.body.flush()
-            logger.debug(f'Trained {self.name} at epi: {clock.epi}, total_t: {clock.total_t}, t: {clock.t}, total_reward so far: {self.body.memory.total_reward}, loss: {loss:.8f}')
-
+            logger.debug(f'Trained {self.name} at epi: {clock.epi}, total_t: {clock.total_t}, t: {clock.t}, total_reward so far: {self.body.memory.total_reward}, loss: {loss:g}')
             return loss.item()
         else:
             return np.nan

--- a/slm_lab/agent/algorithm/ppo.py
+++ b/slm_lab/agent/algorithm/ppo.py
@@ -213,7 +213,6 @@ class PPO(ActorCritic):
 
     @lab_api
     def update(self):
-        net_util.try_store_grad_norm(self)
         self.body.explore_var = self.explore_var_scheduler.update(self, self.body.env.clock)
         if self.entropy_coef_spec is not None:
             self.body.entropy_coef = self.entropy_coef_scheduler.update(self, self.body.env.clock)

--- a/slm_lab/agent/algorithm/reinforce.py
+++ b/slm_lab/agent/algorithm/reinforce.py
@@ -138,8 +138,7 @@ class Reinforce(Algorithm):
             # reset
             self.to_train = 0
             self.body.flush()
-            logger.debug(f'Trained {self.name} at epi: {clock.epi}, total_t: {clock.total_t}, t: {clock.t}, total_reward so far: {self.body.memory.total_reward}, loss: {loss:.8f}')
-
+            logger.debug(f'Trained {self.name} at epi: {clock.epi}, total_t: {clock.total_t}, t: {clock.t}, total_reward so far: {self.body.memory.total_reward}, loss: {loss:g}')
             return loss.item()
         else:
             return np.nan
@@ -157,7 +156,7 @@ class Reinforce(Algorithm):
             entropies = torch.stack(self.body.entropies)
             policy_loss += (-self.body.entropy_coef * entropies)
         policy_loss = torch.sum(policy_loss)
-        logger.debug(f'Actor policy loss: {policy_loss:.4f}')
+        logger.debug(f'Actor policy loss: {policy_loss:g}')
         return policy_loss
 
     @lab_api

--- a/slm_lab/agent/algorithm/reinforce.py
+++ b/slm_lab/agent/algorithm/reinforce.py
@@ -110,10 +110,7 @@ class Reinforce(Algorithm):
         if self.normalize_state:
             state = policy_util.update_online_stats_and_normalize_state(body, state)
         action, action_pd = self.action_policy(state, self, body)
-        # sum for single and multi-action
-        body.entropies.append(action_pd.entropy().sum(dim=0))
-        body.log_probs.append(action_pd.log_prob(action.float()).sum(dim=0))
-        assert not torch.isnan(body.log_probs[-1])
+        body.action_tensor, body.action_pd = action, action_pd  # used for body.action_pd_update later
         if len(action.shape) == 0:  # scalar
             return action.cpu().numpy().astype(body.action_space.dtype).item()
         else:

--- a/slm_lab/agent/algorithm/reinforce.py
+++ b/slm_lab/agent/algorithm/reinforce.py
@@ -162,7 +162,6 @@ class Reinforce(Algorithm):
 
     @lab_api
     def update(self):
-        net_util.try_store_grad_norm(self)
         self.body.explore_var = self.explore_var_scheduler.update(self, self.body.env.clock)
         if self.entropy_coef_spec is not None:
             self.body.entropy_coef = self.entropy_coef_scheduler.update(self, self.body.env.clock)

--- a/slm_lab/agent/algorithm/reinforce.py
+++ b/slm_lab/agent/algorithm/reinforce.py
@@ -127,7 +127,7 @@ class Reinforce(Algorithm):
 
     @lab_api
     def train(self):
-        if util.get_lab_mode() in ('enjoy', 'eval'):
+        if util.in_eval_lab_modes():
             self.body.flush()
             return np.nan
         clock = self.body.env.clock

--- a/slm_lab/agent/algorithm/reinforce.py
+++ b/slm_lab/agent/algorithm/reinforce.py
@@ -156,8 +156,6 @@ class Reinforce(Algorithm):
         if self.entropy_coef_spec is not None:
             entropies = torch.stack(self.body.entropies)
             policy_loss += (-self.body.entropy_coef * entropies)
-            # Store mean entropy for debug logging
-            self.body.mean_entropy = torch.mean(torch.tensor(self.body.entropies)).item()
         policy_loss = torch.sum(policy_loss)
         logger.debug(f'Actor policy loss: {policy_loss:.4f}')
         return policy_loss

--- a/slm_lab/agent/algorithm/sarsa.py
+++ b/slm_lab/agent/algorithm/sarsa.py
@@ -105,10 +105,7 @@ class SARSA(Algorithm):
         if self.normalize_state:
             state = policy_util.update_online_stats_and_normalize_state(body, state)
         action, action_pd = self.action_policy(state, self, body)
-        # sum for single and multi-action
-        body.entropies.append(action_pd.entropy().sum(dim=0))
-        body.log_probs.append(action_pd.log_prob(action.float()).sum(dim=0))
-        assert not torch.isnan(body.log_probs[-1])
+        body.action_tensor, body.action_pd = action, action_pd  # used for body.action_pd_update later
         if len(action.shape) == 0:  # scalar
             return action.cpu().numpy().astype(body.action_space.dtype).item()
         else:

--- a/slm_lab/agent/algorithm/sarsa.py
+++ b/slm_lab/agent/algorithm/sarsa.py
@@ -139,7 +139,7 @@ class SARSA(Algorithm):
         Completes one training step for the agent if it is time to train.
         Otherwise this function does nothing.
         '''
-        if util.get_lab_mode() in ('enjoy', 'eval'):
+        if util.in_eval_lab_modes():
             self.body.flush()
             return np.nan
         clock = self.body.env.clock

--- a/slm_lab/agent/algorithm/sarsa.py
+++ b/slm_lab/agent/algorithm/sarsa.py
@@ -158,6 +158,5 @@ class SARSA(Algorithm):
     @lab_api
     def update(self):
         '''Update the agent after training'''
-        net_util.try_store_grad_norm(self)
         self.body.explore_var = self.explore_var_scheduler.update(self, self.body.env.clock)
         return self.body.explore_var

--- a/slm_lab/agent/algorithm/sarsa.py
+++ b/slm_lab/agent/algorithm/sarsa.py
@@ -150,7 +150,7 @@ class SARSA(Algorithm):
             # reset
             self.to_train = 0
             self.body.flush()
-            logger.debug(f'Trained {self.name} at epi: {clock.epi}, total_t: {clock.total_t}, t: {clock.t}, total_reward so far: {self.body.memory.total_reward}, loss: {loss:.8f}')
+            logger.debug(f'Trained {self.name} at epi: {clock.epi}, total_t: {clock.total_t}, t: {clock.t}, total_reward so far: {self.body.memory.total_reward}, loss: {loss:g}')
             return loss.item()
         else:
             return np.nan

--- a/slm_lab/agent/algorithm/sarsa.py
+++ b/slm_lab/agent/algorithm/sarsa.py
@@ -151,7 +151,6 @@ class SARSA(Algorithm):
             self.to_train = 0
             self.body.flush()
             logger.debug(f'Trained {self.name} at epi: {clock.epi}, total_t: {clock.total_t}, t: {clock.t}, total_reward so far: {self.body.memory.total_reward}, loss: {loss:.8f}')
-
             return loss.item()
         else:
             return np.nan

--- a/slm_lab/agent/algorithm/sil.py
+++ b/slm_lab/agent/algorithm/sil.py
@@ -128,8 +128,8 @@ class SIL(ActorCritic):
         sil_policy_loss = self.sil_policy_loss_coef * torch.mean(- log_probs * clipped_advs)
         sil_val_loss = self.sil_val_loss_coef * torch.pow(clipped_advs, 2) / 2
         sil_val_loss = torch.mean(sil_val_loss)
-        logger.debug(f'SIL actor policy loss: {sil_policy_loss:.4f}')
-        logger.debug(f'SIL critic value loss: {sil_val_loss:.4f}')
+        logger.debug(f'SIL actor policy loss: {sil_policy_loss:g}')
+        logger.debug(f'SIL critic value loss: {sil_val_loss:g}')
         return sil_policy_loss, sil_val_loss
 
     def train_shared(self):
@@ -151,8 +151,7 @@ class SIL(ActorCritic):
                     total_sil_loss += sil_loss
             sil_loss = total_sil_loss / self.training_epoch
             loss = super_loss + sil_loss
-            logger.debug(f'Trained {self.name} at epi: {clock.epi}, total_t: {clock.total_t}, t: {clock.t}, total_reward so far: {self.body.memory.total_reward}, loss: {loss:.8f}')
-
+            logger.debug(f'Trained {self.name} at epi: {clock.epi}, total_t: {clock.total_t}, t: {clock.t}, total_reward so far: {self.body.memory.total_reward}, loss: {loss:g}')
             return loss.item()
         else:
             return np.nan
@@ -176,8 +175,7 @@ class SIL(ActorCritic):
                     total_sil_loss += sil_policy_loss + sil_val_loss
             sil_loss = total_sil_loss / self.training_epoch
             loss = super_loss + sil_loss
-            logger.debug(f'Trained {self.name} at epi: {clock.epi}, total_t: {clock.total_t}, t: {clock.t}, total_reward so far: {self.body.memory.total_reward}, loss: {loss:.8f}')
-
+            logger.debug(f'Trained {self.name} at epi: {clock.epi}, total_t: {clock.total_t}, t: {clock.t}, total_reward so far: {self.body.memory.total_reward}, loss: {loss:g}')
             return loss.item()
         else:
             return np.nan

--- a/slm_lab/agent/memory/base.py
+++ b/slm_lab/agent/memory/base.py
@@ -19,7 +19,6 @@ class Memory(ABC):
         '''
         @param {*} body is the unit that stores its experience in this memory. Each body has a distinct memory.
         '''
-        from slm_lab.experiment import analysis
         self.memory_spec = memory_spec
         self.body = body
 
@@ -36,7 +35,6 @@ class Memory(ABC):
         self.total_reward_h = []
         self.avg_total_reward = 0
         self.avg_total_reward_h = []
-        self.avg_window = analysis.MA_WINDOW
 
     @abstractmethod
     def reset(self):
@@ -54,6 +52,7 @@ class Memory(ABC):
 
     def base_update(self, action, reward, state, done):
         '''Method to do base memory update, like stats'''
+        from slm_lab.experiment import analysis
         if np.isnan(reward):  # the start of episode
             self.epi_reset(state)
             return
@@ -61,7 +60,7 @@ class Memory(ABC):
         self.total_reward += reward
         if done:
             self.total_reward_h.append(self.total_reward)
-            self.avg_total_reward = np.mean(self.total_reward_h[-self.avg_window:])
+            self.avg_total_reward = np.mean(self.total_reward_h[-analysis.MA_WINDOW:])
             self.avg_total_reward_h.append(self.avg_total_reward_h)
         return
 

--- a/slm_lab/agent/memory/base.py
+++ b/slm_lab/agent/memory/base.py
@@ -32,9 +32,6 @@ class Memory(ABC):
         self.state_buffer = deque(maxlen=0)
         # total_reward and its history over episodes
         self.total_reward = 0
-        self.total_reward_h = []
-        self.avg_total_reward = 0
-        self.avg_total_reward_h = []
 
     @abstractmethod
     def reset(self):
@@ -58,10 +55,6 @@ class Memory(ABC):
             return
 
         self.total_reward += reward
-        if done:
-            self.total_reward_h.append(self.total_reward)
-            self.avg_total_reward = np.mean(self.total_reward_h[-analysis.MA_WINDOW:])
-            self.avg_total_reward_h.append(self.avg_total_reward_h)
         return
 
     @abstractmethod

--- a/slm_lab/agent/net/net_util.py
+++ b/slm_lab/agent/net/net_util.py
@@ -14,8 +14,14 @@ logger = logger.get_logger(__name__)
 class NoOpLRScheduler:
     '''Symbolic LRScheduler class for API consistency'''
 
+    def __init__(self, optim):
+        self.optim = optim
+
     def step(self, epoch=None):
         pass
+
+    def get_lr(self):
+        return self.optim.defaults['lr']
 
 
 def build_sequential(dims, activation):
@@ -56,7 +62,7 @@ def get_optim(cls, optim_spec):
 def get_lr_scheduler(cls, lr_scheduler_spec):
     '''Helper to parse lr_scheduler param and construct Pytorch optim.lr_scheduler'''
     if ps.is_empty(lr_scheduler_spec):
-        lr_scheduler = NoOpLRScheduler()
+        lr_scheduler = NoOpLRScheduler(cls.optim)
     else:
         LRSchedulerClass = getattr(torch.optim.lr_scheduler, lr_scheduler_spec['name'])
         lr_scheduler_spec = ps.omit(lr_scheduler_spec, 'name')

--- a/slm_lab/agent/net/net_util.py
+++ b/slm_lab/agent/net/net_util.py
@@ -245,9 +245,11 @@ def gen_assert_trained(pre_model):
     return assert_trained
 
 
-def try_store_grad_norm(algorithm):
-    '''Check and if needed, store algorithm's net.grad_norms to body.grad_norms for debugging'''
+def get_grad_norms(algorithm):
+    '''Gather all the net's grad norms of an algorithm for debugging'''
+    grad_norms = []
     for net_name in algorithm.net_names:
         net = getattr(algorithm, net_name)
         if net.grad_norms is not None:
-            algorithm.body.grad_norms.extend(net.grad_norms)
+            grad_norms.extend(net.grad_norms)
+    return grad_norms

--- a/slm_lab/agent/net/net_util.py
+++ b/slm_lab/agent/net/net_util.py
@@ -182,7 +182,7 @@ def load_algorithm(algorithm):
     '''Save all the nets for an algorithm'''
     agent = algorithm.agent
     net_names = algorithm.net_names
-    if util.get_lab_mode() in ('enjoy', 'eval'):
+    if util.in_eval_lab_modes():
         # load specific model in eval mode
         prepath = agent.info_space.eval_model_prepath
     else:

--- a/slm_lab/env/base.py
+++ b/slm_lab/env/base.py
@@ -70,7 +70,6 @@ class BaseEnv(ABC):
       "name": "CartPole-v0",
       "max_t": null,
       "max_tick": 150,
-      "max_tick_unit": "epi",
       "save_frequency": 50
     }],
 
@@ -79,7 +78,6 @@ class BaseEnv(ABC):
       "name": "CartPole-v0",
       "max_t": null,
       "max_tick": 10000,
-      "max_tick_unit": "total_t",
       "save_frequency": 50
     }],
     '''
@@ -93,11 +91,13 @@ class BaseEnv(ABC):
         util.set_attr(self, dict(
             reward_scale=1.0,
         ))
+        util.set_attr(self, spec['meta'], [
+            'max_tick_unit',
+        ])
         util.set_attr(self, self.env_spec, [
             'name',
             'max_t',
             'max_tick',
-            'max_tick_unit',
             'save_frequency',
             'reward_scale',
         ])

--- a/slm_lab/env/base.py
+++ b/slm_lab/env/base.py
@@ -70,7 +70,6 @@ class BaseEnv(ABC):
       "name": "CartPole-v0",
       "max_t": null,
       "max_tick": 150,
-      "save_frequency": 50
     }],
 
     # or using total_t
@@ -78,7 +77,6 @@ class BaseEnv(ABC):
       "name": "CartPole-v0",
       "max_t": null,
       "max_tick": 10000,
-      "save_frequency": 50
     }],
     '''
 
@@ -92,13 +90,13 @@ class BaseEnv(ABC):
             reward_scale=1.0,
         ))
         util.set_attr(self, spec['meta'], [
+            'eval_frequency',
             'max_tick_unit',
         ])
         util.set_attr(self, self.env_spec, [
             'name',
             'max_t',
             'max_tick',
-            'save_frequency',
             'reward_scale',
         ])
         if util.get_lab_mode() == 'eval':

--- a/slm_lab/env/openai.py
+++ b/slm_lab/env/openai.py
@@ -47,7 +47,8 @@ class OpenAIEnv(BaseEnv):
                 env = wrap_deepmind(env, stack_len=stack_len, clip_rewards=False)
         self.u_env = env
         self._set_attr_from_u_env(self.u_env)
-        self.max_t = self.max_t or self.u_env.spec.tags.get('wrapper_config.TimeLimit.max_epi_steps')
+        self.max_t = self.max_t or self.u_env.spec.tags.get('wrapper_config.TimeLimit.max_episode_steps')
+        assert self.max_t is not None
         if env_space is None:  # singleton mode
             pass
         else:

--- a/slm_lab/env/openai.py
+++ b/slm_lab/env/openai.py
@@ -35,7 +35,11 @@ class OpenAIEnv(BaseEnv):
 
     def __init__(self, spec, e=None, env_space=None):
         super(OpenAIEnv, self).__init__(spec, e, env_space)
-        register_env(spec)  # register any additional environments first
+        try:
+            # register any additional environments first. guard for re-registration
+            register_env(spec)
+        except Exception as e:
+            pass
         env = gym.make(self.name)
         if 'NoFrameskip' in env.spec.id:  # for Atari
             stack_len = ps.get(spec, 'agent.0.memory.stack_len')

--- a/slm_lab/env/openai.py
+++ b/slm_lab/env/openai.py
@@ -28,7 +28,6 @@ class OpenAIEnv(BaseEnv):
       "name": "CartPole-v0",
       "max_t": null,
       "max_tick": 150,
-      "max_tick_unit": "epi",
       "save_frequency": 50
     }],
     '''

--- a/slm_lab/env/openai.py
+++ b/slm_lab/env/openai.py
@@ -28,7 +28,6 @@ class OpenAIEnv(BaseEnv):
       "name": "CartPole-v0",
       "max_t": null,
       "max_tick": 150,
-      "save_frequency": 50
     }],
     '''
 

--- a/slm_lab/env/unity.py
+++ b/slm_lab/env/unity.py
@@ -50,7 +50,6 @@ class UnityEnv(BaseEnv):
       "name": "gridworld",
       "max_t": 20,
       "max_tick": 3,
-      "max_tick_unit": "epi",
       "unity": {
         "gridSize": 6,
         "numObstacles": 2,

--- a/slm_lab/env/unity.py
+++ b/slm_lab/env/unity.py
@@ -66,6 +66,7 @@ class UnityEnv(BaseEnv):
         self.u_env = UnityEnvironment(file_name=get_env_path(self.name), worker_id=worker_id)
         self.patch_gym_spaces(self.u_env)
         self._set_attr_from_u_env(self.u_env)
+        assert self.max_t is not None
         if env_space is None:  # singleton mode
             pass
         else:

--- a/slm_lab/experiment/analysis.py
+++ b/slm_lab/experiment/analysis.py
@@ -271,7 +271,7 @@ def get_session_data(session):
     '''
     session_data = {}
     for aeb, body in util.ndenumerate_nonan(session.aeb_space.body_space.data):
-        session_data[aeb] = body.df.copy()
+        session_data[aeb] = body.eval_df.copy()
     return session_data
 
 

--- a/slm_lab/experiment/analysis.py
+++ b/slm_lab/experiment/analysis.py
@@ -264,7 +264,7 @@ def calc_mean_fitness(fitness_df):
     return fitness_df.mean(axis=1, level=3)
 
 
-def get_session_data(session, body_df_kind='eval'):
+def get_session_data(session, body_df_kind='eval', tmp_space_session_sub=False):
     '''
     Gather data from session from all the bodies
     Depending on body_df_kind, will use eval_df or train_df
@@ -272,6 +272,9 @@ def get_session_data(session, body_df_kind='eval'):
     session_data = {}
     for aeb, body in util.ndenumerate_nonan(session.aeb_space.body_space.data):
         aeb_df = body.eval_df if body_df_kind == 'eval' else body.train_df
+        # TODO tmp substitution since SpaceSession does not have run_eval_episode yet
+        if tmp_space_session_sub:
+            aeb_df = body.train_df
         session_data[aeb] = aeb_df.copy()
     return session_data
 
@@ -551,15 +554,15 @@ def _analyze_session(session, session_data, body_df_kind='eval'):
     return session_fitness_df
 
 
-def analyze_session(session):
+def analyze_session(session, tmp_space_session_sub=False):
     '''
     Gather session data, plot, and return fitness df for high level agg.
     @returns {DataFrame} session_fitness_df Single-row df of session fitness vector (avg over aeb), indexed with session index.
     '''
     logger.info('Analyzing session')
     session_data = get_session_data(session, body_df_kind='train')
-    _analyze_session(session, session_data, body_df_kind='train')
-    session_data = get_session_data(session, body_df_kind='eval')
+    session_fitness_df = _analyze_session(session, session_data, body_df_kind='train')
+    session_data = get_session_data(session, body_df_kind='eval', tmp_space_session_sub=tmp_space_session_sub)
     session_fitness_df = _analyze_session(session, session_data, body_df_kind='eval')
     return session_fitness_df
 

--- a/slm_lab/experiment/analysis.py
+++ b/slm_lab/experiment/analysis.py
@@ -362,7 +362,7 @@ def gather_aeb_rewards_df(aeb, session_datas, max_tick_unit):
         aeb_reward_sr.index = aeb_df[max_tick_unit]
         # guard for duplicate eval result
         aeb_reward_sr = aeb_reward_sr[~aeb_reward_sr.index.duplicated()]
-        if util.get_lab_mode() in ('enjoy', 'eval'):
+        if util.in_eval_lab_modes():
             # guard for eval appending possibly not ordered
             aeb_reward_sr.sort_index(inplace=True)
         aeb_session_rewards[s] = aeb_reward_sr
@@ -480,7 +480,7 @@ def plot_experiment(experiment_spec, experiment_df):
 
 def save_session_df(session_data, filepath, info_space):
     '''Save session_df, and if is in eval mode, modify it and save with append'''
-    if util.get_lab_mode() in ('enjoy', 'eval'):
+    if util.in_eval_lab_modes():
         ckpt = util.find_ckpt(info_space.eval_model_prepath)
         epi = int(re.search('epi(\d+)', ckpt)[1])
         totalt = int(re.search('totalt(\d+)', ckpt)[1])

--- a/slm_lab/experiment/analysis.py
+++ b/slm_lab/experiment/analysis.py
@@ -610,18 +610,3 @@ def analyze_experiment(experiment):
     experiment_fig = plot_experiment(experiment.spec, experiment_df)
     save_experiment_data(experiment.spec, experiment.info_space, experiment_df, experiment_fig)
     return experiment_df
-
-
-def run_online_eval(spec, info_space, ckpt):
-    '''
-    Calls a subprocess to run lab in eval mode with the constructed ckpt prepath, same as how one would manually run the bash cmd
-    @example
-
-    python run_lab.py data/dqn_cartpole_2018_12_19_224811/dqn_cartpole_t0_spec.json dqn_cartpole eval@dqn_cartpole_t0_s1_ckpt-epi10-totalt1000
-    '''
-    prepath_t = util.get_prepath(spec, info_space, unit='trial')
-    prepath_s = util.get_prepath(spec, info_space, unit='session')
-    predir, _, prename, spec_name, _, _ = util.prepath_split(prepath_s)
-    cmd = f'python run_lab.py {prepath_t}_spec.json {spec_name} eval@{prename}_ckpt-{ckpt}'
-    logger.info(f'Running online eval for ckpt-{ckpt}')
-    return util.run_cmd(cmd)

--- a/slm_lab/experiment/analysis.py
+++ b/slm_lab/experiment/analysis.py
@@ -324,7 +324,7 @@ def calc_trial_fitness_df(trial):
 
 def plot_session(session_spec, info_space, session_data):
     '''Plot the session graph, 2 panes: reward, loss & explore_var. Each aeb_df gets its own color'''
-    max_tick_unit = ps.get(session_spec, 'env.0.max_tick_unit')
+    max_tick_unit = ps.get(session_spec, 'meta.max_tick_unit')
     aeb_count = len(session_data)
     palette = viz.get_palette(aeb_count)
     fig = viz.tools.make_subplots(rows=3, cols=1, shared_xaxes=True, print_grid=False)
@@ -403,7 +403,7 @@ def calc_trial_df(trial_spec, info_space):
     predir, _, _, _, _, _ = util.prepath_split(prepath)
     session_datas = retro_analysis.session_datas_from_file(predir, trial_spec, info_space.get('trial'), ps.get(info_space, 'ckpt'))
     aeb_transpose = {aeb: [] for aeb in session_datas[list(session_datas.keys())[0]]}
-    max_tick_unit = ps.get(trial_spec, 'env.0.max_tick_unit')
+    max_tick_unit = ps.get(trial_spec, 'meta.max_tick_unit')
     for s, session_data in session_datas.items():
         for aeb, aeb_df in session_data.items():
             aeb_transpose[aeb].append(aeb_df.sort_values(by=[max_tick_unit]).set_index(max_tick_unit, drop=False))
@@ -423,7 +423,7 @@ def plot_trial(trial_spec, info_space):
     predir, _, _, _, _, _ = util.prepath_split(prepath)
     session_datas = retro_analysis.session_datas_from_file(predir, trial_spec, info_space.get('trial'), ps.get(info_space, 'ckpt'))
     rand_session_data = session_datas[list(session_datas.keys())[0]]
-    max_tick_unit = ps.get(trial_spec, 'env.0.max_tick_unit')
+    max_tick_unit = ps.get(trial_spec, 'meta.max_tick_unit')
     aeb_count = len(rand_session_data)
     palette = viz.get_palette(aeb_count)
     fig = None
@@ -485,7 +485,7 @@ def reindex_session_data(spec, session_data):
     will have index [200, 400, 600, 800] with value front-filled
     '''
     freq = ps.get(spec, 'env.0.save_frequency')
-    max_tick_unit = ps.get(spec, 'env.0.max_tick_unit')
+    max_tick_unit = ps.get(spec, 'meta.max_tick_unit')
     for aeb, aeb_df in session_data.items():
         # div int then +1 for rounding up at freq
         aeb_df.index = ((aeb_df[max_tick_unit] / freq).astype(int) + 1) * freq

--- a/slm_lab/experiment/analysis.py
+++ b/slm_lab/experiment/analysis.py
@@ -479,12 +479,12 @@ def plot_experiment(experiment_spec, experiment_df):
 
 def reindex_session_data(spec, session_data):
     '''
-    Reindex session_data to make max_tick_unit column values round up to multiples of save_frequency
-    then reindex to start from min to max max_tick_unit with regular ticks at save_frequency
-    e.g. aeb_df in session_data with index total_t [100, 320, 700] with save_frequency 200
+    Reindex session_data to make max_tick_unit column values round up to multiples of eval_frequency
+    then reindex to start from min to max max_tick_unit with regular ticks at eval_frequency
+    e.g. aeb_df in session_data with index total_t [100, 320, 700] with eval_frequency 200
     will have index [200, 400, 600, 800] with value front-filled
     '''
-    freq = ps.get(spec, 'env.0.save_frequency')
+    freq = ps.get(spec, 'meta.eval_frequency')
     max_tick_unit = ps.get(spec, 'meta.max_tick_unit')
     for aeb, aeb_df in session_data.items():
         # div int then +1 for rounding up at freq

--- a/slm_lab/experiment/analysis.py
+++ b/slm_lab/experiment/analysis.py
@@ -205,7 +205,7 @@ Checkpoint and early termination analysis
 '''
 
 
-def get_reward_mas(agent, name='current_reward_ma'):
+def get_reward_mas(agent, name='eval_reward_ma'):
     '''Return array of the named reward_ma for all of an agent's bodies.'''
     bodies = getattr(agent, 'nanflat_body_a', [agent.body])
     return np.array([getattr(body, name) for body in bodies], dtype=np.float16)
@@ -220,22 +220,22 @@ def get_std_epi_rewards(agent):
 def new_best(agent):
     '''Check if algorithm is now the new best result, then update the new best'''
     best_reward_mas = get_reward_mas(agent, 'best_reward_ma')
-    current_reward_mas = get_reward_mas(agent, 'current_reward_ma')
-    best = (current_reward_mas >= best_reward_mas).all()
+    eval_reward_mas = get_reward_mas(agent, 'eval_reward_ma')
+    best = (eval_reward_mas >= best_reward_mas).all()
     if best:
         bodies = getattr(agent, 'nanflat_body_a', [agent.body])
         for body in bodies:
-            body.best_reward_ma = body.current_reward_ma
+            body.best_reward_ma = body.eval_reward_ma
     return best
 
 
 def all_solved(agent):
     '''Check if envs have all been solved using std from slm_lab/spec/_fitness_std.json'''
-    current_reward_mas = get_reward_mas(agent, 'current_reward_ma')
+    eval_reward_mas = get_reward_mas(agent, 'eval_reward_ma')
     std_epi_rewards = get_std_epi_rewards(agent)
     solved = (
         not np.isnan(std_epi_rewards).any() and
-        (current_reward_mas >= std_epi_rewards).all()
+        (eval_reward_mas >= std_epi_rewards).all()
     )
     return solved
 

--- a/slm_lab/experiment/control.py
+++ b/slm_lab/experiment/control.py
@@ -136,10 +136,12 @@ class SpaceSession(Session):
 
     def try_ckpt(self, agent_space, env_space):
         '''Try to checkpoint agent at the start, save_freq, and the end'''
-        for agent in agent_space.agents:
-            for body in agent.nanflat_body_a:
-                env = body.env
-                super(SpaceSession, self).try_ckpt(agent, env)
+        # TODO ckpt and eval not implemented for SpaceSession
+        pass
+        # for agent in agent_space.agents:
+        #     for body in agent.nanflat_body_a:
+        #         env = body.env
+        #         super(SpaceSession, self).try_ckpt(agent, env)
 
     def run_all_episodes(self):
         '''

--- a/slm_lab/experiment/control.py
+++ b/slm_lab/experiment/control.py
@@ -76,7 +76,7 @@ class Session:
             total_reward += reward
         # update body.eval_df
         self.agent.body.eval_update(self.eval_env, total_reward)
-        self.agent.body.log_summary(mode='eval')
+        self.agent.body.log_summary(body_df_kind='eval')
 
     def run_episode(self):
         self.env.clock.tick('epi')
@@ -90,7 +90,7 @@ class Session:
             reward, state, done = self.env.step(action)
             self.agent.update(action, reward, state, done)
         self.try_ckpt(self.agent, self.env)  # final timestep ckpt
-        self.agent.body.log_summary(mode='train')
+        self.agent.body.log_summary(body_df_kind='train')
 
     def close(self):
         '''

--- a/slm_lab/experiment/control.py
+++ b/slm_lab/experiment/control.py
@@ -171,7 +171,7 @@ class SpaceSession(Session):
 
     def run(self):
         self.run_all_episodes()
-        self.data = analysis.analyze_session(self)  # session fitness
+        self.data = analysis.analyze_session(self, tmp_space_session_sub=True)  # session fitness
         self.close()
         return self.data
 

--- a/slm_lab/experiment/control.py
+++ b/slm_lab/experiment/control.py
@@ -33,11 +33,12 @@ class Session:
 
         # init singleton agent and env
         self.env = make_env(self.spec)
+        util.set_rand_seed(self.info_space.get_random_seed(), self.env)
         with util.ctx_lab_mode('eval'):  # env for eval
             self.eval_env = make_env(self.spec)
-        body = Body(self.env, self.spec['agent'])
-        util.set_rand_seed(self.info_space.get_random_seed(), self.env)
+            util.set_rand_seed(self.info_space.get_random_seed(), self.eval_env)
         util.try_set_cuda_id(self.spec, self.info_space)
+        body = Body(self.env, self.spec['agent'])
         self.agent = Agent(self.spec, self.info_space, body=body, global_nets=global_nets)
 
         enable_aeb_space(self)  # to use lab's data analysis framework
@@ -103,6 +104,7 @@ class Session:
         '''
         self.agent.close()
         self.env.close()
+        self.eval_env.close()
         logger.info('Session done and closed.')
 
     def run(self):

--- a/slm_lab/experiment/control.py
+++ b/slm_lab/experiment/control.py
@@ -67,6 +67,22 @@ class Session:
             if tick > 0:  # nothing to analyze at start
                 analysis.analyze_session(self)
 
+    def run_eval_episode(self):
+        self.eval_env.clock.tick('epi')
+        # logger.info(f'Running trial {self.info_space.get("trial")} session {self.index} episode {self.eval_env.clock.epi}')
+        logger.info('Running eval episode')
+        total_reward = 0
+        reward, state, done = self.eval_env.reset()
+        while not done:
+            self.eval_env.clock.tick('t')
+            action = self.agent.act(state)
+            reward, state, done = self.eval_env.step(action)
+            total_reward += reward
+        # update body.eval_df
+        self.agent.body.eval_update(self.eval_env, total_reward)
+        logger.info(f'Eval episode done, total_reward: {total_reward}')
+        print(self.agent.body.eval_df)
+
     def run_episode(self):
         self.env.clock.tick('epi')
         logger.info(f'Running trial {self.info_space.get("trial")} session {self.index} episode {self.env.clock.epi}')

--- a/slm_lab/experiment/control.py
+++ b/slm_lab/experiment/control.py
@@ -49,7 +49,7 @@ class Session:
         tick = env.clock.get(env.max_tick_unit)
         to_ckpt = False
         if util.get_lab_mode() not in ('enjoy', 'eval') and tick <= env.max_tick:
-            to_ckpt = (tick % env.save_frequency == 0) or tick == env.max_tick
+            to_ckpt = (tick % env.eval_frequency == 0) or tick == env.max_tick
         if env.max_tick_unit == 'epi':  # extra condition for epi
             to_ckpt = to_ckpt and env.done
 

--- a/slm_lab/experiment/control.py
+++ b/slm_lab/experiment/control.py
@@ -48,7 +48,7 @@ class Session:
         '''Try to checkpoint agent at the start, save_freq, and the end'''
         tick = env.clock.get(env.max_tick_unit)
         to_ckpt = False
-        if util.get_lab_mode() not in ('enjoy', 'eval') and tick <= env.max_tick:
+        if not util.in_eval_lab_modes() and tick <= env.max_tick:
             to_ckpt = (tick % env.eval_frequency == 0) or tick == env.max_tick
         if env.max_tick_unit == 'epi':  # extra condition for epi
             to_ckpt = to_ckpt and env.done
@@ -57,7 +57,7 @@ class Session:
             if self.spec['meta'].get('parallel_eval'):
                 retro_analysis.run_parallel_eval(self, agent, env)
             else:
-                with util.ctx_lab_mode('eval'):  # env for eval
+                with util.ctx_lab_mode('eval'):  # run eval in context
                     self.run_eval_episode()
             if analysis.new_best(agent):
                 agent.save(ckpt='best')
@@ -105,7 +105,7 @@ class Session:
     def run(self):
         while self.env.clock.get(self.env.max_tick_unit) < self.env.max_tick:
             self.run_episode()
-            if util.get_lab_mode() not in ('enjoy', 'eval') and analysis.all_solved(self.agent):
+            if not util.in_eval_lab_modes() and analysis.all_solved(self.agent):
                 logger.info('All environments solved. Early exit.')
                 break
         retro_analysis.try_wait_parallel_eval(self)

--- a/slm_lab/experiment/control.py
+++ b/slm_lab/experiment/control.py
@@ -69,8 +69,7 @@ class Session:
 
     def run_eval_episode(self):
         self.eval_env.clock.tick('epi')
-        # logger.info(f'Running trial {self.info_space.get("trial")} session {self.index} episode {self.eval_env.clock.epi}')
-        logger.info('Running eval episode')
+        logger.info(f'Running eval episode for trial {self.info_space.get("trial")} session {self.index}')
         total_reward = 0
         reward, state, done = self.eval_env.reset()
         while not done:
@@ -80,8 +79,7 @@ class Session:
             total_reward += reward
         # update body.eval_df
         self.agent.body.eval_update(self.eval_env, total_reward)
-        logger.info(f'Eval episode done, total_reward: {total_reward}')
-        print(self.agent.body.eval_df)
+        self.agent.body.log_summary(mode='eval')
 
     def run_episode(self):
         self.env.clock.tick('epi')
@@ -95,7 +93,7 @@ class Session:
             reward, state, done = self.env.step(action)
             self.agent.update(action, reward, state, done)
         self.try_ckpt(self.agent, self.env)  # final timestep ckpt
-        self.agent.body.log_summary()
+        self.agent.body.log_summary(mode='train')
 
     def close(self):
         '''

--- a/slm_lab/experiment/control.py
+++ b/slm_lab/experiment/control.py
@@ -55,7 +55,8 @@ class Session:
             to_ckpt = to_ckpt and env.done
 
         if to_ckpt:
-            self.run_eval_episode()
+            with util.ctx_lab_mode('eval'):  # env for eval
+                self.run_eval_episode()
             if analysis.new_best(agent):
                 agent.save(ckpt='best')
             # run online eval for train mode

--- a/slm_lab/experiment/control.py
+++ b/slm_lab/experiment/control.py
@@ -33,6 +33,8 @@ class Session:
 
         # init singleton agent and env
         self.env = make_env(self.spec)
+        with util.ctx_lab_mode('eval'):  # env for eval
+            self.eval_env = make_env(self.spec)
         body = Body(self.env, self.spec['agent'])
         util.set_rand_seed(self.info_space.get_random_seed(), self.env)
         util.try_set_cuda_id(self.spec, self.info_space)
@@ -53,6 +55,7 @@ class Session:
             to_ckpt = to_ckpt and env.done
 
         if to_ckpt:
+            self.run_eval_episode()
             if analysis.new_best(agent):
                 agent.save(ckpt='best')
             # run online eval for train mode

--- a/slm_lab/experiment/control.py
+++ b/slm_lab/experiment/control.py
@@ -58,7 +58,9 @@ class Session:
                 retro_analysis.run_parallel_eval(self, agent, env)
             else:
                 with util.ctx_lab_mode('eval'):  # run eval in context
+                    self.agent.algorithm.update()  # set explore_var etc. to end_val under ctx
                     self.run_eval_episode()
+                self.agent.algorithm.update()  # restore outside of ctx
             if analysis.new_best(agent):
                 agent.save(ckpt='best')
             if tick > 0:  # nothing to analyze at start

--- a/slm_lab/experiment/monitor.py
+++ b/slm_lab/experiment/monitor.py
@@ -162,7 +162,7 @@ class Body:
             't': env.clock.get('t'),
             'reward': total_reward,
             'loss': self.loss,
-            'lr': self.get_net_avg_lrs(),
+            'lr': self.get_mean_lr(),
             'explore_var': self.explore_var,
             'entropy_coef': self.entropy_coef if hasattr(self, 'entropy_coef') else np.nan,
             'entropy': self.mean_entropy,
@@ -215,20 +215,17 @@ class Body:
     def __str__(self):
         return 'body: ' + util.to_json(util.get_class_attr(self))
 
-    def get_net_avg_lrs(self):
+    def get_mean_lr(self):
         '''Gets the average current learning rate of the algorithm's nets.'''
         if not hasattr(self.agent.algorithm, 'net_names'):
             return np.nan
         lrs = []
         for net_name in self.agent.algorithm.net_names:
+            # we are only interested in directly trainable network, so exclude target net
             if net_name is 'target_net':
                 continue
             net = getattr(self.agent.algorithm, net_name)
-            if net.lr_scheduler.__class__.__name__ == 'NoOpLRScheduler':
-                lr = net.optim_spec['lr']
-            else:
-                lr = net.lr_scheduler.get_lr()
-            lrs.append(lr)
+            lrs.append(net.lr_scheduler.get_lr())
         return np.mean(lrs)
 
     def get_log_prefix(self):

--- a/slm_lab/experiment/monitor.py
+++ b/slm_lab/experiment/monitor.py
@@ -92,12 +92,11 @@ class Body:
         self.nanflat_a_idx = self.a
         self.nanflat_e_idx = self.e
 
-        # stats variables
-        self.loss = np.nan  # training losses
-        self.last_loss = np.nan  # the last non-nan loss, for printing
         # for action policy exploration, so be set in algo during init_algorithm_params()
         self.explore_var = np.nan
 
+        # body stats variables
+        self.loss = np.nan  # training losses
         # diagnostics variables/stats from action_policy prob. dist.
         self.action_tensor = None
         self.action_pd = None  # for the latest action, to compute entropy and log prob
@@ -162,7 +161,7 @@ class Body:
             # t and reward are measured from a given env or eval_env
             't': env.clock.get('t'),
             'reward': total_reward,
-            'loss': self.last_loss,
+            'loss': self.loss,
             'lr': self.get_net_avg_lrs(),
             'explore_var': self.explore_var,
             'entropy_coef': self.entropy_coef if hasattr(self, 'entropy_coef') else np.nan,
@@ -244,7 +243,7 @@ class Body:
         '''Log the summary for this body when its environment is done'''
         prefix = self.get_log_prefix()
         memory = self.memory
-        msg = f'{prefix}, loss: {self.last_loss:.8f}, total_reward: {memory.total_reward:.4f}, last-{analysis.MA_WINDOW}-epi avg: {memory.avg_total_reward:.4f}'
+        msg = f'{prefix}, loss: {self.loss:.8f}, total_reward: {memory.total_reward:.4f}, last-{analysis.MA_WINDOW}-epi avg: {memory.avg_total_reward:.4f}'
         logger.info(msg)
 
     def space_init(self, aeb_space):

--- a/slm_lab/experiment/monitor.py
+++ b/slm_lab/experiment/monitor.py
@@ -236,15 +236,15 @@ class Body:
         prefix = f'{spec["name"]}_t{info_space.get("trial")}_s{info_space.get("session")}, aeb{self.aeb}'
         return prefix
 
-    def log_summary(self, mode='train'):
+    def log_summary(self, body_df_kind='eval'):
         '''Log the summary for this body when its environment is done'''
         prefix = self.get_log_prefix()
-        df = self.eval_df if mode == 'eval' else self.train_df
+        df = self.eval_df if body_df_kind == 'eval' else self.train_df
         last_row = df.iloc[-1]
         row_str = ', '.join([f'{k}: {v:g}' for k, v in last_row.items()])
         reward_ma = df[-analysis.MA_WINDOW:]['reward'].mean()
         reward_ma_str = f'last-{analysis.MA_WINDOW}-epi avg: {reward_ma:g}'
-        msg = f'{prefix} [{mode}_df] {row_str}, {reward_ma_str}'
+        msg = f'{prefix} [{body_df_kind}_df] {row_str}, {reward_ma_str}'
         logger.info(msg)
 
     def space_init(self, aeb_space):
@@ -425,7 +425,7 @@ class AEBSpace:
         for env in self.env_space.envs:
             if env.done:
                 for body in env.nanflat_body_e:
-                    body.log_summary(mode='train')
+                    body.log_summary(body_df_kind='train')
             env.clock.tick(unit or ('epi' if env.done else 't'))
             end_session = not (env.clock.get(env.max_tick_unit) < env.max_tick)
             end_sessions.append(end_session)

--- a/slm_lab/experiment/monitor.py
+++ b/slm_lab/experiment/monitor.py
@@ -89,8 +89,7 @@ class Body:
         self.env = env
         self.aeb = aeb
         self.a, self.e, self.b = aeb
-        self.nanflat_a_idx = self.a
-        self.nanflat_e_idx = self.e
+        self.nanflat_a_idx, self.nanflat_e_idx = self.a, self.e
 
         # for action policy exploration, so be set in algo during init_algorithm_params()
         self.explore_var = np.nan
@@ -251,8 +250,7 @@ class Body:
         '''Post init override for space body. Note that aeb is already correct from __init__'''
         self.aeb_space = aeb_space
         # to be reset properly later
-        self.nanflat_a_idx = None
-        self.nanflat_e_idx = None
+        self.nanflat_a_idx, self.nanflat_e_idx = None, None
 
         self.observation_space = self.env.observation_spaces[self.a]
         self.action_space = self.env.action_spaces[self.a]

--- a/slm_lab/experiment/monitor.py
+++ b/slm_lab/experiment/monitor.py
@@ -23,6 +23,7 @@ from gym import spaces
 from slm_lab.agent import AGENT_DATA_NAMES
 from slm_lab.agent.algorithm import policy_util
 from slm_lab.env import ENV_DATA_NAMES
+from slm_lab.experiment import analysis
 from slm_lab.lib import logger, util
 from slm_lab.spec import spec_util
 import numpy as np
@@ -189,14 +190,14 @@ class Body:
         row = self.calc_df_row(self.env, self.memory.total_reward)
         # append efficiently to df
         self.train_df.loc[len(self.train_df)] = row
-        # update current reward_ma
-        self.current_reward_ma = self.memory.avg_total_reward
 
     def eval_update(self, eval_env, total_reward):
         '''Update to append data at eval checkpoint'''
         row = self.calc_df_row(eval_env, total_reward)
         # append efficiently to df
         self.eval_df.loc[len(self.eval_df)] = row
+        # update current reward_ma
+        self.current_reward_ma = self.eval_df[-analysis.MA_WINDOW:]['reward'].mean()
 
     def flush(self):
         '''Flush gradient-related variables after training step similar.'''
@@ -237,7 +238,7 @@ class Body:
         '''Log the summary for this body when its environment is done'''
         prefix = self.get_log_prefix()
         memory = self.memory
-        msg = f'{prefix}, loss: {self.last_loss:.8f}, total_reward: {memory.total_reward:.4f}, last-{memory.avg_window}-epi avg: {memory.avg_total_reward:.4f}'
+        msg = f'{prefix}, loss: {self.last_loss:.8f}, total_reward: {memory.total_reward:.4f}, last-{analysis.MA_WINDOW}-epi avg: {memory.avg_total_reward:.4f}'
         logger.info(msg)
 
     def space_init(self, aeb_space):

--- a/slm_lab/experiment/retro_analysis.py
+++ b/slm_lab/experiment/retro_analysis.py
@@ -14,11 +14,11 @@ import regex as re
 logger = logger.get_logger(__name__)
 
 
-def session_data_from_file(predir, trial_index, session_index, ckpt=None):
+def session_data_from_file(predir, trial_index, session_index, ckpt=None, prefix=''):
     '''Build session.session_data from file'''
     ckpt_str = '' if ckpt is None else f'_ckpt-{ckpt}'
     for filename in os.listdir(predir):
-        if filename.endswith(f'_t{trial_index}_s{session_index}{ckpt_str}_session_df.csv'):
+        if filename.endswith(f'_t{trial_index}_s{session_index}{ckpt_str}_{prefix}session_df.csv'):
             filepath = f'{predir}/{filename}'
             session_df = util.read(filepath, header=[0, 1, 2, 3], index_col=0)
             session_data = util.session_df_to_data(session_df)
@@ -135,11 +135,11 @@ def retro_analyze_sessions(predir):
         # to account for both types of session_df
         if filename.endswith('_session_df.csv'):
             body_df_kind = 'eval'  # from body.eval_df
-            predix = ''
+            prefix = ''
             is_session_df = True
         elif filename.endswith('_trainsession_df.csv'):
             body_df_kind = 'train'  # from body.train_df
-            predix = 'train'
+            prefix = 'train'
             is_session_df = True
         else:
             is_session_df = False
@@ -150,7 +150,7 @@ def retro_analyze_sessions(predir):
             trial_index, session_index = util.prepath_to_idxs(prepath)
             SessionClass = Session if spec_util.is_singleton(spec) else SpaceSession
             session = SessionClass(spec, info_space)
-            session_data = session_data_from_file(predir, trial_index, session_index, ps.get(info_space, 'ckpt'))
+            session_data = session_data_from_file(predir, trial_index, session_index, ps.get(info_space, 'ckpt'), prefix)
             analysis._analyze_session(session, session_data, body_df_kind)
 
 

--- a/slm_lab/experiment/retro_analysis.py
+++ b/slm_lab/experiment/retro_analysis.py
@@ -132,14 +132,26 @@ def retro_analyze_sessions(predir):
     logger.info('Retro-analyzing sessions from file')
     from slm_lab.experiment.control import Session, SpaceSession
     for filename in os.listdir(predir):
+        # to account for both types of session_df
         if filename.endswith('_session_df.csv'):
-            prepath = f'{predir}/{filename}'.replace('_session_df.csv', '')
+            body_df_kind = 'eval'  # from body.eval_df
+            predix = ''
+            is_session_df = True
+        elif filename.endswith('_trainsession_df.csv'):
+            body_df_kind = 'train'  # from body.train_df
+            predix = 'train'
+            is_session_df = True
+        else:
+            is_session_df = False
+
+        if is_session_df:
+            prepath = f'{predir}/{filename}'.replace(f'_{prefix}session_df.csv', '')
             spec, info_space = util.prepath_to_spec_info_space(prepath)
             trial_index, session_index = util.prepath_to_idxs(prepath)
             SessionClass = Session if spec_util.is_singleton(spec) else SpaceSession
             session = SessionClass(spec, info_space)
             session_data = session_data_from_file(predir, trial_index, session_index, ps.get(info_space, 'ckpt'))
-            analysis.analyze_session(session, session_data)
+            analysis._analyze_session(session, session_data, body_df_kind)
 
 
 def retro_analyze_trials(predir):

--- a/slm_lab/lib/util.py
+++ b/slm_lab/lib/util.py
@@ -286,12 +286,12 @@ def is_jupyter():
 @contextmanager
 def ctx_lab_mode(lab_mode):
     '''
-    Set lab_mode for a context
+    Creates context to run method with a specific lab_mode
     @example
     with util.ctx_lab_mode('eval'):
         run_eval()
     '''
-    prev_lab_mode = os.environ['lab_mode']
+    prev_lab_mode = os.environ.get('lab_mode')
     os.environ['lab_mode'] = lab_mode
     yield
     os.environ['lab_mode'] = prev_lab_mode

--- a/slm_lab/lib/util.py
+++ b/slm_lab/lib/util.py
@@ -1,7 +1,7 @@
 from contextlib import contextmanager
 from datetime import datetime
 from importlib import reload
-from slm_lab import ROOT_DIR
+from slm_lab import ROOT_DIR, EVAL_MODES
 import cv2
 import json
 import numpy as np
@@ -271,6 +271,11 @@ def guard_data_a(cls, data_a, data_name):
             new_data_a[eb] = data_a
         data_a = new_data_a
     return data_a
+
+
+def in_eval_lab_modes():
+    '''Check if lab_mode is one of EVAL_MODES'''
+    return get_lab_mode() in EVAL_MODES
 
 
 def is_jupyter():

--- a/slm_lab/lib/util.py
+++ b/slm_lab/lib/util.py
@@ -1,3 +1,4 @@
+from contextlib import contextmanager
 from datetime import datetime
 from importlib import reload
 from slm_lab import ROOT_DIR
@@ -280,6 +281,20 @@ def is_jupyter():
     except NameError:
         return False
     return False
+
+
+@contextmanager
+def ctx_lab_mode(lab_mode):
+    '''
+    Set lab_mode for a context
+    @example
+    with util.ctx_lab_mode('eval'):
+        run_eval()
+    '''
+    prev_lab_mode = os.environ['lab_mode']
+    os.environ['lab_mode'] = lab_mode
+    yield
+    os.environ['lab_mode'] = prev_lab_mode
 
 
 def monkey_patch(base_cls, extend_cls):

--- a/slm_lab/lib/util.py
+++ b/slm_lab/lib/util.py
@@ -294,7 +294,10 @@ def ctx_lab_mode(lab_mode):
     prev_lab_mode = os.environ.get('lab_mode')
     os.environ['lab_mode'] = lab_mode
     yield
-    os.environ['lab_mode'] = prev_lab_mode
+    if prev_lab_mode is None:
+        del os.environ['lab_mode']
+    else:
+        os.environ['lab_mode'] = prev_lab_mode
 
 
 def monkey_patch(base_cls, extend_cls):

--- a/slm_lab/spec/base.json
+++ b/slm_lab/spec/base.json
@@ -14,7 +14,6 @@
       "name": "gridworld",
       "max_t": 20,
       "max_tick": 3,
-      "max_tick_unit": "epi",
       "unity": {
         "gridSize": 6,
         "numObstacles": 2,
@@ -27,6 +26,7 @@
     },
     "meta": {
       "distributed": false,
+      "max_tick_unit": "epi",
       "max_session": 1,
       "max_trial": 1,
       "search": "RandomSearch",
@@ -63,7 +63,6 @@
       "name": "CartPole-v0",
       "max_t": 20,
       "max_tick": 3,
-      "max_tick_unit": "epi",
     }],
     "body": {
       "product": "outer",
@@ -71,6 +70,7 @@
     },
     "meta": {
       "distributed": false,
+      "max_tick_unit": "epi",
       "max_session": 1,
       "max_trial": 1,
       "search": "RandomSearch"
@@ -95,7 +95,6 @@
       "name": "CartPole-v0",
       "max_t": 10,
       "max_tick": 1,
-      "max_tick_unit": "epi",
     }],
     "body": {
       "product": "outer",
@@ -103,6 +102,7 @@
     },
     "meta": {
       "distributed": false,
+      "max_tick_unit": "epi",
       "max_session": 1,
       "max_trial": 1,
       "search": "RandomSearch"
@@ -124,7 +124,6 @@
       "name": "CartPole-v0",
       "max_t": 10,
       "max_tick": 1,
-      "max_tick_unit": "epi",
     }],
     "body": {
       "product": "outer",
@@ -132,6 +131,7 @@
     },
     "meta": {
       "distributed": false,
+      "max_tick_unit": "epi",
       "max_session": 1,
       "max_trial": 1,
       "search": "RandomSearch"
@@ -153,7 +153,6 @@
       "name": "CartPole-v0",
       "max_t": 10,
       "max_tick": 1,
-      "max_tick_unit": "epi",
     }],
     "body": {
       "product": "outer",
@@ -161,6 +160,7 @@
     },
     "meta": {
       "distributed": false,
+      "max_tick_unit": "epi",
       "max_session": 1,
       "max_trial": 1,
       "search": "RandomSearch"
@@ -186,7 +186,6 @@
       "name": "CartPole-v0",
       "max_t": 10,
       "max_tick": 1,
-      "max_tick_unit": "epi",
     }],
     "body": {
       "product": "outer",
@@ -194,6 +193,7 @@
     },
     "meta": {
       "distributed": false,
+      "max_tick_unit": "epi",
       "max_session": 1,
       "max_trial": 1,
       "search": "RandomSearch",
@@ -215,7 +215,6 @@
       "name": "3dball",
       "max_t": 20,
       "max_tick": 3,
-      "max_tick_unit": "epi",
     }],
     "body": {
       "product": "outer",
@@ -223,6 +222,7 @@
     },
     "meta": {
       "distributed": false,
+      "max_tick_unit": "epi",
       "max_session": 1,
       "max_trial": 1,
       "search": "RandomSearch"
@@ -252,7 +252,6 @@
       "name": "tennis",
       "max_t": 20,
       "max_tick": 3,
-      "max_tick_unit": "epi",
     }],
     "body": {
       "product": "outer",
@@ -260,6 +259,7 @@
     },
     "meta": {
       "distributed": false,
+      "max_tick_unit": "epi",
       "max_session": 1,
       "max_trial": 1,
       "search": "RandomSearch"
@@ -280,12 +280,10 @@
       "name": "gridworld",
       "max_t": 20,
       "max_tick": 3,
-      "max_tick_unit": "epi",
     }, {
       "name": "3dball",
       "max_t": 20,
       "max_tick": 3,
-      "max_tick_unit": "epi",
     }],
     "body": {
       "product": "outer",
@@ -293,6 +291,7 @@
     },
     "meta": {
       "distributed": false,
+      "max_tick_unit": "epi",
       "max_session": 1,
       "max_trial": 1,
       "search": "RandomSearch"
@@ -322,12 +321,10 @@
       "name": "tennis",
       "max_t": 20,
       "max_tick": 3,
-      "max_tick_unit": "epi",
     }, {
       "name": "tennis",
       "max_t": 20,
       "max_tick": 3,
-      "max_tick_unit": "epi",
     }],
     "body": {
       "product": "outer",
@@ -335,6 +332,7 @@
     },
     "meta": {
       "distributed": false,
+      "max_tick_unit": "epi",
       "max_session": 1,
       "max_trial": 1,
       "search": "RandomSearch"
@@ -364,12 +362,10 @@
       "name": "gridworld",
       "max_t": 20,
       "max_tick": 3,
-      "max_tick_unit": "epi",
     }, {
       "name": "3dball",
       "max_t": 20,
       "max_tick": 3,
-      "max_tick_unit": "epi",
     }],
     "body": {
       "product": "outer",
@@ -377,6 +373,7 @@
     },
     "meta": {
       "distributed": false,
+      "max_tick_unit": "epi",
       "max_session": 1,
       "max_trial": 1,
       "search": "RandomSearch"
@@ -406,12 +403,10 @@
       "name": "gridworld",
       "max_t": 20,
       "max_tick": 3,
-      "max_tick_unit": "epi",
     }, {
       "name": "3dball",
       "max_t": 20,
       "max_tick": 3,
-      "max_tick_unit": "epi",
     }],
     "body": {
       "product": "inner",
@@ -419,6 +414,7 @@
     },
     "meta": {
       "distributed": false,
+      "max_tick_unit": "epi",
       "max_session": 1,
       "max_trial": 1,
       "search": "RandomSearch"
@@ -439,12 +435,10 @@
       "name": "gridworld",
       "max_t": 20,
       "max_tick": 3,
-      "max_tick_unit": "epi",
     }, {
       "name": "3dball",
       "max_t": 20,
       "max_tick": 3,
-      "max_tick_unit": "epi",
     }],
     "body": {
       "product": "custom",
@@ -466,6 +460,7 @@
     },
     "meta": {
       "distributed": false,
+      "max_tick_unit": "epi",
       "max_session": 1,
       "max_trial": 1,
       "search": "RandomSearch"

--- a/slm_lab/spec/base.json
+++ b/slm_lab/spec/base.json
@@ -26,6 +26,7 @@
     },
     "meta": {
       "distributed": false,
+      "eval_frequency": 1000,
       "max_tick_unit": "epi",
       "max_session": 1,
       "max_trial": 1,
@@ -70,6 +71,7 @@
     },
     "meta": {
       "distributed": false,
+      "eval_frequency": 1000,
       "max_tick_unit": "epi",
       "max_session": 1,
       "max_trial": 1,
@@ -102,6 +104,7 @@
     },
     "meta": {
       "distributed": false,
+      "eval_frequency": 1000,
       "max_tick_unit": "epi",
       "max_session": 1,
       "max_trial": 1,
@@ -131,6 +134,7 @@
     },
     "meta": {
       "distributed": false,
+      "eval_frequency": 1000,
       "max_tick_unit": "epi",
       "max_session": 1,
       "max_trial": 1,
@@ -160,6 +164,7 @@
     },
     "meta": {
       "distributed": false,
+      "eval_frequency": 1000,
       "max_tick_unit": "epi",
       "max_session": 1,
       "max_trial": 1,
@@ -193,6 +198,7 @@
     },
     "meta": {
       "distributed": false,
+      "eval_frequency": 1000,
       "max_tick_unit": "epi",
       "max_session": 1,
       "max_trial": 1,
@@ -222,6 +228,7 @@
     },
     "meta": {
       "distributed": false,
+      "eval_frequency": 1000,
       "max_tick_unit": "epi",
       "max_session": 1,
       "max_trial": 1,
@@ -259,6 +266,7 @@
     },
     "meta": {
       "distributed": false,
+      "eval_frequency": 1000,
       "max_tick_unit": "epi",
       "max_session": 1,
       "max_trial": 1,
@@ -291,6 +299,7 @@
     },
     "meta": {
       "distributed": false,
+      "eval_frequency": 1000,
       "max_tick_unit": "epi",
       "max_session": 1,
       "max_trial": 1,
@@ -332,6 +341,7 @@
     },
     "meta": {
       "distributed": false,
+      "eval_frequency": 1000,
       "max_tick_unit": "epi",
       "max_session": 1,
       "max_trial": 1,
@@ -373,6 +383,7 @@
     },
     "meta": {
       "distributed": false,
+      "eval_frequency": 1000,
       "max_tick_unit": "epi",
       "max_session": 1,
       "max_trial": 1,
@@ -414,6 +425,7 @@
     },
     "meta": {
       "distributed": false,
+      "eval_frequency": 1000,
       "max_tick_unit": "epi",
       "max_session": 1,
       "max_trial": 1,
@@ -460,6 +472,7 @@
     },
     "meta": {
       "distributed": false,
+      "eval_frequency": 1000,
       "max_tick_unit": "epi",
       "max_session": 1,
       "max_trial": 1,

--- a/slm_lab/spec/benchmark/ddqn_lunar.json
+++ b/slm_lab/spec/benchmark/ddqn_lunar.json
@@ -59,7 +59,6 @@
       "name": "LunarLander-v2",
       "max_t": null,
       "max_tick": 250000,
-      "max_tick_unit": "total_t",
       "save_frequency": 10000
     }],
     "body": {
@@ -68,6 +67,7 @@
     },
     "meta": {
       "distributed": false,
+      "max_tick_unit": "total_t",
       "max_session": 4,
       "max_trial": 62,
       "search": "RandomSearch",

--- a/slm_lab/spec/benchmark/ddqn_lunar.json
+++ b/slm_lab/spec/benchmark/ddqn_lunar.json
@@ -58,8 +58,7 @@
     "env": [{
       "name": "LunarLander-v2",
       "max_t": null,
-      "max_tick": 250000,
-      "save_frequency": 10000
+      "max_tick": 250000
     }],
     "body": {
       "product": "outer",
@@ -67,6 +66,7 @@
     },
     "meta": {
       "distributed": false,
+      "eval_frequency": 1000,
       "max_tick_unit": "total_t",
       "max_session": 4,
       "max_trial": 62,

--- a/slm_lab/spec/benchmark/dqn_lunar.json
+++ b/slm_lab/spec/benchmark/dqn_lunar.json
@@ -57,8 +57,7 @@
     "env": [{
       "name": "LunarLander-v2",
       "max_t": null,
-      "max_tick": 250000,
-      "save_frequency": 10000
+      "max_tick": 250000
     }],
     "body": {
       "product": "outer",
@@ -66,6 +65,7 @@
     },
     "meta": {
       "distributed": false,
+      "eval_frequency": 1000,
       "max_tick_unit": "total_t",
       "max_session": 4,
       "max_trial": 62,

--- a/slm_lab/spec/benchmark/dqn_lunar.json
+++ b/slm_lab/spec/benchmark/dqn_lunar.json
@@ -58,7 +58,6 @@
       "name": "LunarLander-v2",
       "max_t": null,
       "max_tick": 250000,
-      "max_tick_unit": "total_t",
       "save_frequency": 10000
     }],
     "body": {
@@ -67,6 +66,7 @@
     },
     "meta": {
       "distributed": false,
+      "max_tick_unit": "total_t",
       "max_session": 4,
       "max_trial": 62,
       "search": "RandomSearch",

--- a/slm_lab/spec/demo.json
+++ b/slm_lab/spec/demo.json
@@ -52,8 +52,7 @@
     "env": [{
       "name": "CartPole-v0",
       "max_t": null,
-      "max_tick": 10000,
-      "save_frequency": 2000
+      "max_tick": 10000
     }],
     "body": {
       "product": "outer",
@@ -61,6 +60,7 @@
     },
     "meta": {
       "distributed": false,
+      "eval_frequency": 1000,
       "max_tick_unit": "total_t",
       "max_trial": 4,
       "max_session": 4,

--- a/slm_lab/spec/demo.json
+++ b/slm_lab/spec/demo.json
@@ -53,7 +53,6 @@
       "name": "CartPole-v0",
       "max_t": null,
       "max_tick": 10000,
-      "max_tick_unit": "total_t",
       "save_frequency": 2000
     }],
     "body": {
@@ -62,6 +61,7 @@
     },
     "meta": {
       "distributed": false,
+      "max_tick_unit": "total_t",
       "max_trial": 4,
       "max_session": 4,
       "search": "RandomSearch",

--- a/slm_lab/spec/demo.json
+++ b/slm_lab/spec/demo.json
@@ -64,7 +64,6 @@
       "distributed": false,
       "max_trial": 4,
       "max_session": 4,
-      "training_eval": false,
       "search": "RandomSearch",
       "resources": {
         "num_cpus": 4,

--- a/slm_lab/spec/experimental/a2c.json
+++ b/slm_lab/spec/experimental/a2c.json
@@ -53,7 +53,6 @@
       "name": "CartPole-v0",
       "max_t": null,
       "max_tick": 500,
-      "max_tick_unit": "epi",
       "save_frequency": 1000
     }],
     "body": {
@@ -62,6 +61,7 @@
     },
     "meta": {
       "distributed": false,
+      "max_tick_unit": "epi",
       "max_session": 4,
       "max_trial": 100,
       "search": "RandomSearch"
@@ -137,7 +137,6 @@
       "name": "CartPole-v0",
       "max_t": null,
       "max_tick": 500,
-      "max_tick_unit": "epi",
       "save_frequency": 1000
     }],
     "body": {
@@ -146,6 +145,7 @@
     },
     "meta": {
       "distributed": false,
+      "max_tick_unit": "epi",
       "max_session": 4,
       "max_trial": 100,
       "search": "RandomSearch"
@@ -222,7 +222,6 @@
       "name": "CartPole-v0",
       "max_t": null,
       "max_tick": 500,
-      "max_tick_unit": "epi",
       "save_frequency": 1000
     }],
     "body": {
@@ -231,6 +230,7 @@
     },
     "meta": {
       "distributed": false,
+      "max_tick_unit": "epi",
       "max_session": 4,
       "max_trial": 100,
       "search": "RandomSearch"
@@ -310,7 +310,6 @@
       "name": "CartPole-v0",
       "max_t": null,
       "max_tick": 500,
-      "max_tick_unit": "epi",
       "save_frequency": 1000
     }],
     "body": {
@@ -319,6 +318,7 @@
     },
     "meta": {
       "distributed": false,
+      "max_tick_unit": "epi",
       "max_session": 4,
       "max_trial": 100,
       "search": "RandomSearch"
@@ -398,7 +398,6 @@
       "name": "CartPole-v0",
       "max_t": null,
       "max_tick": 500,
-      "max_tick_unit": "epi",
       "save_frequency": 1000
     }],
     "body": {
@@ -407,6 +406,7 @@
     },
     "meta": {
       "distributed": false,
+      "max_tick_unit": "epi",
       "max_session": 4,
       "max_trial": 100,
       "search": "RandomSearch"
@@ -482,7 +482,6 @@
       "name": "Pendulum-v0",
       "max_t": null,
       "max_tick": 500,
-      "max_tick_unit": "epi",
       "save_frequency": 1000
     }],
     "body": {
@@ -491,6 +490,7 @@
     },
     "meta": {
       "distributed": false,
+      "max_tick_unit": "epi",
       "max_session": 4,
       "max_trial": 100,
       "search": "RandomSearch"
@@ -566,7 +566,6 @@
       "name": "Pendulum-v0",
       "max_t": null,
       "max_tick": 500,
-      "max_tick_unit": "epi",
       "save_frequency": 1000
     }],
     "body": {
@@ -575,6 +574,7 @@
     },
     "meta": {
       "distributed": false,
+      "max_tick_unit": "epi",
       "max_session": 4,
       "max_trial": 100,
       "search": "RandomSearch"
@@ -654,7 +654,6 @@
       "name": "Pendulum-v0",
       "max_t": null,
       "max_tick": 500,
-      "max_tick_unit": "epi",
       "save_frequency": 1000
     }],
     "body": {
@@ -663,6 +662,7 @@
     },
     "meta": {
       "distributed": false,
+      "max_tick_unit": "epi",
       "max_session": 4,
       "max_trial": 100,
       "search": "RandomSearch"
@@ -742,7 +742,6 @@
       "name": "Pendulum-v0",
       "max_t": null,
       "max_tick": 500,
-      "max_tick_unit": "epi",
       "save_frequency": 1000
     }],
     "body": {
@@ -751,6 +750,7 @@
     },
     "meta": {
       "distributed": false,
+      "max_tick_unit": "epi",
       "max_session": 4,
       "max_trial": 100,
       "search": "RandomSearch"
@@ -833,7 +833,6 @@
       "name": "PongNoFrameskip-v4",
       "max_t": null,
       "max_tick": 10000000,
-      "max_tick_unit": "total_t",
       "save_frequency": 100000
     }],
     "body": {
@@ -842,6 +841,7 @@
     },
     "meta": {
       "distributed": false,
+      "max_tick_unit": "total_t",
       "max_session": 1,
       "max_trial": 1,
       "search": "RandomSearch",

--- a/slm_lab/spec/experimental/a2c.json
+++ b/slm_lab/spec/experimental/a2c.json
@@ -53,7 +53,6 @@
       "name": "CartPole-v0",
       "max_t": null,
       "max_tick": 500,
-      "save_frequency": 1000
     }],
     "body": {
       "product": "outer",
@@ -61,6 +60,7 @@
     },
     "meta": {
       "distributed": false,
+      "eval_frequency": 1000,
       "max_tick_unit": "epi",
       "max_session": 4,
       "max_trial": 100,
@@ -137,7 +137,6 @@
       "name": "CartPole-v0",
       "max_t": null,
       "max_tick": 500,
-      "save_frequency": 1000
     }],
     "body": {
       "product": "outer",
@@ -145,6 +144,7 @@
     },
     "meta": {
       "distributed": false,
+      "eval_frequency": 1000,
       "max_tick_unit": "epi",
       "max_session": 4,
       "max_trial": 100,
@@ -222,7 +222,6 @@
       "name": "CartPole-v0",
       "max_t": null,
       "max_tick": 500,
-      "save_frequency": 1000
     }],
     "body": {
       "product": "outer",
@@ -230,6 +229,7 @@
     },
     "meta": {
       "distributed": false,
+      "eval_frequency": 1000,
       "max_tick_unit": "epi",
       "max_session": 4,
       "max_trial": 100,
@@ -310,7 +310,6 @@
       "name": "CartPole-v0",
       "max_t": null,
       "max_tick": 500,
-      "save_frequency": 1000
     }],
     "body": {
       "product": "outer",
@@ -318,6 +317,7 @@
     },
     "meta": {
       "distributed": false,
+      "eval_frequency": 1000,
       "max_tick_unit": "epi",
       "max_session": 4,
       "max_trial": 100,
@@ -398,7 +398,6 @@
       "name": "CartPole-v0",
       "max_t": null,
       "max_tick": 500,
-      "save_frequency": 1000
     }],
     "body": {
       "product": "outer",
@@ -406,6 +405,7 @@
     },
     "meta": {
       "distributed": false,
+      "eval_frequency": 1000,
       "max_tick_unit": "epi",
       "max_session": 4,
       "max_trial": 100,
@@ -482,7 +482,6 @@
       "name": "Pendulum-v0",
       "max_t": null,
       "max_tick": 500,
-      "save_frequency": 1000
     }],
     "body": {
       "product": "outer",
@@ -490,6 +489,7 @@
     },
     "meta": {
       "distributed": false,
+      "eval_frequency": 1000,
       "max_tick_unit": "epi",
       "max_session": 4,
       "max_trial": 100,
@@ -566,7 +566,6 @@
       "name": "Pendulum-v0",
       "max_t": null,
       "max_tick": 500,
-      "save_frequency": 1000
     }],
     "body": {
       "product": "outer",
@@ -574,6 +573,7 @@
     },
     "meta": {
       "distributed": false,
+      "eval_frequency": 1000,
       "max_tick_unit": "epi",
       "max_session": 4,
       "max_trial": 100,
@@ -654,7 +654,6 @@
       "name": "Pendulum-v0",
       "max_t": null,
       "max_tick": 500,
-      "save_frequency": 1000
     }],
     "body": {
       "product": "outer",
@@ -662,6 +661,7 @@
     },
     "meta": {
       "distributed": false,
+      "eval_frequency": 1000,
       "max_tick_unit": "epi",
       "max_session": 4,
       "max_trial": 100,
@@ -742,7 +742,6 @@
       "name": "Pendulum-v0",
       "max_t": null,
       "max_tick": 500,
-      "save_frequency": 1000
     }],
     "body": {
       "product": "outer",
@@ -750,6 +749,7 @@
     },
     "meta": {
       "distributed": false,
+      "eval_frequency": 1000,
       "max_tick_unit": "epi",
       "max_session": 4,
       "max_trial": 100,
@@ -833,7 +833,6 @@
       "name": "PongNoFrameskip-v4",
       "max_t": null,
       "max_tick": 10000000,
-      "save_frequency": 100000
     }],
     "body": {
       "product": "outer",
@@ -841,6 +840,7 @@
     },
     "meta": {
       "distributed": false,
+      "eval_frequency": 1000,
       "max_tick_unit": "total_t",
       "max_session": 1,
       "max_trial": 1,

--- a/slm_lab/spec/experimental/a3c.json
+++ b/slm_lab/spec/experimental/a3c.json
@@ -53,7 +53,6 @@
       "name": "CartPole-v0",
       "max_t": null,
       "max_tick": 500,
-      "max_tick_unit": "epi",
       "save_frequency": 1000
     }],
     "body": {
@@ -62,6 +61,7 @@
     },
     "meta": {
       "distributed": true,
+      "max_tick_unit": "epi",
       "max_session": 4,
       "max_trial": 100,
       "search": "RandomSearch"
@@ -137,7 +137,6 @@
       "name": "CartPole-v0",
       "max_t": null,
       "max_tick": 500,
-      "max_tick_unit": "epi",
       "save_frequency": 1000
     }],
     "body": {
@@ -146,6 +145,7 @@
     },
     "meta": {
       "distributed": true,
+      "max_tick_unit": "epi",
       "max_session": 4,
       "max_trial": 100,
       "search": "RandomSearch"
@@ -221,7 +221,6 @@
       "name": "CartPole-v0",
       "max_t": null,
       "max_tick": 400,
-      "max_tick_unit": "epi",
       "save_frequency": 300
     }],
     "body": {
@@ -230,6 +229,7 @@
     },
     "meta": {
       "distributed": true,
+      "max_tick_unit": "epi",
       "max_session": 4,
       "max_trial": 100,
       "search": "RandomSearch"
@@ -309,7 +309,6 @@
       "name": "CartPole-v0",
       "max_t": null,
       "max_tick": 500,
-      "max_tick_unit": "epi",
       "save_frequency": 1000
     }],
     "body": {
@@ -318,6 +317,7 @@
     },
     "meta": {
       "distributed": true,
+      "max_tick_unit": "epi",
       "max_session": 4,
       "max_trial": 100,
       "search": "RandomSearch"
@@ -397,7 +397,6 @@
       "name": "CartPole-v0",
       "max_t": null,
       "max_tick": 500,
-      "max_tick_unit": "epi",
       "save_frequency": 1000
     }],
     "body": {
@@ -406,6 +405,7 @@
     },
     "meta": {
       "distributed": true,
+      "max_tick_unit": "epi",
       "max_session": 4,
       "max_trial": 100,
       "search": "RandomSearch"
@@ -481,7 +481,6 @@
       "name": "Pendulum-v0",
       "max_t": null,
       "max_tick": 500,
-      "max_tick_unit": "epi",
       "save_frequency": 1000
     }],
     "body": {
@@ -490,6 +489,7 @@
     },
     "meta": {
       "distributed": true,
+      "max_tick_unit": "epi",
       "max_session": 4,
       "max_trial": 100,
       "search": "RandomSearch"
@@ -565,7 +565,6 @@
       "name": "Pendulum-v0",
       "max_t": null,
       "max_tick": 500,
-      "max_tick_unit": "epi",
       "save_frequency": 1000
     }],
     "body": {
@@ -574,6 +573,7 @@
     },
     "meta": {
       "distributed": true,
+      "max_tick_unit": "epi",
       "max_session": 4,
       "max_trial": 100,
       "search": "RandomSearch"
@@ -653,7 +653,6 @@
       "name": "Pendulum-v0",
       "max_t": null,
       "max_tick": 500,
-      "max_tick_unit": "epi",
       "save_frequency": 1000
     }],
     "body": {
@@ -662,6 +661,7 @@
     },
     "meta": {
       "distributed": true,
+      "max_tick_unit": "epi",
       "max_session": 4,
       "max_trial": 100,
       "search": "RandomSearch"
@@ -741,7 +741,6 @@
       "name": "Pendulum-v0",
       "max_t": null,
       "max_tick": 500,
-      "max_tick_unit": "epi",
       "save_frequency": 1000
     }],
     "body": {
@@ -750,6 +749,7 @@
     },
     "meta": {
       "distributed": true,
+      "max_tick_unit": "epi",
       "max_session": 4,
       "max_trial": 100,
       "search": "RandomSearch"
@@ -830,7 +830,6 @@
       "name": "Breakout-v0",
       "max_t": null,
       "max_tick": 1,
-      "max_tick_unit": "epi",
     }],
     "body": {
       "product": "outer",
@@ -838,6 +837,7 @@
     },
     "meta": {
       "distributed": true,
+      "max_tick_unit": "epi",
       "max_session": 1,
       "max_trial": 1,
       "search": "RandomSearch"
@@ -902,7 +902,6 @@
       "name": "Breakout-v0",
       "max_t": null,
       "max_tick": 1,
-      "max_tick_unit": "epi",
     }],
     "body": {
       "product": "outer",
@@ -910,6 +909,7 @@
     },
     "meta": {
       "distributed": true,
+      "max_tick_unit": "epi",
       "max_session": 1,
       "max_trial": 1,
       "search": "RandomSearch"

--- a/slm_lab/spec/experimental/a3c.json
+++ b/slm_lab/spec/experimental/a3c.json
@@ -53,7 +53,6 @@
       "name": "CartPole-v0",
       "max_t": null,
       "max_tick": 500,
-      "save_frequency": 1000
     }],
     "body": {
       "product": "outer",
@@ -61,6 +60,7 @@
     },
     "meta": {
       "distributed": true,
+      "eval_frequency": 1000,
       "max_tick_unit": "epi",
       "max_session": 4,
       "max_trial": 100,
@@ -137,7 +137,6 @@
       "name": "CartPole-v0",
       "max_t": null,
       "max_tick": 500,
-      "save_frequency": 1000
     }],
     "body": {
       "product": "outer",
@@ -145,6 +144,7 @@
     },
     "meta": {
       "distributed": true,
+      "eval_frequency": 1000,
       "max_tick_unit": "epi",
       "max_session": 4,
       "max_trial": 100,
@@ -221,7 +221,6 @@
       "name": "CartPole-v0",
       "max_t": null,
       "max_tick": 400,
-      "save_frequency": 300
     }],
     "body": {
       "product": "outer",
@@ -229,6 +228,7 @@
     },
     "meta": {
       "distributed": true,
+      "eval_frequency": 1000,
       "max_tick_unit": "epi",
       "max_session": 4,
       "max_trial": 100,
@@ -309,7 +309,6 @@
       "name": "CartPole-v0",
       "max_t": null,
       "max_tick": 500,
-      "save_frequency": 1000
     }],
     "body": {
       "product": "outer",
@@ -317,6 +316,7 @@
     },
     "meta": {
       "distributed": true,
+      "eval_frequency": 1000,
       "max_tick_unit": "epi",
       "max_session": 4,
       "max_trial": 100,
@@ -397,7 +397,6 @@
       "name": "CartPole-v0",
       "max_t": null,
       "max_tick": 500,
-      "save_frequency": 1000
     }],
     "body": {
       "product": "outer",
@@ -405,6 +404,7 @@
     },
     "meta": {
       "distributed": true,
+      "eval_frequency": 1000,
       "max_tick_unit": "epi",
       "max_session": 4,
       "max_trial": 100,
@@ -481,7 +481,6 @@
       "name": "Pendulum-v0",
       "max_t": null,
       "max_tick": 500,
-      "save_frequency": 1000
     }],
     "body": {
       "product": "outer",
@@ -489,6 +488,7 @@
     },
     "meta": {
       "distributed": true,
+      "eval_frequency": 1000,
       "max_tick_unit": "epi",
       "max_session": 4,
       "max_trial": 100,
@@ -565,7 +565,6 @@
       "name": "Pendulum-v0",
       "max_t": null,
       "max_tick": 500,
-      "save_frequency": 1000
     }],
     "body": {
       "product": "outer",
@@ -573,6 +572,7 @@
     },
     "meta": {
       "distributed": true,
+      "eval_frequency": 1000,
       "max_tick_unit": "epi",
       "max_session": 4,
       "max_trial": 100,
@@ -653,7 +653,6 @@
       "name": "Pendulum-v0",
       "max_t": null,
       "max_tick": 500,
-      "save_frequency": 1000
     }],
     "body": {
       "product": "outer",
@@ -661,6 +660,7 @@
     },
     "meta": {
       "distributed": true,
+      "eval_frequency": 1000,
       "max_tick_unit": "epi",
       "max_session": 4,
       "max_trial": 100,
@@ -741,7 +741,6 @@
       "name": "Pendulum-v0",
       "max_t": null,
       "max_tick": 500,
-      "save_frequency": 1000
     }],
     "body": {
       "product": "outer",
@@ -749,6 +748,7 @@
     },
     "meta": {
       "distributed": true,
+      "eval_frequency": 1000,
       "max_tick_unit": "epi",
       "max_session": 4,
       "max_trial": 100,
@@ -837,6 +837,7 @@
     },
     "meta": {
       "distributed": true,
+      "eval_frequency": 1000,
       "max_tick_unit": "epi",
       "max_session": 1,
       "max_trial": 1,
@@ -909,6 +910,7 @@
     },
     "meta": {
       "distributed": true,
+      "eval_frequency": 1000,
       "max_tick_unit": "epi",
       "max_session": 1,
       "max_trial": 1,

--- a/slm_lab/spec/experimental/cartpole.json
+++ b/slm_lab/spec/experimental/cartpole.json
@@ -45,7 +45,6 @@
       "name": "CartPole-v0",
       "max_t": null,
       "max_tick": 40000,
-      "save_frequency": 5000,
     }],
     "body": {
       "product": "outer",
@@ -53,6 +52,7 @@
     },
     "meta": {
       "distributed": false,
+      "eval_frequency": 1000,
       "max_tick_unit": "total_t",
       "max_session": 4,
       "max_trial": 95,
@@ -128,7 +128,6 @@
       "name": "CartPole-v0",
       "max_t": null,
       "max_tick": 40000,
-      "save_frequency": 5000,
     }],
     "body": {
       "product": "outer",
@@ -136,6 +135,7 @@
     },
     "meta": {
       "distributed": false,
+      "eval_frequency": 1000,
       "max_tick_unit": "total_t",
       "max_session": 4,
       "max_trial": 95,
@@ -215,7 +215,6 @@
       "name": "CartPole-v0",
       "max_t": null,
       "max_tick": 40000,
-      "save_frequency": 5000,
     }],
     "body": {
       "product": "outer",
@@ -223,6 +222,7 @@
     },
     "meta": {
       "distributed": false,
+      "eval_frequency": 1000,
       "max_tick_unit": "total_t",
       "max_session": 4,
       "max_trial": 95,
@@ -302,7 +302,6 @@
       "name": "CartPole-v0",
       "max_t": null,
       "max_tick": 40000,
-      "save_frequency": 5000,
     }],
     "body": {
       "product": "outer",
@@ -310,6 +309,7 @@
     },
     "meta": {
       "distributed": false,
+      "eval_frequency": 1000,
       "max_tick_unit": "total_t",
       "max_session": 4,
       "max_trial": 95,
@@ -392,7 +392,6 @@
       "name": "CartPole-v0",
       "max_t": null,
       "max_tick": 40000,
-      "save_frequency": 5000,
     }],
     "body": {
       "product": "outer",
@@ -400,6 +399,7 @@
     },
     "meta": {
       "distributed": false,
+      "eval_frequency": 1000,
       "max_tick_unit": "total_t",
       "max_session": 4,
       "max_trial": 23,
@@ -486,7 +486,6 @@
       "name": "CartPole-v0",
       "max_t": null,
       "max_tick": 40000,
-      "save_frequency": 5000,
     }],
     "body": {
       "product": "outer",
@@ -494,6 +493,7 @@
     },
     "meta": {
       "distributed": false,
+      "eval_frequency": 1000,
       "max_tick_unit": "total_t",
       "max_session": 4,
       "max_trial": 95,
@@ -576,7 +576,6 @@
       "name": "CartPole-v0",
       "max_t": null,
       "max_tick": 40000,
-      "save_frequency": 5000,
     }],
     "body": {
       "product": "outer",
@@ -584,6 +583,7 @@
     },
     "meta": {
       "distributed": false,
+      "eval_frequency": 1000,
       "max_tick_unit": "total_t",
       "max_session": 4,
       "max_trial": 95,
@@ -664,7 +664,6 @@
       "name": "CartPole-v0",
       "max_t": null,
       "max_tick": 40000,
-      "save_frequency": 5000,
     }],
     "body": {
       "product": "outer",
@@ -672,6 +671,7 @@
     },
     "meta": {
       "distributed": false,
+      "eval_frequency": 1000,
       "max_tick_unit": "total_t",
       "max_session": 4,
       "max_trial": 95,
@@ -755,7 +755,6 @@
       "name": "CartPole-v0",
       "max_t": null,
       "max_tick": 40000,
-      "save_frequency": 5000,
     }],
     "body": {
       "product": "outer",
@@ -763,6 +762,7 @@
     },
     "meta": {
       "distributed": true,
+      "eval_frequency": 1000,
       "max_tick_unit": "total_t",
       "max_session": 4,
       "max_trial": 23,
@@ -846,7 +846,6 @@
       "name": "CartPole-v0",
       "max_t": null,
       "max_tick": 40000,
-      "save_frequency": 5000,
     }],
     "body": {
       "product": "outer",
@@ -854,6 +853,7 @@
     },
     "meta": {
       "distributed": false,
+      "eval_frequency": 1000,
       "max_tick_unit": "total_t",
       "max_session": 4,
       "max_trial": 95,
@@ -942,7 +942,6 @@
       "name": "CartPole-v0",
       "max_t": null,
       "max_tick": 40000,
-      "save_frequency": 5000,
     }],
     "body": {
       "product": "outer",
@@ -950,6 +949,7 @@
     },
     "meta": {
       "distributed": false,
+      "eval_frequency": 1000,
       "max_tick_unit": "total_t",
       "max_session": 4,
       "max_trial": 95,
@@ -1044,7 +1044,6 @@
       "name": "CartPole-v0",
       "max_t": null,
       "max_tick": 40000,
-      "save_frequency": 5000,
     }],
     "body": {
       "product": "outer",
@@ -1052,6 +1051,7 @@
     },
     "meta": {
       "distributed": false,
+      "eval_frequency": 1000,
       "max_tick_unit": "total_t",
       "max_session": 4,
       "max_trial": 95,
@@ -1141,7 +1141,6 @@
       "name": "CartPole-v0",
       "max_t": null,
       "max_tick": 40000,
-      "save_frequency": 5000,
     }],
     "body": {
       "product": "outer",
@@ -1149,6 +1148,7 @@
     },
     "meta": {
       "distributed": false,
+      "eval_frequency": 1000,
       "max_tick_unit": "total_t",
       "max_session": 4,
       "max_trial": 95,
@@ -1224,7 +1224,6 @@
       "name": "CartPole-v0",
       "max_t": null,
       "max_tick": 40000,
-      "save_frequency": 5000,
     }],
     "body": {
       "product": "outer",
@@ -1232,6 +1231,7 @@
     },
     "meta": {
       "distributed": false,
+      "eval_frequency": 1000,
       "max_tick_unit": "total_t",
       "max_session": 4,
       "max_trial": 95,
@@ -1305,7 +1305,6 @@
       "name": "CartPole-v0",
       "max_t": null,
       "max_tick": 40000,
-      "save_frequency": 5000,
     }],
     "body": {
       "product": "outer",
@@ -1313,6 +1312,7 @@
     },
     "meta": {
       "distributed": false,
+      "eval_frequency": 1000,
       "max_tick_unit": "total_t",
       "max_session": 4,
       "max_trial": 95,
@@ -1392,7 +1392,6 @@
       "name": "CartPole-v0",
       "max_t": null,
       "max_tick": 40000,
-      "save_frequency": 5000,
     }],
     "body": {
       "product": "outer",
@@ -1400,6 +1399,7 @@
     },
     "meta": {
       "distributed": false,
+      "eval_frequency": 1000,
       "max_tick_unit": "total_t",
       "max_session": 4,
       "max_trial": 64,
@@ -1484,7 +1484,6 @@
       "name": "CartPole-v0",
       "max_t": null,
       "max_tick": 40000,
-      "save_frequency": 5000,
     }],
     "body": {
       "product": "outer",
@@ -1492,6 +1491,7 @@
     },
     "meta": {
       "distributed": true,
+      "eval_frequency": 1000,
       "max_tick_unit": "total_t",
       "max_session": 4,
       "max_trial": 23,
@@ -1571,7 +1571,6 @@
       "name": "CartPole-v0",
       "max_t": null,
       "max_tick": 40000,
-      "save_frequency": 5000,
     }],
     "body": {
       "product": "outer",
@@ -1579,6 +1578,7 @@
     },
     "meta": {
       "distributed": false,
+      "eval_frequency": 1000,
       "max_tick_unit": "total_t",
       "max_session": 4,
       "max_trial": 64,
@@ -1666,7 +1666,6 @@
       "name": "CartPole-v0",
       "max_t": null,
       "max_tick": 40000,
-      "save_frequency": 5000,
     }],
     "body": {
       "product": "outer",
@@ -1674,6 +1673,7 @@
     },
     "meta": {
       "distributed": false,
+      "eval_frequency": 1000,
       "max_tick_unit": "total_t",
       "max_session": 4,
       "max_trial": 64,
@@ -1760,7 +1760,6 @@
       "name": "CartPole-v0",
       "max_t": null,
       "max_tick": 40000,
-      "save_frequency": 5000,
     }],
     "body": {
       "product": "outer",
@@ -1768,6 +1767,7 @@
     },
     "meta": {
       "distributed": false,
+      "eval_frequency": 1000,
       "max_tick_unit": "total_t",
       "max_session": 4,
       "max_trial": 64,
@@ -1851,7 +1851,6 @@
       "name": "CartPole-v0",
       "max_t": null,
       "max_tick": 40000,
-      "save_frequency": 5000,
     }],
     "body": {
       "product": "outer",
@@ -1859,6 +1858,7 @@
     },
     "meta": {
       "distributed": false,
+      "eval_frequency": 1000,
       "max_tick_unit": "total_t",
       "max_session": 4,
       "max_trial": 64,
@@ -1943,7 +1943,6 @@
       "name": "CartPole-v0",
       "max_t": null,
       "max_tick": 40000,
-      "save_frequency": 5000,
     }],
     "body": {
       "product": "outer",
@@ -1951,6 +1950,7 @@
     },
     "meta": {
       "distributed": false,
+      "eval_frequency": 1000,
       "max_tick_unit": "total_t",
       "max_session": 4,
       "max_trial": 64,
@@ -2038,7 +2038,6 @@
       "name": "CartPole-v0",
       "max_t": null,
       "max_tick": 40000,
-      "save_frequency": 5000,
     }],
     "body": {
       "product": "outer",
@@ -2046,6 +2045,7 @@
     },
     "meta": {
       "distributed": false,
+      "eval_frequency": 1000,
       "max_tick_unit": "total_t",
       "max_session": 4,
       "max_trial": 64,
@@ -2132,7 +2132,6 @@
       "name": "CartPole-v0",
       "max_t": null,
       "max_tick": 40000,
-      "save_frequency": 5000,
     }],
     "body": {
       "product": "outer",
@@ -2140,6 +2139,7 @@
     },
     "meta": {
       "distributed": false,
+      "eval_frequency": 1000,
       "max_tick_unit": "total_t",
       "max_session": 4,
       "max_trial": 64,
@@ -2223,7 +2223,6 @@
       "name": "CartPole-v0",
       "max_t": null,
       "max_tick": 40000,
-      "save_frequency": 5000,
     }],
     "body": {
       "product": "outer",
@@ -2231,6 +2230,7 @@
     },
     "meta": {
       "distributed": false,
+      "eval_frequency": 1000,
       "max_tick_unit": "total_t",
       "max_session": 4,
       "max_trial": 95,

--- a/slm_lab/spec/experimental/cartpole.json
+++ b/slm_lab/spec/experimental/cartpole.json
@@ -44,7 +44,6 @@
     "env": [{
       "name": "CartPole-v0",
       "max_t": null,
-      "max_tick_unit": "total_t",
       "max_tick": 40000,
       "save_frequency": 5000,
     }],
@@ -54,6 +53,7 @@
     },
     "meta": {
       "distributed": false,
+      "max_tick_unit": "total_t",
       "max_session": 4,
       "max_trial": 95,
       "search": "RandomSearch",
@@ -127,7 +127,6 @@
     "env": [{
       "name": "CartPole-v0",
       "max_t": null,
-      "max_tick_unit": "total_t",
       "max_tick": 40000,
       "save_frequency": 5000,
     }],
@@ -137,6 +136,7 @@
     },
     "meta": {
       "distributed": false,
+      "max_tick_unit": "total_t",
       "max_session": 4,
       "max_trial": 95,
       "search": "RandomSearch",
@@ -214,7 +214,6 @@
     "env": [{
       "name": "CartPole-v0",
       "max_t": null,
-      "max_tick_unit": "total_t",
       "max_tick": 40000,
       "save_frequency": 5000,
     }],
@@ -224,6 +223,7 @@
     },
     "meta": {
       "distributed": false,
+      "max_tick_unit": "total_t",
       "max_session": 4,
       "max_trial": 95,
       "search": "RandomSearch",
@@ -301,7 +301,6 @@
     "env": [{
       "name": "CartPole-v0",
       "max_t": null,
-      "max_tick_unit": "total_t",
       "max_tick": 40000,
       "save_frequency": 5000,
     }],
@@ -311,6 +310,7 @@
     },
     "meta": {
       "distributed": false,
+      "max_tick_unit": "total_t",
       "max_session": 4,
       "max_trial": 95,
       "search": "RandomSearch",
@@ -391,7 +391,6 @@
     "env": [{
       "name": "CartPole-v0",
       "max_t": null,
-      "max_tick_unit": "total_t",
       "max_tick": 40000,
       "save_frequency": 5000,
     }],
@@ -401,6 +400,7 @@
     },
     "meta": {
       "distributed": false,
+      "max_tick_unit": "total_t",
       "max_session": 4,
       "max_trial": 23,
       "search": "RandomSearch",
@@ -485,7 +485,6 @@
     "env": [{
       "name": "CartPole-v0",
       "max_t": null,
-      "max_tick_unit": "total_t",
       "max_tick": 40000,
       "save_frequency": 5000,
     }],
@@ -495,6 +494,7 @@
     },
     "meta": {
       "distributed": false,
+      "max_tick_unit": "total_t",
       "max_session": 4,
       "max_trial": 95,
       "search": "RandomSearch",
@@ -575,7 +575,6 @@
     "env": [{
       "name": "CartPole-v0",
       "max_t": null,
-      "max_tick_unit": "total_t",
       "max_tick": 40000,
       "save_frequency": 5000,
     }],
@@ -585,6 +584,7 @@
     },
     "meta": {
       "distributed": false,
+      "max_tick_unit": "total_t",
       "max_session": 4,
       "max_trial": 95,
       "search": "RandomSearch",
@@ -663,7 +663,6 @@
     "env": [{
       "name": "CartPole-v0",
       "max_t": null,
-      "max_tick_unit": "total_t",
       "max_tick": 40000,
       "save_frequency": 5000,
     }],
@@ -673,6 +672,7 @@
     },
     "meta": {
       "distributed": false,
+      "max_tick_unit": "total_t",
       "max_session": 4,
       "max_trial": 95,
       "search": "RandomSearch",
@@ -754,7 +754,6 @@
     "env": [{
       "name": "CartPole-v0",
       "max_t": null,
-      "max_tick_unit": "total_t",
       "max_tick": 40000,
       "save_frequency": 5000,
     }],
@@ -764,6 +763,7 @@
     },
     "meta": {
       "distributed": true,
+      "max_tick_unit": "total_t",
       "max_session": 4,
       "max_trial": 23,
       "search": "RandomSearch",
@@ -845,7 +845,6 @@
     "env": [{
       "name": "CartPole-v0",
       "max_t": null,
-      "max_tick_unit": "total_t",
       "max_tick": 40000,
       "save_frequency": 5000,
     }],
@@ -855,6 +854,7 @@
     },
     "meta": {
       "distributed": false,
+      "max_tick_unit": "total_t",
       "max_session": 4,
       "max_trial": 95,
       "search": "RandomSearch",
@@ -941,7 +941,6 @@
     "env": [{
       "name": "CartPole-v0",
       "max_t": null,
-      "max_tick_unit": "total_t",
       "max_tick": 40000,
       "save_frequency": 5000,
     }],
@@ -951,6 +950,7 @@
     },
     "meta": {
       "distributed": false,
+      "max_tick_unit": "total_t",
       "max_session": 4,
       "max_trial": 95,
       "search": "RandomSearch",
@@ -1043,7 +1043,6 @@
     "env": [{
       "name": "CartPole-v0",
       "max_t": null,
-      "max_tick_unit": "total_t",
       "max_tick": 40000,
       "save_frequency": 5000,
     }],
@@ -1053,6 +1052,7 @@
     },
     "meta": {
       "distributed": false,
+      "max_tick_unit": "total_t",
       "max_session": 4,
       "max_trial": 95,
       "search": "RandomSearch",
@@ -1140,7 +1140,6 @@
     "env": [{
       "name": "CartPole-v0",
       "max_t": null,
-      "max_tick_unit": "total_t",
       "max_tick": 40000,
       "save_frequency": 5000,
     }],
@@ -1150,6 +1149,7 @@
     },
     "meta": {
       "distributed": false,
+      "max_tick_unit": "total_t",
       "max_session": 4,
       "max_trial": 95,
       "search": "RandomSearch",
@@ -1223,7 +1223,6 @@
     "env": [{
       "name": "CartPole-v0",
       "max_t": null,
-      "max_tick_unit": "total_t",
       "max_tick": 40000,
       "save_frequency": 5000,
     }],
@@ -1233,6 +1232,7 @@
     },
     "meta": {
       "distributed": false,
+      "max_tick_unit": "total_t",
       "max_session": 4,
       "max_trial": 95,
       "search": "RandomSearch",
@@ -1304,7 +1304,6 @@
     "env": [{
       "name": "CartPole-v0",
       "max_t": null,
-      "max_tick_unit": "total_t",
       "max_tick": 40000,
       "save_frequency": 5000,
     }],
@@ -1314,6 +1313,7 @@
     },
     "meta": {
       "distributed": false,
+      "max_tick_unit": "total_t",
       "max_session": 4,
       "max_trial": 95,
       "search": "RandomSearch",
@@ -1391,7 +1391,6 @@
     "env": [{
       "name": "CartPole-v0",
       "max_t": null,
-      "max_tick_unit": "total_t",
       "max_tick": 40000,
       "save_frequency": 5000,
     }],
@@ -1401,6 +1400,7 @@
     },
     "meta": {
       "distributed": false,
+      "max_tick_unit": "total_t",
       "max_session": 4,
       "max_trial": 64,
       "search": "RandomSearch",
@@ -1483,7 +1483,6 @@
     "env": [{
       "name": "CartPole-v0",
       "max_t": null,
-      "max_tick_unit": "total_t",
       "max_tick": 40000,
       "save_frequency": 5000,
     }],
@@ -1493,6 +1492,7 @@
     },
     "meta": {
       "distributed": true,
+      "max_tick_unit": "total_t",
       "max_session": 4,
       "max_trial": 23,
       "search": "RandomSearch",
@@ -1570,7 +1570,6 @@
     "env": [{
       "name": "CartPole-v0",
       "max_t": null,
-      "max_tick_unit": "total_t",
       "max_tick": 40000,
       "save_frequency": 5000,
     }],
@@ -1580,6 +1579,7 @@
     },
     "meta": {
       "distributed": false,
+      "max_tick_unit": "total_t",
       "max_session": 4,
       "max_trial": 64,
       "search": "RandomSearch",
@@ -1665,7 +1665,6 @@
     "env": [{
       "name": "CartPole-v0",
       "max_t": null,
-      "max_tick_unit": "total_t",
       "max_tick": 40000,
       "save_frequency": 5000,
     }],
@@ -1675,6 +1674,7 @@
     },
     "meta": {
       "distributed": false,
+      "max_tick_unit": "total_t",
       "max_session": 4,
       "max_trial": 64,
       "search": "RandomSearch",
@@ -1759,7 +1759,6 @@
     "env": [{
       "name": "CartPole-v0",
       "max_t": null,
-      "max_tick_unit": "total_t",
       "max_tick": 40000,
       "save_frequency": 5000,
     }],
@@ -1769,6 +1768,7 @@
     },
     "meta": {
       "distributed": false,
+      "max_tick_unit": "total_t",
       "max_session": 4,
       "max_trial": 64,
       "search": "RandomSearch",
@@ -1850,7 +1850,6 @@
     "env": [{
       "name": "CartPole-v0",
       "max_t": null,
-      "max_tick_unit": "total_t",
       "max_tick": 40000,
       "save_frequency": 5000,
     }],
@@ -1860,6 +1859,7 @@
     },
     "meta": {
       "distributed": false,
+      "max_tick_unit": "total_t",
       "max_session": 4,
       "max_trial": 64,
       "search": "RandomSearch",
@@ -1942,7 +1942,6 @@
     "env": [{
       "name": "CartPole-v0",
       "max_t": null,
-      "max_tick_unit": "total_t",
       "max_tick": 40000,
       "save_frequency": 5000,
     }],
@@ -1952,6 +1951,7 @@
     },
     "meta": {
       "distributed": false,
+      "max_tick_unit": "total_t",
       "max_session": 4,
       "max_trial": 64,
       "search": "RandomSearch",
@@ -2037,7 +2037,6 @@
     "env": [{
       "name": "CartPole-v0",
       "max_t": null,
-      "max_tick_unit": "total_t",
       "max_tick": 40000,
       "save_frequency": 5000,
     }],
@@ -2047,6 +2046,7 @@
     },
     "meta": {
       "distributed": false,
+      "max_tick_unit": "total_t",
       "max_session": 4,
       "max_trial": 64,
       "search": "RandomSearch",
@@ -2131,7 +2131,6 @@
     "env": [{
       "name": "CartPole-v0",
       "max_t": null,
-      "max_tick_unit": "total_t",
       "max_tick": 40000,
       "save_frequency": 5000,
     }],
@@ -2141,6 +2140,7 @@
     },
     "meta": {
       "distributed": false,
+      "max_tick_unit": "total_t",
       "max_session": 4,
       "max_trial": 64,
       "search": "RandomSearch",
@@ -2222,7 +2222,6 @@
     "env": [{
       "name": "CartPole-v0",
       "max_t": null,
-      "max_tick_unit": "total_t",
       "max_tick": 40000,
       "save_frequency": 5000,
     }],
@@ -2232,6 +2231,7 @@
     },
     "meta": {
       "distributed": false,
+      "max_tick_unit": "total_t",
       "max_session": 4,
       "max_trial": 95,
       "search": "RandomSearch",

--- a/slm_lab/spec/experimental/ddqn.json
+++ b/slm_lab/spec/experimental/ddqn.json
@@ -52,7 +52,6 @@
     "env": [{
       "name": "CartPole-v0",
       "max_t": null,
-      "max_tick_unit": "epi",
       "max_tick": 400,
       "save_frequency": 300
     }],
@@ -62,6 +61,7 @@
     },
     "meta": {
       "distributed": false,
+      "max_tick_unit": "epi",
       "max_session": 4,
       "max_trial": 100,
       "search": "RandomSearch"
@@ -135,7 +135,6 @@
     "env": [{
       "name": "CartPole-v0",
       "max_t": null,
-      "max_tick_unit": "epi",
       "max_tick": 250,
       "save_frequency": 1000
     }],
@@ -145,6 +144,7 @@
     },
     "meta": {
       "distributed": false,
+      "max_tick_unit": "epi",
       "max_session": 4,
       "max_trial": 100,
       "search": "RandomSearch"
@@ -228,7 +228,6 @@
     "env": [{
       "name": "CartPole-v0",
       "max_t": null,
-      "max_tick_unit": "epi",
       "max_tick": 250,
       "save_frequency": 1000
     }],
@@ -238,6 +237,7 @@
     },
     "meta": {
       "distributed": false,
+      "max_tick_unit": "epi",
       "max_session": 4,
       "max_trial": 100,
       "search": "RandomSearch"
@@ -321,7 +321,6 @@
     "env": [{
       "name": "CartPole-v0",
       "max_t": null,
-      "max_tick_unit": "epi",
       "max_tick": 250,
       "save_frequency": 1000
     }],
@@ -331,6 +330,7 @@
     },
     "meta": {
       "distributed": false,
+      "max_tick_unit": "epi",
       "max_session": 4,
       "max_trial": 100,
       "search": "RandomSearch"
@@ -421,7 +421,6 @@
     "env": [{
       "name": "BreakoutDeterministic-v4",
       "max_t": null,
-      "max_tick_unit": "epi",
       "max_tick": 50000,
       "save_frequency": 10000
     }],
@@ -431,6 +430,7 @@
     },
     "meta": {
       "distributed": false,
+      "max_tick_unit": "epi",
       "max_session": 1,
       "max_trial": 1,
       "search": "RandomSearch"
@@ -500,7 +500,6 @@
     "env": [{
       "name": "BreakoutDeterministic-v4",
       "max_t": null,
-      "max_tick_unit": "epi",
       "max_tick": 50000,
       "save_frequency": 10000
     }],
@@ -510,6 +509,7 @@
     },
     "meta": {
       "distributed": false,
+      "max_tick_unit": "epi",
       "max_session": 1,
       "max_trial": 1,
       "search": "RandomSearch"

--- a/slm_lab/spec/experimental/ddqn.json
+++ b/slm_lab/spec/experimental/ddqn.json
@@ -53,7 +53,6 @@
       "name": "CartPole-v0",
       "max_t": null,
       "max_tick": 400,
-      "save_frequency": 300
     }],
     "body": {
       "product": "outer",
@@ -61,6 +60,7 @@
     },
     "meta": {
       "distributed": false,
+      "eval_frequency": 1000,
       "max_tick_unit": "epi",
       "max_session": 4,
       "max_trial": 100,
@@ -136,7 +136,6 @@
       "name": "CartPole-v0",
       "max_t": null,
       "max_tick": 250,
-      "save_frequency": 1000
     }],
     "body": {
       "product": "outer",
@@ -144,6 +143,7 @@
     },
     "meta": {
       "distributed": false,
+      "eval_frequency": 1000,
       "max_tick_unit": "epi",
       "max_session": 4,
       "max_trial": 100,
@@ -229,7 +229,6 @@
       "name": "CartPole-v0",
       "max_t": null,
       "max_tick": 250,
-      "save_frequency": 1000
     }],
     "body": {
       "product": "outer",
@@ -237,6 +236,7 @@
     },
     "meta": {
       "distributed": false,
+      "eval_frequency": 1000,
       "max_tick_unit": "epi",
       "max_session": 4,
       "max_trial": 100,
@@ -322,7 +322,6 @@
       "name": "CartPole-v0",
       "max_t": null,
       "max_tick": 250,
-      "save_frequency": 1000
     }],
     "body": {
       "product": "outer",
@@ -330,6 +329,7 @@
     },
     "meta": {
       "distributed": false,
+      "eval_frequency": 1000,
       "max_tick_unit": "epi",
       "max_session": 4,
       "max_trial": 100,
@@ -422,7 +422,6 @@
       "name": "BreakoutDeterministic-v4",
       "max_t": null,
       "max_tick": 50000,
-      "save_frequency": 10000
     }],
     "body": {
       "product": "outer",
@@ -430,6 +429,7 @@
     },
     "meta": {
       "distributed": false,
+      "eval_frequency": 1000,
       "max_tick_unit": "epi",
       "max_session": 1,
       "max_trial": 1,
@@ -501,7 +501,6 @@
       "name": "BreakoutDeterministic-v4",
       "max_t": null,
       "max_tick": 50000,
-      "save_frequency": 10000
     }],
     "body": {
       "product": "outer",
@@ -509,6 +508,7 @@
     },
     "meta": {
       "distributed": false,
+      "eval_frequency": 1000,
       "max_tick_unit": "epi",
       "max_session": 1,
       "max_trial": 1,

--- a/slm_lab/spec/experimental/ddqn_beamrider.json
+++ b/slm_lab/spec/experimental/ddqn_beamrider.json
@@ -70,7 +70,6 @@
       "distributed": false,
       "max_session": 6,
       "max_trial": 16,
-      "training_eval": true,
       "search": "RandomSearch",
       "resources": {
         "num_cpus": 16

--- a/slm_lab/spec/experimental/ddqn_beamrider.json
+++ b/slm_lab/spec/experimental/ddqn_beamrider.json
@@ -58,8 +58,7 @@
     "env": [{
       "name": "BeamRiderNoFrameskip-v4",
       "max_t": null,
-      "max_tick": 10000000,
-      "save_frequency": 100000
+      "max_tick": 10000000
     }],
     "body": {
       "product": "outer",
@@ -67,6 +66,7 @@
     },
     "meta": {
       "distributed": false,
+      "eval_frequency": 10000,
       "max_tick_unit": "total_t",
       "max_session": 6,
       "max_trial": 16,

--- a/slm_lab/spec/experimental/ddqn_beamrider.json
+++ b/slm_lab/spec/experimental/ddqn_beamrider.json
@@ -58,7 +58,6 @@
     "env": [{
       "name": "BeamRiderNoFrameskip-v4",
       "max_t": null,
-      "max_tick_unit": "total_t",
       "max_tick": 10000000,
       "save_frequency": 100000
     }],
@@ -68,6 +67,7 @@
     },
     "meta": {
       "distributed": false,
+      "max_tick_unit": "total_t",
       "max_session": 6,
       "max_trial": 16,
       "search": "RandomSearch",

--- a/slm_lab/spec/experimental/ddqn_breakout.json
+++ b/slm_lab/spec/experimental/ddqn_breakout.json
@@ -70,7 +70,6 @@
       "distributed": false,
       "max_session": 6,
       "max_trial": 16,
-      "training_eval": true,
       "search": "RandomSearch",
       "resources": {
         "num_cpus": 16

--- a/slm_lab/spec/experimental/ddqn_breakout.json
+++ b/slm_lab/spec/experimental/ddqn_breakout.json
@@ -58,7 +58,6 @@
     "env": [{
       "name": "BreakoutNoFrameskip-v4",
       "max_t": null,
-      "max_tick_unit": "total_t",
       "max_tick": 10000000,
       "save_frequency": 100000
     }],
@@ -68,6 +67,7 @@
     },
     "meta": {
       "distributed": false,
+      "max_tick_unit": "total_t",
       "max_session": 6,
       "max_trial": 16,
       "search": "RandomSearch",

--- a/slm_lab/spec/experimental/ddqn_breakout.json
+++ b/slm_lab/spec/experimental/ddqn_breakout.json
@@ -58,8 +58,7 @@
     "env": [{
       "name": "BreakoutNoFrameskip-v4",
       "max_t": null,
-      "max_tick": 10000000,
-      "save_frequency": 100000
+      "max_tick": 10000000
     }],
     "body": {
       "product": "outer",
@@ -67,6 +66,7 @@
     },
     "meta": {
       "distributed": false,
+      "eval_frequency": 10000,
       "max_tick_unit": "total_t",
       "max_session": 6,
       "max_trial": 16,

--- a/slm_lab/spec/experimental/ddqn_enduro.json
+++ b/slm_lab/spec/experimental/ddqn_enduro.json
@@ -70,7 +70,6 @@
       "distributed": false,
       "max_session": 6,
       "max_trial": 16,
-      "training_eval": true,
       "search": "RandomSearch",
       "resources": {
         "num_cpus": 16

--- a/slm_lab/spec/experimental/ddqn_enduro.json
+++ b/slm_lab/spec/experimental/ddqn_enduro.json
@@ -58,7 +58,6 @@
     "env": [{
       "name": "EnduroNoFrameskip-v4",
       "max_t": null,
-      "max_tick_unit": "total_t",
       "max_tick": 10000000,
       "save_frequency": 100000
     }],
@@ -68,6 +67,7 @@
     },
     "meta": {
       "distributed": false,
+      "max_tick_unit": "total_t",
       "max_session": 6,
       "max_trial": 16,
       "search": "RandomSearch",

--- a/slm_lab/spec/experimental/ddqn_enduro.json
+++ b/slm_lab/spec/experimental/ddqn_enduro.json
@@ -58,8 +58,7 @@
     "env": [{
       "name": "EnduroNoFrameskip-v4",
       "max_t": null,
-      "max_tick": 10000000,
-      "save_frequency": 100000
+      "max_tick": 10000000
     }],
     "body": {
       "product": "outer",
@@ -67,6 +66,7 @@
     },
     "meta": {
       "distributed": false,
+      "eval_frequency": 10000,
       "max_tick_unit": "total_t",
       "max_session": 6,
       "max_trial": 16,

--- a/slm_lab/spec/experimental/ddqn_mspacman.json
+++ b/slm_lab/spec/experimental/ddqn_mspacman.json
@@ -70,7 +70,6 @@
       "distributed": false,
       "max_session": 6,
       "max_trial": 16,
-      "training_eval": true,
       "search": "RandomSearch",
       "resources": {
         "num_cpus": 16

--- a/slm_lab/spec/experimental/ddqn_mspacman.json
+++ b/slm_lab/spec/experimental/ddqn_mspacman.json
@@ -58,8 +58,7 @@
     "env": [{
       "name": "MsPacmanNoFrameskip-v4",
       "max_t": null,
-      "max_tick": 10000000,
-      "save_frequency": 100000
+      "max_tick": 10000000
     }],
     "body": {
       "product": "outer",
@@ -67,6 +66,7 @@
     },
     "meta": {
       "distributed": false,
+      "eval_frequency": 10000,
       "max_tick_unit": "total_t",
       "max_session": 6,
       "max_trial": 16,

--- a/slm_lab/spec/experimental/ddqn_mspacman.json
+++ b/slm_lab/spec/experimental/ddqn_mspacman.json
@@ -58,7 +58,6 @@
     "env": [{
       "name": "MsPacmanNoFrameskip-v4",
       "max_t": null,
-      "max_tick_unit": "total_t",
       "max_tick": 10000000,
       "save_frequency": 100000
     }],
@@ -68,6 +67,7 @@
     },
     "meta": {
       "distributed": false,
+      "max_tick_unit": "total_t",
       "max_session": 6,
       "max_trial": 16,
       "search": "RandomSearch",

--- a/slm_lab/spec/experimental/ddqn_pong.json
+++ b/slm_lab/spec/experimental/ddqn_pong.json
@@ -58,8 +58,7 @@
     "env": [{
       "name": "PongNoFrameskip-v4",
       "max_t": null,
-      "max_tick": 10000000,
-      "save_frequency": 100000
+      "max_tick": 10000000
     }],
     "body": {
       "product": "outer",
@@ -67,6 +66,7 @@
     },
     "meta": {
       "distributed": false,
+      "eval_frequency": 10000,
       "max_tick_unit": "total_t",
       "max_session": 6,
       "max_trial": 16,

--- a/slm_lab/spec/experimental/ddqn_pong.json
+++ b/slm_lab/spec/experimental/ddqn_pong.json
@@ -70,7 +70,6 @@
       "distributed": false,
       "max_session": 6,
       "max_trial": 16,
-      "training_eval": true,
       "search": "RandomSearch",
       "resources": {
         "num_cpus": 16

--- a/slm_lab/spec/experimental/ddqn_pong.json
+++ b/slm_lab/spec/experimental/ddqn_pong.json
@@ -58,7 +58,6 @@
     "env": [{
       "name": "PongNoFrameskip-v4",
       "max_t": null,
-      "max_tick_unit": "total_t",
       "max_tick": 10000000,
       "save_frequency": 100000
     }],
@@ -68,6 +67,7 @@
     },
     "meta": {
       "distributed": false,
+      "max_tick_unit": "total_t",
       "max_session": 6,
       "max_trial": 16,
       "search": "RandomSearch",

--- a/slm_lab/spec/experimental/ddqn_qbert.json
+++ b/slm_lab/spec/experimental/ddqn_qbert.json
@@ -70,7 +70,6 @@
       "distributed": false,
       "max_session": 6,
       "max_trial": 16,
-      "training_eval": true,
       "search": "RandomSearch",
       "resources": {
         "num_cpus": 16

--- a/slm_lab/spec/experimental/ddqn_qbert.json
+++ b/slm_lab/spec/experimental/ddqn_qbert.json
@@ -58,8 +58,7 @@
     "env": [{
       "name": "QbertNoFrameskip-v4",
       "max_t": null,
-      "max_tick": 10000000,
-      "save_frequency": 100000
+      "max_tick": 10000000
     }],
     "body": {
       "product": "outer",
@@ -67,6 +66,7 @@
     },
     "meta": {
       "distributed": false,
+      "eval_frequency": 10000,
       "max_tick_unit": "total_t",
       "max_session": 6,
       "max_trial": 16,

--- a/slm_lab/spec/experimental/ddqn_qbert.json
+++ b/slm_lab/spec/experimental/ddqn_qbert.json
@@ -58,7 +58,6 @@
     "env": [{
       "name": "QbertNoFrameskip-v4",
       "max_t": null,
-      "max_tick_unit": "total_t",
       "max_tick": 10000000,
       "save_frequency": 100000
     }],
@@ -68,6 +67,7 @@
     },
     "meta": {
       "distributed": false,
+      "max_tick_unit": "total_t",
       "max_session": 6,
       "max_trial": 16,
       "search": "RandomSearch",

--- a/slm_lab/spec/experimental/ddqn_seaquest.json
+++ b/slm_lab/spec/experimental/ddqn_seaquest.json
@@ -70,7 +70,6 @@
       "distributed": false,
       "max_session": 6,
       "max_trial": 16,
-      "training_eval": true,
       "search": "RandomSearch",
       "resources": {
         "num_cpus": 16

--- a/slm_lab/spec/experimental/ddqn_seaquest.json
+++ b/slm_lab/spec/experimental/ddqn_seaquest.json
@@ -58,8 +58,7 @@
     "env": [{
       "name": "SeaquestNoFrameskip-v4",
       "max_t": null,
-      "max_tick": 10000000,
-      "save_frequency": 100000
+      "max_tick": 10000000
     }],
     "body": {
       "product": "outer",
@@ -67,6 +66,7 @@
     },
     "meta": {
       "distributed": false,
+      "eval_frequency": 10000,
       "max_tick_unit": "total_t",
       "max_session": 6,
       "max_trial": 16,

--- a/slm_lab/spec/experimental/ddqn_seaquest.json
+++ b/slm_lab/spec/experimental/ddqn_seaquest.json
@@ -58,7 +58,6 @@
     "env": [{
       "name": "SeaquestNoFrameskip-v4",
       "max_t": null,
-      "max_tick_unit": "total_t",
       "max_tick": 10000000,
       "save_frequency": 100000
     }],
@@ -68,6 +67,7 @@
     },
     "meta": {
       "distributed": false,
+      "max_tick_unit": "total_t",
       "max_session": 6,
       "max_trial": 16,
       "search": "RandomSearch",

--- a/slm_lab/spec/experimental/ddqn_spaceinvaders.json
+++ b/slm_lab/spec/experimental/ddqn_spaceinvaders.json
@@ -70,7 +70,6 @@
       "distributed": false,
       "max_session": 6,
       "max_trial": 16,
-      "training_eval": true,
       "search": "RandomSearch",
       "resources": {
         "num_cpus": 16

--- a/slm_lab/spec/experimental/ddqn_spaceinvaders.json
+++ b/slm_lab/spec/experimental/ddqn_spaceinvaders.json
@@ -58,7 +58,6 @@
     "env": [{
       "name": "SpaceInvadersNoFrameskip-v4",
       "max_t": null,
-      "max_tick_unit": "total_t",
       "max_tick": 10000000,
       "save_frequency": 100000
     }],
@@ -68,6 +67,7 @@
     },
     "meta": {
       "distributed": false,
+      "max_tick_unit": "total_t",
       "max_session": 6,
       "max_trial": 16,
       "search": "RandomSearch",

--- a/slm_lab/spec/experimental/ddqn_spaceinvaders.json
+++ b/slm_lab/spec/experimental/ddqn_spaceinvaders.json
@@ -58,8 +58,7 @@
     "env": [{
       "name": "SpaceInvadersNoFrameskip-v4",
       "max_t": null,
-      "max_tick": 10000000,
-      "save_frequency": 100000
+      "max_tick": 10000000
     }],
     "body": {
       "product": "outer",
@@ -67,6 +66,7 @@
     },
     "meta": {
       "distributed": false,
+      "eval_frequency": 10000,
       "max_tick_unit": "total_t",
       "max_session": 6,
       "max_trial": 16,

--- a/slm_lab/spec/experimental/dppo.json
+++ b/slm_lab/spec/experimental/dppo.json
@@ -57,7 +57,6 @@
     "env": [{
       "name": "CartPole-v0",
       "max_t": null,
-      "max_tick_unit": "epi",
       "max_tick": 500,
       "save_frequency": 1000
     }],
@@ -67,6 +66,7 @@
     },
     "meta": {
       "distributed": true,
+      "max_tick_unit": "epi",
       "max_session": 4,
       "max_trial": 100,
       "search": "RandomSearch"
@@ -149,7 +149,6 @@
     "env": [{
       "name": "CartPole-v0",
       "max_t": null,
-      "max_tick_unit": "epi",
       "max_tick": 500,
       "save_frequency": 1000
     }],
@@ -159,6 +158,7 @@
     },
     "meta": {
       "distributed": true,
+      "max_tick_unit": "epi",
       "max_session": 4,
       "max_trial": 100,
       "search": "RandomSearch"
@@ -245,7 +245,6 @@
     "env": [{
       "name": "CartPole-v0",
       "max_t": null,
-      "max_tick_unit": "epi",
       "max_tick": 500,
       "save_frequency": 1000
     }],
@@ -255,6 +254,7 @@
     },
     "meta": {
       "distributed": true,
+      "max_tick_unit": "epi",
       "max_session": 4,
       "max_trial": 100,
       "search": "RandomSearch"
@@ -341,7 +341,6 @@
     "env": [{
       "name": "CartPole-v0",
       "max_t": null,
-      "max_tick_unit": "epi",
       "max_tick": 500,
       "save_frequency": 1000
     }],
@@ -351,6 +350,7 @@
     },
     "meta": {
       "distributed": true,
+      "max_tick_unit": "epi",
       "max_session": 4,
       "max_trial": 100,
       "search": "RandomSearch"
@@ -433,7 +433,6 @@
     "env": [{
       "name": "Pendulum-v0",
       "max_t": null,
-      "max_tick_unit": "epi",
       "max_tick": 500,
       "save_frequency": 1000
     }],
@@ -443,6 +442,7 @@
     },
     "meta": {
       "distributed": true,
+      "max_tick_unit": "epi",
       "max_session": 4,
       "max_trial": 100,
       "search": "RandomSearch"
@@ -525,7 +525,6 @@
     "env": [{
       "name": "Pendulum-v0",
       "max_t": null,
-      "max_tick_unit": "epi",
       "max_tick": 500,
       "save_frequency": 1000
     }],
@@ -535,6 +534,7 @@
     },
     "meta": {
       "distributed": true,
+      "max_tick_unit": "epi",
       "max_session": 4,
       "max_trial": 100,
       "search": "RandomSearch"
@@ -621,7 +621,6 @@
     "env": [{
       "name": "Pendulum-v0",
       "max_t": null,
-      "max_tick_unit": "epi",
       "max_tick": 500,
       "save_frequency": 1000
     }],
@@ -631,6 +630,7 @@
     },
     "meta": {
       "distributed": true,
+      "max_tick_unit": "epi",
       "max_session": 4,
       "max_trial": 100,
       "search": "RandomSearch"
@@ -717,7 +717,6 @@
     "env": [{
       "name": "Pendulum-v0",
       "max_t": null,
-      "max_tick_unit": "epi",
       "max_tick": 500,
       "save_frequency": 1000
     }],
@@ -727,6 +726,7 @@
     },
     "meta": {
       "distributed": true,
+      "max_tick_unit": "epi",
       "max_session": 4,
       "max_trial": 100,
       "search": "RandomSearch"
@@ -814,7 +814,6 @@
     "env": [{
       "name": "Breakout-v0",
       "max_t": null,
-      "max_tick_unit": "epi",
       "max_tick": 1
     }],
     "body": {
@@ -823,6 +822,7 @@
     },
     "meta": {
       "distributed": true,
+      "max_tick_unit": "epi",
       "max_session": 1,
       "max_trial": 1,
       "search": "RandomSearch"
@@ -891,7 +891,6 @@
     "env": [{
       "name": "Breakout-v0",
       "max_t": null,
-      "max_tick_unit": "epi",
       "max_tick": 1
     }],
     "body": {
@@ -900,6 +899,7 @@
     },
     "meta": {
       "distributed": true,
+      "max_tick_unit": "epi",
       "max_session": 1,
       "max_trial": 1,
       "search": "RandomSearch"

--- a/slm_lab/spec/experimental/dppo.json
+++ b/slm_lab/spec/experimental/dppo.json
@@ -58,7 +58,6 @@
       "name": "CartPole-v0",
       "max_t": null,
       "max_tick": 500,
-      "save_frequency": 1000
     }],
     "body": {
       "product": "outer",
@@ -66,6 +65,7 @@
     },
     "meta": {
       "distributed": true,
+      "eval_frequency": 1000,
       "max_tick_unit": "epi",
       "max_session": 4,
       "max_trial": 100,
@@ -150,7 +150,6 @@
       "name": "CartPole-v0",
       "max_t": null,
       "max_tick": 500,
-      "save_frequency": 1000
     }],
     "body": {
       "product": "outer",
@@ -158,6 +157,7 @@
     },
     "meta": {
       "distributed": true,
+      "eval_frequency": 1000,
       "max_tick_unit": "epi",
       "max_session": 4,
       "max_trial": 100,
@@ -246,7 +246,6 @@
       "name": "CartPole-v0",
       "max_t": null,
       "max_tick": 500,
-      "save_frequency": 1000
     }],
     "body": {
       "product": "outer",
@@ -254,6 +253,7 @@
     },
     "meta": {
       "distributed": true,
+      "eval_frequency": 1000,
       "max_tick_unit": "epi",
       "max_session": 4,
       "max_trial": 100,
@@ -342,7 +342,6 @@
       "name": "CartPole-v0",
       "max_t": null,
       "max_tick": 500,
-      "save_frequency": 1000
     }],
     "body": {
       "product": "outer",
@@ -350,6 +349,7 @@
     },
     "meta": {
       "distributed": true,
+      "eval_frequency": 1000,
       "max_tick_unit": "epi",
       "max_session": 4,
       "max_trial": 100,
@@ -434,7 +434,6 @@
       "name": "Pendulum-v0",
       "max_t": null,
       "max_tick": 500,
-      "save_frequency": 1000
     }],
     "body": {
       "product": "outer",
@@ -442,6 +441,7 @@
     },
     "meta": {
       "distributed": true,
+      "eval_frequency": 1000,
       "max_tick_unit": "epi",
       "max_session": 4,
       "max_trial": 100,
@@ -526,7 +526,6 @@
       "name": "Pendulum-v0",
       "max_t": null,
       "max_tick": 500,
-      "save_frequency": 1000
     }],
     "body": {
       "product": "outer",
@@ -534,6 +533,7 @@
     },
     "meta": {
       "distributed": true,
+      "eval_frequency": 1000,
       "max_tick_unit": "epi",
       "max_session": 4,
       "max_trial": 100,
@@ -622,7 +622,6 @@
       "name": "Pendulum-v0",
       "max_t": null,
       "max_tick": 500,
-      "save_frequency": 1000
     }],
     "body": {
       "product": "outer",
@@ -630,6 +629,7 @@
     },
     "meta": {
       "distributed": true,
+      "eval_frequency": 1000,
       "max_tick_unit": "epi",
       "max_session": 4,
       "max_trial": 100,
@@ -718,7 +718,6 @@
       "name": "Pendulum-v0",
       "max_t": null,
       "max_tick": 500,
-      "save_frequency": 1000
     }],
     "body": {
       "product": "outer",
@@ -726,6 +725,7 @@
     },
     "meta": {
       "distributed": true,
+      "eval_frequency": 1000,
       "max_tick_unit": "epi",
       "max_session": 4,
       "max_trial": 100,
@@ -822,6 +822,7 @@
     },
     "meta": {
       "distributed": true,
+      "eval_frequency": 1000,
       "max_tick_unit": "epi",
       "max_session": 1,
       "max_trial": 1,
@@ -899,6 +900,7 @@
     },
     "meta": {
       "distributed": true,
+      "eval_frequency": 1000,
       "max_tick_unit": "epi",
       "max_session": 1,
       "max_trial": 1,

--- a/slm_lab/spec/experimental/dqn.json
+++ b/slm_lab/spec/experimental/dqn.json
@@ -49,7 +49,6 @@
     "env": [{
       "name": "CartPole-v0",
       "max_t": null,
-      "max_tick_unit": "epi",
       "max_tick": 250,
       "save_frequency": 1000
     }],
@@ -59,6 +58,7 @@
     },
     "meta": {
       "distributed": false,
+      "max_tick_unit": "epi",
       "max_session": 4,
       "max_trial": 100,
       "search": "RandomSearch"
@@ -138,7 +138,6 @@
     "env": [{
       "name": "CartPole-v0",
       "max_t": null,
-      "max_tick_unit": "epi",
       "max_tick": 250,
       "save_frequency": 1000
     }],
@@ -148,6 +147,7 @@
     },
     "meta": {
       "distributed": false,
+      "max_tick_unit": "epi",
       "max_session": 4,
       "max_trial": 100,
       "search": "RandomSearch"
@@ -227,7 +227,6 @@
     "env": [{
       "name": "CartPole-v0",
       "max_t": null,
-      "max_tick_unit": "epi",
       "max_tick": 250,
       "save_frequency": 1000
     }],
@@ -237,6 +236,7 @@
     },
     "meta": {
       "distributed": false,
+      "max_tick_unit": "epi",
       "max_session": 4,
       "max_trial": 100,
       "search": "RandomSearch"
@@ -320,7 +320,6 @@
     "env": [{
       "name": "CartPole-v0",
       "max_t": null,
-      "max_tick_unit": "epi",
       "max_tick": 250,
       "save_frequency": 1000
     }],
@@ -330,6 +329,7 @@
     },
     "meta": {
       "distributed": false,
+      "max_tick_unit": "epi",
       "max_session": 4,
       "max_trial": 100,
       "search": "RandomSearch"
@@ -413,7 +413,6 @@
     "env": [{
       "name": "CartPole-v0",
       "max_t": null,
-      "max_tick_unit": "epi",
       "max_tick": 250,
       "save_frequency": 1000
     }],
@@ -423,6 +422,7 @@
     },
     "meta": {
       "distributed": false,
+      "max_tick_unit": "epi",
       "max_session": 4,
       "max_trial": 100,
       "search": "RandomSearch"
@@ -503,7 +503,6 @@
     "env": [{
       "name": "LunarLander-v2",
       "max_t": null,
-      "max_tick_unit": "epi",
       "max_tick": 600,
       "save_frequency": 1000
     }],
@@ -513,6 +512,7 @@
     },
     "meta": {
       "distributed": false,
+      "max_tick_unit": "epi",
       "max_session": 1,
       "max_trial": 1,
       "search": "RandomSearch"
@@ -574,7 +574,6 @@
     "env": [{
       "name": "PongNoFrameskip-v4",
       "max_t": null,
-      "max_tick_unit": "total_t",
       "max_tick": 10000000,
       "save_frequency": 100000
     }],
@@ -584,6 +583,7 @@
     },
     "meta": {
       "distributed": false,
+      "max_tick_unit": "total_t",
       "max_session": 1,
       "max_trial": 16,
       "search": "RandomSearch",

--- a/slm_lab/spec/experimental/dqn.json
+++ b/slm_lab/spec/experimental/dqn.json
@@ -49,8 +49,7 @@
     "env": [{
       "name": "CartPole-v0",
       "max_t": null,
-      "max_tick": 250,
-      "save_frequency": 1000
+      "max_tick": 250
     }],
     "body": {
       "product": "outer",
@@ -58,6 +57,7 @@
     },
     "meta": {
       "distributed": false,
+      "eval_frequency": 1000,
       "max_tick_unit": "epi",
       "max_session": 4,
       "max_trial": 100,
@@ -139,7 +139,6 @@
       "name": "CartPole-v0",
       "max_t": null,
       "max_tick": 250,
-      "save_frequency": 1000
     }],
     "body": {
       "product": "outer",
@@ -147,6 +146,7 @@
     },
     "meta": {
       "distributed": false,
+      "eval_frequency": 1000,
       "max_tick_unit": "epi",
       "max_session": 4,
       "max_trial": 100,
@@ -228,7 +228,6 @@
       "name": "CartPole-v0",
       "max_t": null,
       "max_tick": 250,
-      "save_frequency": 1000
     }],
     "body": {
       "product": "outer",
@@ -236,6 +235,7 @@
     },
     "meta": {
       "distributed": false,
+      "eval_frequency": 1000,
       "max_tick_unit": "epi",
       "max_session": 4,
       "max_trial": 100,
@@ -321,7 +321,6 @@
       "name": "CartPole-v0",
       "max_t": null,
       "max_tick": 250,
-      "save_frequency": 1000
     }],
     "body": {
       "product": "outer",
@@ -329,6 +328,7 @@
     },
     "meta": {
       "distributed": false,
+      "eval_frequency": 1000,
       "max_tick_unit": "epi",
       "max_session": 4,
       "max_trial": 100,
@@ -414,7 +414,6 @@
       "name": "CartPole-v0",
       "max_t": null,
       "max_tick": 250,
-      "save_frequency": 1000
     }],
     "body": {
       "product": "outer",
@@ -422,6 +421,7 @@
     },
     "meta": {
       "distributed": false,
+      "eval_frequency": 1000,
       "max_tick_unit": "epi",
       "max_session": 4,
       "max_trial": 100,
@@ -504,7 +504,6 @@
       "name": "LunarLander-v2",
       "max_t": null,
       "max_tick": 600,
-      "save_frequency": 1000
     }],
     "body": {
       "product": "outer",
@@ -512,6 +511,7 @@
     },
     "meta": {
       "distributed": false,
+      "eval_frequency": 1000,
       "max_tick_unit": "epi",
       "max_session": 1,
       "max_trial": 1,
@@ -575,7 +575,6 @@
       "name": "PongNoFrameskip-v4",
       "max_t": null,
       "max_tick": 10000000,
-      "save_frequency": 100000
     }],
     "body": {
       "product": "outer",
@@ -583,6 +582,7 @@
     },
     "meta": {
       "distributed": false,
+      "eval_frequency": 1000,
       "max_tick_unit": "total_t",
       "max_session": 1,
       "max_trial": 16,

--- a/slm_lab/spec/experimental/dqn_beamrider.json
+++ b/slm_lab/spec/experimental/dqn_beamrider.json
@@ -61,8 +61,7 @@
     "env": [{
       "name": "BeamRiderNoFrameskip-v4",
       "max_t": null,
-      "max_tick": 10000000,
-      "save_frequency": 100000
+      "max_tick": 10000000
     }],
     "body": {
       "product": "outer",
@@ -70,6 +69,7 @@
     },
     "meta": {
       "distributed": false,
+      "eval_frequency": 10000,
       "max_tick_unit": "total_t",
       "max_session": 4,
       "max_trial": 12,

--- a/slm_lab/spec/experimental/dqn_beamrider.json
+++ b/slm_lab/spec/experimental/dqn_beamrider.json
@@ -73,7 +73,6 @@
       "distributed": false,
       "max_session": 4,
       "max_trial": 12,
-      "training_eval": true,
       "search": "RandomSearch",
       "resources": {
         "num_cpus": 12

--- a/slm_lab/spec/experimental/dqn_beamrider.json
+++ b/slm_lab/spec/experimental/dqn_beamrider.json
@@ -61,7 +61,6 @@
     "env": [{
       "name": "BeamRiderNoFrameskip-v4",
       "max_t": null,
-      "max_tick_unit": "total_t",
       "max_tick": 10000000,
       "save_frequency": 100000
     }],
@@ -71,6 +70,7 @@
     },
     "meta": {
       "distributed": false,
+      "max_tick_unit": "total_t",
       "max_session": 4,
       "max_trial": 12,
       "search": "RandomSearch",

--- a/slm_lab/spec/experimental/dqn_breakout.json
+++ b/slm_lab/spec/experimental/dqn_breakout.json
@@ -58,7 +58,6 @@
     "env": [{
       "name": "BreakoutNoFrameskip-v4",
       "max_t": null,
-      "max_tick_unit": "total_t",
       "max_tick": 10000000,
       "save_frequency": 100000
     }],
@@ -68,6 +67,7 @@
     },
     "meta": {
       "distributed": false,
+      "max_tick_unit": "total_t",
       "max_session": 4,
       "max_trial": 16,
       "search": "RandomSearch",

--- a/slm_lab/spec/experimental/dqn_breakout.json
+++ b/slm_lab/spec/experimental/dqn_breakout.json
@@ -70,7 +70,6 @@
       "distributed": false,
       "max_session": 4,
       "max_trial": 16,
-      "training_eval": true,
       "search": "RandomSearch",
       "resources": {
         "num_cpus": 16

--- a/slm_lab/spec/experimental/dqn_breakout.json
+++ b/slm_lab/spec/experimental/dqn_breakout.json
@@ -58,8 +58,7 @@
     "env": [{
       "name": "BreakoutNoFrameskip-v4",
       "max_t": null,
-      "max_tick": 10000000,
-      "save_frequency": 100000
+      "max_tick": 10000000
     }],
     "body": {
       "product": "outer",
@@ -67,6 +66,7 @@
     },
     "meta": {
       "distributed": false,
+      "eval_frequency": 10000,
       "max_tick_unit": "total_t",
       "max_session": 4,
       "max_trial": 16,

--- a/slm_lab/spec/experimental/dqn_enduro.json
+++ b/slm_lab/spec/experimental/dqn_enduro.json
@@ -58,7 +58,6 @@
     "env": [{
       "name": "EnduroNoFrameskip-v4",
       "max_t": null,
-      "max_tick_unit": "total_t",
       "max_tick": 10000000,
       "save_frequency": 100000
     }],
@@ -68,6 +67,7 @@
     },
     "meta": {
       "distributed": false,
+      "max_tick_unit": "total_t",
       "max_session": 4,
       "max_trial": 16,
       "search": "RandomSearch",

--- a/slm_lab/spec/experimental/dqn_enduro.json
+++ b/slm_lab/spec/experimental/dqn_enduro.json
@@ -70,7 +70,6 @@
       "distributed": false,
       "max_session": 4,
       "max_trial": 16,
-      "training_eval": true,
       "search": "RandomSearch",
       "resources": {
         "num_cpus": 16

--- a/slm_lab/spec/experimental/dqn_enduro.json
+++ b/slm_lab/spec/experimental/dqn_enduro.json
@@ -58,8 +58,7 @@
     "env": [{
       "name": "EnduroNoFrameskip-v4",
       "max_t": null,
-      "max_tick": 10000000,
-      "save_frequency": 100000
+      "max_tick": 10000000
     }],
     "body": {
       "product": "outer",
@@ -67,6 +66,7 @@
     },
     "meta": {
       "distributed": false,
+      "eval_frequency": 10000,
       "max_tick_unit": "total_t",
       "max_session": 4,
       "max_trial": 16,

--- a/slm_lab/spec/experimental/dqn_mspacman.json
+++ b/slm_lab/spec/experimental/dqn_mspacman.json
@@ -70,7 +70,6 @@
       "distributed": false,
       "max_session": 4,
       "max_trial": 16,
-      "training_eval": true,
       "search": "RandomSearch",
       "resources": {
         "num_cpus": 16

--- a/slm_lab/spec/experimental/dqn_mspacman.json
+++ b/slm_lab/spec/experimental/dqn_mspacman.json
@@ -58,7 +58,6 @@
     "env": [{
       "name": "MsPacmanNoFrameskip-v4",
       "max_t": null,
-      "max_tick_unit": "total_t",
       "max_tick": 10000000,
       "save_frequency": 100000
     }],
@@ -68,6 +67,7 @@
     },
     "meta": {
       "distributed": false,
+      "max_tick_unit": "total_t",
       "max_session": 4,
       "max_trial": 16,
       "search": "RandomSearch",

--- a/slm_lab/spec/experimental/dqn_mspacman.json
+++ b/slm_lab/spec/experimental/dqn_mspacman.json
@@ -58,8 +58,7 @@
     "env": [{
       "name": "MsPacmanNoFrameskip-v4",
       "max_t": null,
-      "max_tick": 10000000,
-      "save_frequency": 100000
+      "max_tick": 10000000
     }],
     "body": {
       "product": "outer",
@@ -67,6 +66,7 @@
     },
     "meta": {
       "distributed": false,
+      "eval_frequency": 10000,
       "max_tick_unit": "total_t",
       "max_session": 4,
       "max_trial": 16,

--- a/slm_lab/spec/experimental/dqn_pong.json
+++ b/slm_lab/spec/experimental/dqn_pong.json
@@ -58,8 +58,7 @@
     "env": [{
       "name": "PongNoFrameskip-v4",
       "max_t": null,
-      "max_tick": 10000000,
-      "save_frequency": 100000
+      "max_tick": 10000000
     }],
     "body": {
       "product": "outer",
@@ -67,6 +66,7 @@
     },
     "meta": {
       "distributed": false,
+      "eval_frequency": 10000,
       "max_tick_unit": "total_t",
       "max_session": 4,
       "max_trial": 16,

--- a/slm_lab/spec/experimental/dqn_pong.json
+++ b/slm_lab/spec/experimental/dqn_pong.json
@@ -70,7 +70,6 @@
       "distributed": false,
       "max_session": 4,
       "max_trial": 16,
-      "training_eval": true,
       "search": "RandomSearch",
       "resources": {
         "num_cpus": 16

--- a/slm_lab/spec/experimental/dqn_pong.json
+++ b/slm_lab/spec/experimental/dqn_pong.json
@@ -58,7 +58,6 @@
     "env": [{
       "name": "PongNoFrameskip-v4",
       "max_t": null,
-      "max_tick_unit": "total_t",
       "max_tick": 10000000,
       "save_frequency": 100000
     }],
@@ -68,6 +67,7 @@
     },
     "meta": {
       "distributed": false,
+      "max_tick_unit": "total_t",
       "max_session": 4,
       "max_trial": 16,
       "search": "RandomSearch",

--- a/slm_lab/spec/experimental/dqn_qbert.json
+++ b/slm_lab/spec/experimental/dqn_qbert.json
@@ -58,7 +58,6 @@
     "env": [{
       "name": "QbertNoFrameskip-v4",
       "max_t": null,
-      "max_tick_unit": "total_t",
       "max_tick": 10000000,
       "save_frequency": 100000
     }],
@@ -68,6 +67,7 @@
     },
     "meta": {
       "distributed": false,
+      "max_tick_unit": "total_t",
       "max_session": 4,
       "max_trial": 16,
       "search": "RandomSearch",

--- a/slm_lab/spec/experimental/dqn_qbert.json
+++ b/slm_lab/spec/experimental/dqn_qbert.json
@@ -70,7 +70,6 @@
       "distributed": false,
       "max_session": 4,
       "max_trial": 16,
-      "training_eval": true,
       "search": "RandomSearch",
       "resources": {
         "num_cpus": 16

--- a/slm_lab/spec/experimental/dqn_qbert.json
+++ b/slm_lab/spec/experimental/dqn_qbert.json
@@ -58,8 +58,7 @@
     "env": [{
       "name": "QbertNoFrameskip-v4",
       "max_t": null,
-      "max_tick": 10000000,
-      "save_frequency": 100000
+      "max_tick": 10000000
     }],
     "body": {
       "product": "outer",
@@ -67,6 +66,7 @@
     },
     "meta": {
       "distributed": false,
+      "eval_frequency": 10000,
       "max_tick_unit": "total_t",
       "max_session": 4,
       "max_trial": 16,

--- a/slm_lab/spec/experimental/dqn_seaquest.json
+++ b/slm_lab/spec/experimental/dqn_seaquest.json
@@ -70,7 +70,6 @@
       "distributed": false,
       "max_session": 4,
       "max_trial": 16,
-      "training_eval": true,
       "search": "RandomSearch",
       "resources": {
         "num_cpus": 16

--- a/slm_lab/spec/experimental/dqn_seaquest.json
+++ b/slm_lab/spec/experimental/dqn_seaquest.json
@@ -58,8 +58,7 @@
     "env": [{
       "name": "SeaquestNoFrameskip-v4",
       "max_t": null,
-      "max_tick": 10000000,
-      "save_frequency": 100000
+      "max_tick": 10000000
     }],
     "body": {
       "product": "outer",
@@ -67,6 +66,7 @@
     },
     "meta": {
       "distributed": false,
+      "eval_frequency": 10000,
       "max_tick_unit": "total_t",
       "max_session": 4,
       "max_trial": 16,

--- a/slm_lab/spec/experimental/dqn_seaquest.json
+++ b/slm_lab/spec/experimental/dqn_seaquest.json
@@ -58,7 +58,6 @@
     "env": [{
       "name": "SeaquestNoFrameskip-v4",
       "max_t": null,
-      "max_tick_unit": "total_t",
       "max_tick": 10000000,
       "save_frequency": 100000
     }],
@@ -68,6 +67,7 @@
     },
     "meta": {
       "distributed": false,
+      "max_tick_unit": "total_t",
       "max_session": 4,
       "max_trial": 16,
       "search": "RandomSearch",

--- a/slm_lab/spec/experimental/dqn_spaceinvaders.json
+++ b/slm_lab/spec/experimental/dqn_spaceinvaders.json
@@ -70,7 +70,6 @@
       "distributed": false,
       "max_session": 4,
       "max_trial": 16,
-      "training_eval": true,
       "search": "RandomSearch",
       "resources": {
         "num_cpus": 16

--- a/slm_lab/spec/experimental/dqn_spaceinvaders.json
+++ b/slm_lab/spec/experimental/dqn_spaceinvaders.json
@@ -58,7 +58,6 @@
     "env": [{
       "name": "SpaceInvadersNoFrameskip-v4",
       "max_t": null,
-      "max_tick_unit": "total_t",
       "max_tick": 10000000,
       "save_frequency": 100000
     }],
@@ -68,6 +67,7 @@
     },
     "meta": {
       "distributed": false,
+      "max_tick_unit": "total_t",
       "max_session": 4,
       "max_trial": 16,
       "search": "RandomSearch",

--- a/slm_lab/spec/experimental/dqn_spaceinvaders.json
+++ b/slm_lab/spec/experimental/dqn_spaceinvaders.json
@@ -58,8 +58,7 @@
     "env": [{
       "name": "SpaceInvadersNoFrameskip-v4",
       "max_t": null,
-      "max_tick": 10000000,
-      "save_frequency": 100000
+      "max_tick": 10000000
     }],
     "body": {
       "product": "outer",
@@ -67,6 +66,7 @@
     },
     "meta": {
       "distributed": false,
+      "eval_frequency": 10000,
       "max_tick_unit": "total_t",
       "max_session": 4,
       "max_trial": 16,

--- a/slm_lab/spec/experimental/dueling_dqn.json
+++ b/slm_lab/spec/experimental/dueling_dqn.json
@@ -52,7 +52,6 @@
     "env": [{
       "name": "CartPole-v0",
       "max_t": null,
-      "max_tick_unit": "epi",
       "max_tick": 250,
       "save_frequency": 1000
     }],
@@ -62,6 +61,7 @@
     },
     "meta": {
       "distributed": false,
+      "max_tick_unit": "epi",
       "max_session": 1,
       "max_trial": 100,
       "search": "RandomSearch"
@@ -141,7 +141,6 @@
     "env": [{
       "name": "CartPole-v0",
       "max_t": null,
-      "max_tick_unit": "epi",
       "max_tick": 250,
       "save_frequency": 1000
     }],
@@ -151,6 +150,7 @@
     },
     "meta": {
       "distributed": false,
+      "max_tick_unit": "epi",
       "max_session": 4,
       "max_trial": 100,
       "search": "RandomSearch"
@@ -231,7 +231,6 @@
     "env": [{
       "name": "LunarLander-v2",
       "max_t": null,
-      "max_tick_unit": "epi",
       "max_tick": 600,
       "save_frequency": 1000
     }],
@@ -241,6 +240,7 @@
     },
     "meta": {
       "distributed": false,
+      "max_tick_unit": "epi",
       "max_session": 1,
       "max_trial": 1,
       "search": "RandomSearch"
@@ -310,7 +310,6 @@
     "env": [{
       "name": "BreakoutDeterministic-v4",
       "max_t": null,
-      "max_tick_unit": "epi",
       "max_tick": 50000,
       "save_frequency": 1000
     }],
@@ -320,6 +319,7 @@
     },
     "meta": {
       "distributed": false,
+      "max_tick_unit": "epi",
       "max_session": 1,
       "max_trial": 1,
       "search": "RandomSearch"

--- a/slm_lab/spec/experimental/dueling_dqn.json
+++ b/slm_lab/spec/experimental/dueling_dqn.json
@@ -53,7 +53,6 @@
       "name": "CartPole-v0",
       "max_t": null,
       "max_tick": 250,
-      "save_frequency": 1000
     }],
     "body": {
       "product": "outer",
@@ -61,6 +60,7 @@
     },
     "meta": {
       "distributed": false,
+      "eval_frequency": 1000,
       "max_tick_unit": "epi",
       "max_session": 1,
       "max_trial": 100,
@@ -142,7 +142,6 @@
       "name": "CartPole-v0",
       "max_t": null,
       "max_tick": 250,
-      "save_frequency": 1000
     }],
     "body": {
       "product": "outer",
@@ -150,6 +149,7 @@
     },
     "meta": {
       "distributed": false,
+      "eval_frequency": 1000,
       "max_tick_unit": "epi",
       "max_session": 4,
       "max_trial": 100,
@@ -232,7 +232,6 @@
       "name": "LunarLander-v2",
       "max_t": null,
       "max_tick": 600,
-      "save_frequency": 1000
     }],
     "body": {
       "product": "outer",
@@ -240,6 +239,7 @@
     },
     "meta": {
       "distributed": false,
+      "eval_frequency": 1000,
       "max_tick_unit": "epi",
       "max_session": 1,
       "max_trial": 1,
@@ -311,7 +311,6 @@
       "name": "BreakoutDeterministic-v4",
       "max_t": null,
       "max_tick": 50000,
-      "save_frequency": 1000
     }],
     "body": {
       "product": "outer",
@@ -319,6 +318,7 @@
     },
     "meta": {
       "distributed": false,
+      "eval_frequency": 1000,
       "max_tick_unit": "epi",
       "max_session": 1,
       "max_trial": 1,

--- a/slm_lab/spec/experimental/gridworld.json
+++ b/slm_lab/spec/experimental/gridworld.json
@@ -46,7 +46,6 @@
     "env": [{
       "name": "gridworld",
       "max_t": null,
-      "max_tick_unit": "epi",
       "max_tick": 1000,
       "save_frequency": 1500,
     }],
@@ -56,6 +55,7 @@
     },
     "meta": {
       "distributed": false,
+      "max_tick_unit": "epi",
       "max_session": 4,
       "max_trial": 95,
       "search": "RandomSearch",
@@ -135,7 +135,6 @@
     "env": [{
       "name": "gridworld",
       "max_t": null,
-      "max_tick_unit": "epi",
       "max_tick": 1000,
       "save_frequency": 1500,
     }],
@@ -145,6 +144,7 @@
     },
     "meta": {
       "distributed": false,
+      "max_tick_unit": "epi",
       "max_session": 4,
       "max_trial": 95,
       "search": "RandomSearch",
@@ -220,7 +220,6 @@
     "env": [{
       "name": "gridworld",
       "max_t": null,
-      "max_tick_unit": "epi",
       "max_tick": 1000,
       "save_frequency": 1500,
     }],
@@ -230,6 +229,7 @@
     },
     "meta": {
       "distributed": false,
+      "max_tick_unit": "epi",
       "max_session": 4,
       "max_trial": 95,
       "search": "RandomSearch",
@@ -309,7 +309,6 @@
     "env": [{
       "name": "gridworld",
       "max_t": null,
-      "max_tick_unit": "epi",
       "max_tick": 1000,
       "save_frequency": 1500,
     }],
@@ -319,6 +318,7 @@
     },
     "meta": {
       "distributed": false,
+      "max_tick_unit": "epi",
       "max_session": 4,
       "max_trial": 95,
       "search": "RandomSearch",
@@ -401,7 +401,6 @@
     "env": [{
       "name": "gridworld",
       "max_t": null,
-      "max_tick_unit": "epi",
       "max_tick": 1000,
       "save_frequency": 1500,
     }],
@@ -411,6 +410,7 @@
     },
     "meta": {
       "distributed": false,
+      "max_tick_unit": "epi",
       "max_session": 4,
       "max_trial": 95,
       "search": "RandomSearch",
@@ -497,7 +497,6 @@
     "env": [{
       "name": "gridworld",
       "max_t": null,
-      "max_tick_unit": "epi",
       "max_tick": 1000,
       "save_frequency": 1500,
     }],
@@ -507,6 +506,7 @@
     },
     "meta": {
       "distributed": false,
+      "max_tick_unit": "epi",
       "max_session": 4,
       "max_trial": 95,
       "search": "RandomSearch",
@@ -591,7 +591,6 @@
     "env": [{
       "name": "gridworld",
       "max_t": null,
-      "max_tick_unit": "epi",
       "max_tick": 1000,
       "save_frequency": 1500,
     }],
@@ -601,6 +600,7 @@
     },
     "meta": {
       "distributed": false,
+      "max_tick_unit": "epi",
       "max_session": 4,
       "max_trial": 95,
       "search": "RandomSearch",
@@ -687,7 +687,6 @@
     "env": [{
       "name": "gridworld",
       "max_t": null,
-      "max_tick_unit": "epi",
       "max_tick": 1000,
       "save_frequency": 1500,
     }],
@@ -697,6 +696,7 @@
     },
     "meta": {
       "distributed": false,
+      "max_tick_unit": "epi",
       "max_session": 4,
       "max_trial": 95,
       "search": "RandomSearch",

--- a/slm_lab/spec/experimental/gridworld.json
+++ b/slm_lab/spec/experimental/gridworld.json
@@ -47,7 +47,6 @@
       "name": "gridworld",
       "max_t": null,
       "max_tick": 1000,
-      "save_frequency": 1500,
     }],
     "body": {
       "product": "outer",
@@ -55,6 +54,7 @@
     },
     "meta": {
       "distributed": false,
+      "eval_frequency": 1000,
       "max_tick_unit": "epi",
       "max_session": 4,
       "max_trial": 95,
@@ -136,7 +136,6 @@
       "name": "gridworld",
       "max_t": null,
       "max_tick": 1000,
-      "save_frequency": 1500,
     }],
     "body": {
       "product": "outer",
@@ -144,6 +143,7 @@
     },
     "meta": {
       "distributed": false,
+      "eval_frequency": 1000,
       "max_tick_unit": "epi",
       "max_session": 4,
       "max_trial": 95,
@@ -221,7 +221,6 @@
       "name": "gridworld",
       "max_t": null,
       "max_tick": 1000,
-      "save_frequency": 1500,
     }],
     "body": {
       "product": "outer",
@@ -229,6 +228,7 @@
     },
     "meta": {
       "distributed": false,
+      "eval_frequency": 1000,
       "max_tick_unit": "epi",
       "max_session": 4,
       "max_trial": 95,
@@ -310,7 +310,6 @@
       "name": "gridworld",
       "max_t": null,
       "max_tick": 1000,
-      "save_frequency": 1500,
     }],
     "body": {
       "product": "outer",
@@ -318,6 +317,7 @@
     },
     "meta": {
       "distributed": false,
+      "eval_frequency": 1000,
       "max_tick_unit": "epi",
       "max_session": 4,
       "max_trial": 95,
@@ -402,7 +402,6 @@
       "name": "gridworld",
       "max_t": null,
       "max_tick": 1000,
-      "save_frequency": 1500,
     }],
     "body": {
       "product": "outer",
@@ -410,6 +409,7 @@
     },
     "meta": {
       "distributed": false,
+      "eval_frequency": 1000,
       "max_tick_unit": "epi",
       "max_session": 4,
       "max_trial": 95,
@@ -498,7 +498,6 @@
       "name": "gridworld",
       "max_t": null,
       "max_tick": 1000,
-      "save_frequency": 1500,
     }],
     "body": {
       "product": "outer",
@@ -506,6 +505,7 @@
     },
     "meta": {
       "distributed": false,
+      "eval_frequency": 1000,
       "max_tick_unit": "epi",
       "max_session": 4,
       "max_trial": 95,
@@ -592,7 +592,6 @@
       "name": "gridworld",
       "max_t": null,
       "max_tick": 1000,
-      "save_frequency": 1500,
     }],
     "body": {
       "product": "outer",
@@ -600,6 +599,7 @@
     },
     "meta": {
       "distributed": false,
+      "eval_frequency": 1000,
       "max_tick_unit": "epi",
       "max_session": 4,
       "max_trial": 95,
@@ -688,7 +688,6 @@
       "name": "gridworld",
       "max_t": null,
       "max_tick": 1000,
-      "save_frequency": 1500,
     }],
     "body": {
       "product": "outer",
@@ -696,6 +695,7 @@
     },
     "meta": {
       "distributed": false,
+      "eval_frequency": 1000,
       "max_tick_unit": "epi",
       "max_session": 4,
       "max_trial": 95,

--- a/slm_lab/spec/experimental/hydra_dqn.json
+++ b/slm_lab/spec/experimental/hydra_dqn.json
@@ -57,7 +57,6 @@
       "name": "CartPole-v0",
       "max_t": null,
       "max_tick": 1000,
-      "save_frequency": 1000
     }, {
       "name": "CartPole-v0",
       "max_t": null,
@@ -69,6 +68,7 @@
     },
     "meta": {
       "distributed": false,
+      "eval_frequency": 1000,
       "max_tick_unit": "epi",
       "max_session": 4,
       "max_trial": 100,
@@ -157,7 +157,6 @@
       "name": "CartPole-v0",
       "max_t": null,
       "max_tick": 1000,
-      "save_frequency": 1000
     }, {
       "name": "CartPole-v0",
       "max_t": null,
@@ -169,6 +168,7 @@
     },
     "meta": {
       "distributed": false,
+      "eval_frequency": 1000,
       "max_tick_unit": "epi",
       "max_session": 4,
       "max_trial": 100,
@@ -258,13 +258,11 @@
       "max_t": null,
       "max_tick": 300,
       "reward_scale": 1,
-      "save_frequency": 10000
     }, {
       "name": "2DBall",
       "max_t": 1000,
       "max_tick": 300,
       "reward_scale": 10,
-      "save_frequency": 10000
     }],
     "body": {
       "product": "outer",
@@ -272,6 +270,7 @@
     },
     "meta": {
       "distributed": false,
+      "eval_frequency": 1000,
       "max_tick_unit": "epi",
       "max_session": 1,
       "max_trial": 40,
@@ -355,13 +354,11 @@
       "max_t": null,
       "max_tick": 300,
       "reward_scale": 1,
-      "save_frequency": 10000
     }, {
       "name": "2DBall",
       "max_t": 1000,
       "max_tick": 300,
       "reward_scale": 10,
-      "save_frequency": 10000
     }],
     "body": {
       "product": "outer",
@@ -369,6 +366,7 @@
     },
     "meta": {
       "distributed": false,
+      "eval_frequency": 1000,
       "max_tick_unit": "epi",
       "max_session": 1,
       "max_trial": 40,

--- a/slm_lab/spec/experimental/hydra_dqn.json
+++ b/slm_lab/spec/experimental/hydra_dqn.json
@@ -56,13 +56,11 @@
     "env": [{
       "name": "CartPole-v0",
       "max_t": null,
-      "max_tick_unit": "epi",
       "max_tick": 1000,
       "save_frequency": 1000
     }, {
       "name": "CartPole-v0",
       "max_t": null,
-      "max_tick_unit": "epi",
       "max_tick": 1000
     }],
     "body": {
@@ -71,6 +69,7 @@
     },
     "meta": {
       "distributed": false,
+      "max_tick_unit": "epi",
       "max_session": 4,
       "max_trial": 100,
       "search": "RandomSearch"
@@ -157,13 +156,11 @@
     "env": [{
       "name": "CartPole-v0",
       "max_t": null,
-      "max_tick_unit": "epi",
       "max_tick": 1000,
       "save_frequency": 1000
     }, {
       "name": "CartPole-v0",
       "max_t": null,
-      "max_tick_unit": "epi",
       "max_tick": 1000
     }],
     "body": {
@@ -172,6 +169,7 @@
     },
     "meta": {
       "distributed": false,
+      "max_tick_unit": "epi",
       "max_session": 4,
       "max_trial": 100,
       "search": "RandomSearch"
@@ -258,14 +256,12 @@
     "env": [{
       "name": "CartPole-v0",
       "max_t": null,
-      "max_tick_unit": "epi",
       "max_tick": 300,
       "reward_scale": 1,
       "save_frequency": 10000
     }, {
       "name": "2DBall",
       "max_t": 1000,
-      "max_tick_unit": "epi",
       "max_tick": 300,
       "reward_scale": 10,
       "save_frequency": 10000
@@ -276,6 +272,7 @@
     },
     "meta": {
       "distributed": false,
+      "max_tick_unit": "epi",
       "max_session": 1,
       "max_trial": 40,
       "search": "RandomSearch"
@@ -356,14 +353,12 @@
     "env": [{
       "name": "CartPole-v0",
       "max_t": null,
-      "max_tick_unit": "epi",
       "max_tick": 300,
       "reward_scale": 1,
       "save_frequency": 10000
     }, {
       "name": "2DBall",
       "max_t": 1000,
-      "max_tick_unit": "epi",
       "max_tick": 300,
       "reward_scale": 10,
       "save_frequency": 10000
@@ -374,6 +369,7 @@
     },
     "meta": {
       "distributed": false,
+      "max_tick_unit": "epi",
       "max_session": 1,
       "max_trial": 40,
       "search": "RandomSearch"

--- a/slm_lab/spec/experimental/lunar_dqn.json
+++ b/slm_lab/spec/experimental/lunar_dqn.json
@@ -52,7 +52,6 @@
     "env": [{
       "name": "LunarLander-v2",
       "max_t": null,
-      "max_tick_unit": "total_t",
       "max_tick": 250000,
       "save_frequency": 10000,
     }],
@@ -62,6 +61,7 @@
     },
     "meta": {
       "distributed": false,
+      "max_tick_unit": "total_t",
       "max_session": 2,
       "max_trial": 95,
       "search": "RandomSearch",
@@ -151,7 +151,6 @@
     "env": [{
       "name": "LunarLander-v2",
       "max_t": null,
-      "max_tick_unit": "total_t",
       "max_tick": 250000,
       "save_frequency": 10000,
     }],
@@ -161,6 +160,7 @@
     },
     "meta": {
       "distributed": false,
+      "max_tick_unit": "total_t",
       "max_session": 2,
       "max_trial": 95,
       "search": "RandomSearch",
@@ -250,7 +250,6 @@
     "env": [{
       "name": "LunarLander-v2",
       "max_t": null,
-      "max_tick_unit": "total_t",
       "max_tick": 250000,
       "save_frequency": 10000,
     }],
@@ -260,6 +259,7 @@
     },
     "meta": {
       "distributed": false,
+      "max_tick_unit": "total_t",
       "max_session": 2,
       "max_trial": 95,
       "search": "RandomSearch",
@@ -349,7 +349,6 @@
     "env": [{
       "name": "LunarLander-v2",
       "max_t": null,
-      "max_tick_unit": "total_t",
       "max_tick": 250000,
       "save_frequency": 10000,
     }],
@@ -359,6 +358,7 @@
     },
     "meta": {
       "distributed": false,
+      "max_tick_unit": "total_t",
       "max_session": 2,
       "max_trial": 95,
       "search": "RandomSearch",
@@ -448,7 +448,6 @@
     "env": [{
       "name": "LunarLander-v2",
       "max_t": null,
-      "max_tick_unit": "total_t",
       "max_tick": 250000,
       "save_frequency": 10000,
     }],
@@ -458,6 +457,7 @@
     },
     "meta": {
       "distributed": false,
+      "max_tick_unit": "total_t",
       "max_session": 2,
       "max_trial": 95,
       "search": "RandomSearch",
@@ -547,7 +547,6 @@
     "env": [{
       "name": "LunarLander-v2",
       "max_t": null,
-      "max_tick_unit": "total_t",
       "max_tick": 250000,
       "save_frequency": 10000,
     }],
@@ -557,6 +556,7 @@
     },
     "meta": {
       "distributed": false,
+      "max_tick_unit": "total_t",
       "max_session": 2,
       "max_trial": 95,
       "search": "RandomSearch",
@@ -646,7 +646,6 @@
     "env": [{
       "name": "LunarLander-v2",
       "max_t": null,
-      "max_tick_unit": "total_t",
       "max_tick": 250000,
       "save_frequency": 10000,
     }],
@@ -656,6 +655,7 @@
     },
     "meta": {
       "distributed": false,
+      "max_tick_unit": "total_t",
       "max_session": 2,
       "max_trial": 95,
       "search": "RandomSearch",
@@ -745,7 +745,6 @@
     "env": [{
       "name": "LunarLander-v2",
       "max_t": null,
-      "max_tick_unit": "total_t",
       "max_tick": 250000,
       "save_frequency": 10000,
     }],
@@ -755,6 +754,7 @@
     },
     "meta": {
       "distributed": false,
+      "max_tick_unit": "total_t",
       "max_session": 2,
       "max_trial": 95,
       "search": "RandomSearch",
@@ -847,7 +847,6 @@
     "env": [{
       "name": "LunarLander-v2",
       "max_t": null,
-      "max_tick_unit": "total_t",
       "max_tick": 250000,
       "save_frequency": 10000,
     }],
@@ -857,6 +856,7 @@
     },
     "meta": {
       "distributed": false,
+      "max_tick_unit": "total_t",
       "max_session": 2,
       "max_trial": 95,
       "search": "RandomSearch",
@@ -943,7 +943,6 @@
     "env": [{
       "name": "LunarLander-v2",
       "max_t": null,
-      "max_tick_unit": "total_t",
       "max_tick": 250000,
       "save_frequency": 10000,
     }],
@@ -953,6 +952,7 @@
     },
     "meta": {
       "distributed": false,
+      "max_tick_unit": "total_t",
       "max_session": 2,
       "max_trial": 95,
       "search": "RandomSearch",

--- a/slm_lab/spec/experimental/lunar_dqn.json
+++ b/slm_lab/spec/experimental/lunar_dqn.json
@@ -53,7 +53,6 @@
       "name": "LunarLander-v2",
       "max_t": null,
       "max_tick": 250000,
-      "save_frequency": 10000,
     }],
     "body": {
       "product": "outer",
@@ -61,6 +60,7 @@
     },
     "meta": {
       "distributed": false,
+      "eval_frequency": 1000,
       "max_tick_unit": "total_t",
       "max_session": 2,
       "max_trial": 95,
@@ -152,7 +152,6 @@
       "name": "LunarLander-v2",
       "max_t": null,
       "max_tick": 250000,
-      "save_frequency": 10000,
     }],
     "body": {
       "product": "outer",
@@ -160,6 +159,7 @@
     },
     "meta": {
       "distributed": false,
+      "eval_frequency": 1000,
       "max_tick_unit": "total_t",
       "max_session": 2,
       "max_trial": 95,
@@ -251,7 +251,6 @@
       "name": "LunarLander-v2",
       "max_t": null,
       "max_tick": 250000,
-      "save_frequency": 10000,
     }],
     "body": {
       "product": "outer",
@@ -259,6 +258,7 @@
     },
     "meta": {
       "distributed": false,
+      "eval_frequency": 1000,
       "max_tick_unit": "total_t",
       "max_session": 2,
       "max_trial": 95,
@@ -350,7 +350,6 @@
       "name": "LunarLander-v2",
       "max_t": null,
       "max_tick": 250000,
-      "save_frequency": 10000,
     }],
     "body": {
       "product": "outer",
@@ -358,6 +357,7 @@
     },
     "meta": {
       "distributed": false,
+      "eval_frequency": 1000,
       "max_tick_unit": "total_t",
       "max_session": 2,
       "max_trial": 95,
@@ -449,7 +449,6 @@
       "name": "LunarLander-v2",
       "max_t": null,
       "max_tick": 250000,
-      "save_frequency": 10000,
     }],
     "body": {
       "product": "outer",
@@ -457,6 +456,7 @@
     },
     "meta": {
       "distributed": false,
+      "eval_frequency": 1000,
       "max_tick_unit": "total_t",
       "max_session": 2,
       "max_trial": 95,
@@ -548,7 +548,6 @@
       "name": "LunarLander-v2",
       "max_t": null,
       "max_tick": 250000,
-      "save_frequency": 10000,
     }],
     "body": {
       "product": "outer",
@@ -556,6 +555,7 @@
     },
     "meta": {
       "distributed": false,
+      "eval_frequency": 1000,
       "max_tick_unit": "total_t",
       "max_session": 2,
       "max_trial": 95,
@@ -647,7 +647,6 @@
       "name": "LunarLander-v2",
       "max_t": null,
       "max_tick": 250000,
-      "save_frequency": 10000,
     }],
     "body": {
       "product": "outer",
@@ -655,6 +654,7 @@
     },
     "meta": {
       "distributed": false,
+      "eval_frequency": 1000,
       "max_tick_unit": "total_t",
       "max_session": 2,
       "max_trial": 95,
@@ -746,7 +746,6 @@
       "name": "LunarLander-v2",
       "max_t": null,
       "max_tick": 250000,
-      "save_frequency": 10000,
     }],
     "body": {
       "product": "outer",
@@ -754,6 +753,7 @@
     },
     "meta": {
       "distributed": false,
+      "eval_frequency": 1000,
       "max_tick_unit": "total_t",
       "max_session": 2,
       "max_trial": 95,
@@ -848,7 +848,6 @@
       "name": "LunarLander-v2",
       "max_t": null,
       "max_tick": 250000,
-      "save_frequency": 10000,
     }],
     "body": {
       "product": "outer",
@@ -856,6 +855,7 @@
     },
     "meta": {
       "distributed": false,
+      "eval_frequency": 1000,
       "max_tick_unit": "total_t",
       "max_session": 2,
       "max_trial": 95,
@@ -944,7 +944,6 @@
       "name": "LunarLander-v2",
       "max_t": null,
       "max_tick": 250000,
-      "save_frequency": 10000,
     }],
     "body": {
       "product": "outer",
@@ -952,6 +951,7 @@
     },
     "meta": {
       "distributed": false,
+      "eval_frequency": 1000,
       "max_tick_unit": "total_t",
       "max_session": 2,
       "max_trial": 95,

--- a/slm_lab/spec/experimental/lunar_pg.json
+++ b/slm_lab/spec/experimental/lunar_pg.json
@@ -44,7 +44,6 @@
     "env": [{
       "name": "LunarLander-v2",
       "max_t": null,
-      "max_tick_unit": "total_t",
       "max_tick": 400000,
       "save_frequency": 20000,
     }],
@@ -54,6 +53,7 @@
     },
     "meta": {
       "distributed": false,
+      "max_tick_unit": "total_t",
       "max_session": 2,
       "max_trial": 95,
       "search": "RandomSearch",
@@ -137,7 +137,6 @@
     "env": [{
       "name": "LunarLander-v2",
       "max_t": null,
-      "max_tick_unit": "total_t",
       "max_tick": 400000,
       "save_frequency": 20000,
     }],
@@ -147,6 +146,7 @@
     },
     "meta": {
       "distributed": false,
+      "max_tick_unit": "total_t",
       "max_session": 2,
       "max_trial": 95,
       "search": "RandomSearch",
@@ -236,7 +236,6 @@
     "env": [{
       "name": "LunarLander-v2",
       "max_t": null,
-      "max_tick_unit": "total_t",
       "max_tick": 400000,
       "save_frequency": 20000,
     }],
@@ -246,6 +245,7 @@
     },
     "meta": {
       "distributed": false,
+      "max_tick_unit": "total_t",
       "max_session": 2,
       "max_trial": 95,
       "search": "RandomSearch",
@@ -337,7 +337,6 @@
     "env": [{
       "name": "LunarLander-v2",
       "max_t": null,
-      "max_tick_unit": "total_t",
       "max_tick": 400000,
       "save_frequency": 20000,
     }],
@@ -347,6 +346,7 @@
     },
     "meta": {
       "distributed": false,
+      "max_tick_unit": "total_t",
       "max_session": 2,
       "max_trial": 95,
       "search": "RandomSearch",
@@ -436,7 +436,6 @@
     "env": [{
       "name": "LunarLander-v2",
       "max_t": null,
-      "max_tick_unit": "total_t",
       "max_tick": 400000,
       "save_frequency": 20000,
     }],
@@ -446,6 +445,7 @@
     },
     "meta": {
       "distributed": false,
+      "max_tick_unit": "total_t",
       "max_session": 2,
       "max_trial": 95,
       "search": "RandomSearch",
@@ -538,7 +538,6 @@
     "env": [{
       "name": "LunarLander-v2",
       "max_t": null,
-      "max_tick_unit": "total_t",
       "max_tick": 400000,
       "save_frequency": 20000,
     }],
@@ -548,6 +547,7 @@
     },
     "meta": {
       "distributed": false,
+      "max_tick_unit": "total_t",
       "max_session": 2,
       "max_trial": 95,
       "search": "RandomSearch",
@@ -643,7 +643,6 @@
     "env": [{
       "name": "LunarLander-v2",
       "max_t": null,
-      "max_tick_unit": "total_t",
       "max_tick": 400000,
       "save_frequency": 20000,
     }],
@@ -653,6 +652,7 @@
     },
     "meta": {
       "distributed": false,
+      "max_tick_unit": "total_t",
       "max_session": 2,
       "max_trial": 95,
       "search": "RandomSearch",
@@ -743,7 +743,6 @@
     "env": [{
       "name": "LunarLander-v2",
       "max_t": null,
-      "max_tick_unit": "total_t",
       "max_tick": 400000,
       "save_frequency": 20000,
     }],
@@ -753,6 +752,7 @@
     },
     "meta": {
       "distributed": false,
+      "max_tick_unit": "total_t",
       "max_session": 2,
       "max_trial": 95,
       "search": "RandomSearch",
@@ -835,7 +835,6 @@
     "env": [{
       "name": "LunarLander-v2",
       "max_t": null,
-      "max_tick_unit": "total_t",
       "max_tick": 400000,
       "save_frequency": 20000,
     }],
@@ -845,6 +844,7 @@
     },
     "meta": {
       "distributed": false,
+      "max_tick_unit": "total_t",
       "max_session": 2,
       "max_trial": 95,
       "search": "RandomSearch",
@@ -929,7 +929,6 @@
     "env": [{
       "name": "LunarLander-v2",
       "max_t": null,
-      "max_tick_unit": "total_t",
       "max_tick": 400000,
       "save_frequency": 20000,
     }],
@@ -939,6 +938,7 @@
     },
     "meta": {
       "distributed": false,
+      "max_tick_unit": "total_t",
       "max_session": 2,
       "max_trial": 95,
       "search": "RandomSearch",
@@ -1027,7 +1027,6 @@
     "env": [{
       "name": "LunarLander-v2",
       "max_t": null,
-      "max_tick_unit": "total_t",
       "max_tick": 400000,
       "save_frequency": 20000,
     }],
@@ -1037,6 +1036,7 @@
     },
     "meta": {
       "distributed": false,
+      "max_tick_unit": "total_t",
       "max_session": 2,
       "max_trial": 95,
       "search": "RandomSearch",
@@ -1116,7 +1116,6 @@
     "env": [{
       "name": "LunarLander-v2",
       "max_t": null,
-      "max_tick_unit": "total_t",
       "max_tick": 400000,
       "save_frequency": 20000,
     }],
@@ -1126,6 +1125,7 @@
     },
     "meta": {
       "distributed": false,
+      "max_tick_unit": "total_t",
       "max_session": 2,
       "max_trial": 95,
       "search": "RandomSearch",
@@ -1210,7 +1210,6 @@
     "env": [{
       "name": "LunarLander-v2",
       "max_t": null,
-      "max_tick_unit": "total_t",
       "max_tick": 400000,
       "save_frequency": 20000,
     }],
@@ -1220,6 +1219,7 @@
     },
     "meta": {
       "distributed": false,
+      "max_tick_unit": "total_t",
       "max_session": 2,
       "max_trial": 95,
       "search": "RandomSearch",
@@ -1308,7 +1308,6 @@
     "env": [{
       "name": "LunarLander-v2",
       "max_t": null,
-      "max_tick_unit": "total_t",
       "max_tick": 400000,
       "save_frequency": 20000,
     }],
@@ -1318,6 +1317,7 @@
     },
     "meta": {
       "distributed": false,
+      "max_tick_unit": "total_t",
       "max_session": 2,
       "max_trial": 95,
       "search": "RandomSearch",
@@ -1402,7 +1402,6 @@
     "env": [{
       "name": "LunarLander-v2",
       "max_t": null,
-      "max_tick_unit": "total_t",
       "max_tick": 400000,
       "save_frequency": 20000,
     }],
@@ -1412,6 +1411,7 @@
     },
     "meta": {
       "distributed": false,
+      "max_tick_unit": "total_t",
       "max_session": 2,
       "max_trial": 95,
       "search": "RandomSearch",
@@ -1499,7 +1499,6 @@
     "env": [{
       "name": "LunarLander-v2",
       "max_t": null,
-      "max_tick_unit": "total_t",
       "max_tick": 400000,
       "save_frequency": 20000,
     }],
@@ -1509,6 +1508,7 @@
     },
     "meta": {
       "distributed": false,
+      "max_tick_unit": "total_t",
       "max_session": 2,
       "max_trial": 95,
       "search": "RandomSearch",
@@ -1595,7 +1595,6 @@
     "env": [{
       "name": "LunarLander-v2",
       "max_t": null,
-      "max_tick_unit": "total_t",
       "max_tick": 400000,
       "save_frequency": 20000,
     }],
@@ -1605,6 +1604,7 @@
     },
     "meta": {
       "distributed": false,
+      "max_tick_unit": "total_t",
       "max_session": 2,
       "max_trial": 95,
       "search": "RandomSearch",
@@ -1691,7 +1691,6 @@
     "env": [{
       "name": "LunarLander-v2",
       "max_t": null,
-      "max_tick_unit": "total_t",
       "max_tick": 400000,
       "save_frequency": 20000,
     }],
@@ -1701,6 +1700,7 @@
     },
     "meta": {
       "distributed": false,
+      "max_tick_unit": "total_t",
       "max_session": 2,
       "max_trial": 95,
       "search": "RandomSearch",
@@ -1794,7 +1794,6 @@
     "env": [{
       "name": "LunarLander-v2",
       "max_t": null,
-      "max_tick_unit": "total_t",
       "max_tick": 400000,
       "save_frequency": 20000,
     }],
@@ -1804,6 +1803,7 @@
     },
     "meta": {
       "distributed": false,
+      "max_tick_unit": "total_t",
       "max_session": 2,
       "max_trial": 95,
       "search": "RandomSearch",
@@ -1895,7 +1895,6 @@
     "env": [{
       "name": "LunarLander-v2",
       "max_t": null,
-      "max_tick_unit": "total_t",
       "max_tick": 400000,
       "save_frequency": 20000,
     }],
@@ -1905,6 +1904,7 @@
     },
     "meta": {
       "distributed": false,
+      "max_tick_unit": "total_t",
       "max_session": 2,
       "max_trial": 95,
       "search": "RandomSearch",
@@ -1996,7 +1996,6 @@
     "env": [{
       "name": "LunarLander-v2",
       "max_t": null,
-      "max_tick_unit": "total_t",
       "max_tick": 400000,
       "save_frequency": 20000,
     }],
@@ -2006,6 +2005,7 @@
     },
     "meta": {
       "distributed": false,
+      "max_tick_unit": "total_t",
       "max_session": 2,
       "max_trial": 95,
       "search": "RandomSearch",
@@ -2094,7 +2094,6 @@
     "env": [{
       "name": "LunarLander-v2",
       "max_t": null,
-      "max_tick_unit": "total_t",
       "max_tick": 400000,
       "save_frequency": 20000,
     }],
@@ -2104,6 +2103,7 @@
     },
     "meta": {
       "distributed": false,
+      "max_tick_unit": "total_t",
       "max_session": 2,
       "max_trial": 95,
       "search": "RandomSearch",
@@ -2203,7 +2203,6 @@
     "env": [{
       "name": "LunarLander-v2",
       "max_t": null,
-      "max_tick_unit": "total_t",
       "max_tick": 400000,
       "save_frequency": 20000,
     }],
@@ -2213,6 +2212,7 @@
     },
     "meta": {
       "distributed": false,
+      "max_tick_unit": "total_t",
       "max_session": 2,
       "max_trial": 95,
       "search": "RandomSearch",
@@ -2310,7 +2310,6 @@
     "env": [{
       "name": "LunarLander-v2",
       "max_t": null,
-      "max_tick_unit": "total_t",
       "max_tick": 400000,
       "save_frequency": 20000,
     }],
@@ -2320,6 +2319,7 @@
     },
     "meta": {
       "distributed": false,
+      "max_tick_unit": "total_t",
       "max_session": 2,
       "max_trial": 95,
       "search": "RandomSearch",

--- a/slm_lab/spec/experimental/lunar_pg.json
+++ b/slm_lab/spec/experimental/lunar_pg.json
@@ -45,7 +45,6 @@
       "name": "LunarLander-v2",
       "max_t": null,
       "max_tick": 400000,
-      "save_frequency": 20000,
     }],
     "body": {
       "product": "outer",
@@ -53,6 +52,7 @@
     },
     "meta": {
       "distributed": false,
+      "eval_frequency": 1000,
       "max_tick_unit": "total_t",
       "max_session": 2,
       "max_trial": 95,
@@ -138,7 +138,6 @@
       "name": "LunarLander-v2",
       "max_t": null,
       "max_tick": 400000,
-      "save_frequency": 20000,
     }],
     "body": {
       "product": "outer",
@@ -146,6 +145,7 @@
     },
     "meta": {
       "distributed": false,
+      "eval_frequency": 1000,
       "max_tick_unit": "total_t",
       "max_session": 2,
       "max_trial": 95,
@@ -237,7 +237,6 @@
       "name": "LunarLander-v2",
       "max_t": null,
       "max_tick": 400000,
-      "save_frequency": 20000,
     }],
     "body": {
       "product": "outer",
@@ -245,6 +244,7 @@
     },
     "meta": {
       "distributed": false,
+      "eval_frequency": 1000,
       "max_tick_unit": "total_t",
       "max_session": 2,
       "max_trial": 95,
@@ -338,7 +338,6 @@
       "name": "LunarLander-v2",
       "max_t": null,
       "max_tick": 400000,
-      "save_frequency": 20000,
     }],
     "body": {
       "product": "outer",
@@ -346,6 +345,7 @@
     },
     "meta": {
       "distributed": false,
+      "eval_frequency": 1000,
       "max_tick_unit": "total_t",
       "max_session": 2,
       "max_trial": 95,
@@ -437,7 +437,6 @@
       "name": "LunarLander-v2",
       "max_t": null,
       "max_tick": 400000,
-      "save_frequency": 20000,
     }],
     "body": {
       "product": "outer",
@@ -445,6 +444,7 @@
     },
     "meta": {
       "distributed": false,
+      "eval_frequency": 1000,
       "max_tick_unit": "total_t",
       "max_session": 2,
       "max_trial": 95,
@@ -539,7 +539,6 @@
       "name": "LunarLander-v2",
       "max_t": null,
       "max_tick": 400000,
-      "save_frequency": 20000,
     }],
     "body": {
       "product": "outer",
@@ -547,6 +546,7 @@
     },
     "meta": {
       "distributed": false,
+      "eval_frequency": 1000,
       "max_tick_unit": "total_t",
       "max_session": 2,
       "max_trial": 95,
@@ -644,7 +644,6 @@
       "name": "LunarLander-v2",
       "max_t": null,
       "max_tick": 400000,
-      "save_frequency": 20000,
     }],
     "body": {
       "product": "outer",
@@ -652,6 +651,7 @@
     },
     "meta": {
       "distributed": false,
+      "eval_frequency": 1000,
       "max_tick_unit": "total_t",
       "max_session": 2,
       "max_trial": 95,
@@ -744,7 +744,6 @@
       "name": "LunarLander-v2",
       "max_t": null,
       "max_tick": 400000,
-      "save_frequency": 20000,
     }],
     "body": {
       "product": "outer",
@@ -752,6 +751,7 @@
     },
     "meta": {
       "distributed": false,
+      "eval_frequency": 1000,
       "max_tick_unit": "total_t",
       "max_session": 2,
       "max_trial": 95,
@@ -836,7 +836,6 @@
       "name": "LunarLander-v2",
       "max_t": null,
       "max_tick": 400000,
-      "save_frequency": 20000,
     }],
     "body": {
       "product": "outer",
@@ -844,6 +843,7 @@
     },
     "meta": {
       "distributed": false,
+      "eval_frequency": 1000,
       "max_tick_unit": "total_t",
       "max_session": 2,
       "max_trial": 95,
@@ -930,7 +930,6 @@
       "name": "LunarLander-v2",
       "max_t": null,
       "max_tick": 400000,
-      "save_frequency": 20000,
     }],
     "body": {
       "product": "outer",
@@ -938,6 +937,7 @@
     },
     "meta": {
       "distributed": false,
+      "eval_frequency": 1000,
       "max_tick_unit": "total_t",
       "max_session": 2,
       "max_trial": 95,
@@ -1028,7 +1028,6 @@
       "name": "LunarLander-v2",
       "max_t": null,
       "max_tick": 400000,
-      "save_frequency": 20000,
     }],
     "body": {
       "product": "outer",
@@ -1036,6 +1035,7 @@
     },
     "meta": {
       "distributed": false,
+      "eval_frequency": 1000,
       "max_tick_unit": "total_t",
       "max_session": 2,
       "max_trial": 95,
@@ -1117,7 +1117,6 @@
       "name": "LunarLander-v2",
       "max_t": null,
       "max_tick": 400000,
-      "save_frequency": 20000,
     }],
     "body": {
       "product": "outer",
@@ -1125,6 +1124,7 @@
     },
     "meta": {
       "distributed": false,
+      "eval_frequency": 1000,
       "max_tick_unit": "total_t",
       "max_session": 2,
       "max_trial": 95,
@@ -1211,7 +1211,6 @@
       "name": "LunarLander-v2",
       "max_t": null,
       "max_tick": 400000,
-      "save_frequency": 20000,
     }],
     "body": {
       "product": "outer",
@@ -1219,6 +1218,7 @@
     },
     "meta": {
       "distributed": false,
+      "eval_frequency": 1000,
       "max_tick_unit": "total_t",
       "max_session": 2,
       "max_trial": 95,
@@ -1309,7 +1309,6 @@
       "name": "LunarLander-v2",
       "max_t": null,
       "max_tick": 400000,
-      "save_frequency": 20000,
     }],
     "body": {
       "product": "outer",
@@ -1317,6 +1316,7 @@
     },
     "meta": {
       "distributed": false,
+      "eval_frequency": 1000,
       "max_tick_unit": "total_t",
       "max_session": 2,
       "max_trial": 95,
@@ -1403,7 +1403,6 @@
       "name": "LunarLander-v2",
       "max_t": null,
       "max_tick": 400000,
-      "save_frequency": 20000,
     }],
     "body": {
       "product": "outer",
@@ -1411,6 +1410,7 @@
     },
     "meta": {
       "distributed": false,
+      "eval_frequency": 1000,
       "max_tick_unit": "total_t",
       "max_session": 2,
       "max_trial": 95,
@@ -1500,7 +1500,6 @@
       "name": "LunarLander-v2",
       "max_t": null,
       "max_tick": 400000,
-      "save_frequency": 20000,
     }],
     "body": {
       "product": "outer",
@@ -1508,6 +1507,7 @@
     },
     "meta": {
       "distributed": false,
+      "eval_frequency": 1000,
       "max_tick_unit": "total_t",
       "max_session": 2,
       "max_trial": 95,
@@ -1596,7 +1596,6 @@
       "name": "LunarLander-v2",
       "max_t": null,
       "max_tick": 400000,
-      "save_frequency": 20000,
     }],
     "body": {
       "product": "outer",
@@ -1604,6 +1603,7 @@
     },
     "meta": {
       "distributed": false,
+      "eval_frequency": 1000,
       "max_tick_unit": "total_t",
       "max_session": 2,
       "max_trial": 95,
@@ -1692,7 +1692,6 @@
       "name": "LunarLander-v2",
       "max_t": null,
       "max_tick": 400000,
-      "save_frequency": 20000,
     }],
     "body": {
       "product": "outer",
@@ -1700,6 +1699,7 @@
     },
     "meta": {
       "distributed": false,
+      "eval_frequency": 1000,
       "max_tick_unit": "total_t",
       "max_session": 2,
       "max_trial": 95,
@@ -1795,7 +1795,6 @@
       "name": "LunarLander-v2",
       "max_t": null,
       "max_tick": 400000,
-      "save_frequency": 20000,
     }],
     "body": {
       "product": "outer",
@@ -1803,6 +1802,7 @@
     },
     "meta": {
       "distributed": false,
+      "eval_frequency": 1000,
       "max_tick_unit": "total_t",
       "max_session": 2,
       "max_trial": 95,
@@ -1896,7 +1896,6 @@
       "name": "LunarLander-v2",
       "max_t": null,
       "max_tick": 400000,
-      "save_frequency": 20000,
     }],
     "body": {
       "product": "outer",
@@ -1904,6 +1903,7 @@
     },
     "meta": {
       "distributed": false,
+      "eval_frequency": 1000,
       "max_tick_unit": "total_t",
       "max_session": 2,
       "max_trial": 95,
@@ -1997,7 +1997,6 @@
       "name": "LunarLander-v2",
       "max_t": null,
       "max_tick": 400000,
-      "save_frequency": 20000,
     }],
     "body": {
       "product": "outer",
@@ -2005,6 +2004,7 @@
     },
     "meta": {
       "distributed": false,
+      "eval_frequency": 1000,
       "max_tick_unit": "total_t",
       "max_session": 2,
       "max_trial": 95,
@@ -2095,7 +2095,6 @@
       "name": "LunarLander-v2",
       "max_t": null,
       "max_tick": 400000,
-      "save_frequency": 20000,
     }],
     "body": {
       "product": "outer",
@@ -2103,6 +2102,7 @@
     },
     "meta": {
       "distributed": false,
+      "eval_frequency": 1000,
       "max_tick_unit": "total_t",
       "max_session": 2,
       "max_trial": 95,
@@ -2204,7 +2204,6 @@
       "name": "LunarLander-v2",
       "max_t": null,
       "max_tick": 400000,
-      "save_frequency": 20000,
     }],
     "body": {
       "product": "outer",
@@ -2212,6 +2211,7 @@
     },
     "meta": {
       "distributed": false,
+      "eval_frequency": 1000,
       "max_tick_unit": "total_t",
       "max_session": 2,
       "max_trial": 95,
@@ -2311,7 +2311,6 @@
       "name": "LunarLander-v2",
       "max_t": null,
       "max_tick": 400000,
-      "save_frequency": 20000,
     }],
     "body": {
       "product": "outer",
@@ -2319,6 +2318,7 @@
     },
     "meta": {
       "distributed": false,
+      "eval_frequency": 1000,
       "max_tick_unit": "total_t",
       "max_session": 2,
       "max_trial": 95,

--- a/slm_lab/spec/experimental/mountain_car.json
+++ b/slm_lab/spec/experimental/mountain_car.json
@@ -52,7 +52,6 @@
     "env": [{
       "name": "MountainCar-v0",
       "max_t": null,
-      "max_tick_unit": "epi",
       "max_tick": 2600,
       "save_frequency": 3000
     }],
@@ -62,6 +61,7 @@
     },
     "meta": {
       "distributed": false,
+      "max_tick_unit": "epi",
       "max_session": 4,
       "max_trial": 200,
       "search": "RandomSearch",
@@ -153,7 +153,6 @@
     "env": [{
       "name": "MountainCar-v0",
       "max_t": null,
-      "max_tick_unit": "epi",
       "max_tick": 2600,
       "save_frequency": 3000
     }],
@@ -163,6 +162,7 @@
     },
     "meta": {
       "distributed": false,
+      "max_tick_unit": "epi",
       "max_session": 4,
       "max_trial": 200,
       "search": "RandomSearch",
@@ -248,7 +248,6 @@
     "env": [{
       "name": "MountainCar-v0",
       "max_t": null,
-      "max_tick_unit": "epi",
       "max_tick": 2600,
       "save_frequency": 3000
     }],
@@ -258,6 +257,7 @@
     },
     "meta": {
       "distributed": false,
+      "max_tick_unit": "epi",
       "max_session": 4,
       "max_trial": 200,
       "search": "RandomSearch",
@@ -345,7 +345,6 @@
     "env": [{
       "name": "MountainCar-v0",
       "max_t": null,
-      "max_tick_unit": "epi",
       "max_tick": 2600,
       "save_frequency": 3000
     }],
@@ -355,6 +354,7 @@
     },
     "meta": {
       "distributed": false,
+      "max_tick_unit": "epi",
       "max_session": 4,
       "max_trial": 200,
       "search": "RandomSearch",
@@ -442,7 +442,6 @@
     "env": [{
       "name": "MountainCar-v0",
       "max_t": null,
-      "max_tick_unit": "epi",
       "max_tick": 1400,
       "save_frequency": 1600
     }],
@@ -452,6 +451,7 @@
     },
     "meta": {
       "distributed": false,
+      "max_tick_unit": "epi",
       "max_session": 4,
       "max_trial": 200,
       "search": "RandomSearch",
@@ -538,7 +538,6 @@
     "env": [{
       "name": "MountainCar-v0",
       "max_t": null,
-      "max_tick_unit": "epi",
       "max_tick": 1400,
       "save_frequency": 1600
     }],
@@ -548,6 +547,7 @@
     },
     "meta": {
       "distributed": false,
+      "max_tick_unit": "epi",
       "max_session": 4,
       "max_trial": 200,
       "search": "RandomSearch",
@@ -633,7 +633,6 @@
     "env": [{
       "name": "MountainCar-v0",
       "max_t": null,
-      "max_tick_unit": "epi",
       "max_tick": 1400,
       "save_frequency": 1600
     }],
@@ -643,6 +642,7 @@
     },
     "meta": {
       "distributed": false,
+      "max_tick_unit": "epi",
       "max_session": 4,
       "max_trial": 200,
       "search": "RandomSearch",
@@ -729,7 +729,6 @@
     "env": [{
       "name": "MountainCar-v0",
       "max_t": null,
-      "max_tick_unit": "epi",
       "max_tick": 1400,
       "save_frequency": 1600
     }],
@@ -739,6 +738,7 @@
     },
     "meta": {
       "distributed": false,
+      "max_tick_unit": "epi",
       "max_session": 4,
       "max_trial": 200,
       "search": "RandomSearch",

--- a/slm_lab/spec/experimental/mountain_car.json
+++ b/slm_lab/spec/experimental/mountain_car.json
@@ -53,7 +53,6 @@
       "name": "MountainCar-v0",
       "max_t": null,
       "max_tick": 2600,
-      "save_frequency": 3000
     }],
     "body": {
       "product": "outer",
@@ -61,6 +60,7 @@
     },
     "meta": {
       "distributed": false,
+      "eval_frequency": 1000,
       "max_tick_unit": "epi",
       "max_session": 4,
       "max_trial": 200,
@@ -154,7 +154,6 @@
       "name": "MountainCar-v0",
       "max_t": null,
       "max_tick": 2600,
-      "save_frequency": 3000
     }],
     "body": {
       "product": "outer",
@@ -162,6 +161,7 @@
     },
     "meta": {
       "distributed": false,
+      "eval_frequency": 1000,
       "max_tick_unit": "epi",
       "max_session": 4,
       "max_trial": 200,
@@ -249,7 +249,6 @@
       "name": "MountainCar-v0",
       "max_t": null,
       "max_tick": 2600,
-      "save_frequency": 3000
     }],
     "body": {
       "product": "outer",
@@ -257,6 +256,7 @@
     },
     "meta": {
       "distributed": false,
+      "eval_frequency": 1000,
       "max_tick_unit": "epi",
       "max_session": 4,
       "max_trial": 200,
@@ -346,7 +346,6 @@
       "name": "MountainCar-v0",
       "max_t": null,
       "max_tick": 2600,
-      "save_frequency": 3000
     }],
     "body": {
       "product": "outer",
@@ -354,6 +353,7 @@
     },
     "meta": {
       "distributed": false,
+      "eval_frequency": 1000,
       "max_tick_unit": "epi",
       "max_session": 4,
       "max_trial": 200,
@@ -443,7 +443,6 @@
       "name": "MountainCar-v0",
       "max_t": null,
       "max_tick": 1400,
-      "save_frequency": 1600
     }],
     "body": {
       "product": "outer",
@@ -451,6 +450,7 @@
     },
     "meta": {
       "distributed": false,
+      "eval_frequency": 1000,
       "max_tick_unit": "epi",
       "max_session": 4,
       "max_trial": 200,
@@ -539,7 +539,6 @@
       "name": "MountainCar-v0",
       "max_t": null,
       "max_tick": 1400,
-      "save_frequency": 1600
     }],
     "body": {
       "product": "outer",
@@ -547,6 +546,7 @@
     },
     "meta": {
       "distributed": false,
+      "eval_frequency": 1000,
       "max_tick_unit": "epi",
       "max_session": 4,
       "max_trial": 200,
@@ -634,7 +634,6 @@
       "name": "MountainCar-v0",
       "max_t": null,
       "max_tick": 1400,
-      "save_frequency": 1600
     }],
     "body": {
       "product": "outer",
@@ -642,6 +641,7 @@
     },
     "meta": {
       "distributed": false,
+      "eval_frequency": 1000,
       "max_tick_unit": "epi",
       "max_session": 4,
       "max_trial": 200,
@@ -730,7 +730,6 @@
       "name": "MountainCar-v0",
       "max_t": null,
       "max_tick": 1400,
-      "save_frequency": 1600
     }],
     "body": {
       "product": "outer",
@@ -738,6 +737,7 @@
     },
     "meta": {
       "distributed": false,
+      "eval_frequency": 1000,
       "max_tick_unit": "epi",
       "max_session": 4,
       "max_trial": 200,

--- a/slm_lab/spec/experimental/pendulum.json
+++ b/slm_lab/spec/experimental/pendulum.json
@@ -52,7 +52,6 @@
     "env": [{
       "name": "Pendulum-v0",
       "max_t": null,
-      "max_tick_unit": "total_t",
       "max_tick": 500000,
       "save_frequency": 20000,
     }],
@@ -62,6 +61,7 @@
     },
     "meta": {
       "distributed": false,
+      "max_tick_unit": "total_t",
       "max_session": 4,
       "max_trial": 190,
       "search": "RandomSearch",
@@ -149,7 +149,6 @@
     "env": [{
       "name": "Pendulum-v0",
       "max_t": null,
-      "max_tick_unit": "total_t",
       "max_tick": 500000,
       "save_frequency": 20000,
     }],
@@ -159,6 +158,7 @@
     },
     "meta": {
       "distributed": false,
+      "max_tick_unit": "total_t",
       "max_session": 4,
       "max_trial": 190,
       "search": "RandomSearch",
@@ -243,7 +243,6 @@
     "env": [{
       "name": "Pendulum-v0",
       "max_t": null,
-      "max_tick_unit": "total_t",
       "max_tick": 500000,
       "save_frequency": 20000,
     }],
@@ -253,6 +252,7 @@
     },
     "meta": {
       "distributed": false,
+      "max_tick_unit": "total_t",
       "max_session": 4,
       "max_trial": 190,
       "search": "RandomSearch",
@@ -340,7 +340,6 @@
     "env": [{
       "name": "Pendulum-v0",
       "max_t": null,
-      "max_tick_unit": "total_t",
       "max_tick": 500000,
       "save_frequency": 20000,
     }],
@@ -350,6 +349,7 @@
     },
     "meta": {
       "distributed": false,
+      "max_tick_unit": "total_t",
       "max_session": 4,
       "max_trial": 190,
       "search": "RandomSearch",
@@ -441,7 +441,6 @@
     "env": [{
       "name": "Pendulum-v0",
       "max_t": null,
-      "max_tick_unit": "total_t",
       "max_tick": 500000,
       "save_frequency": 25000,
     }],
@@ -451,6 +450,7 @@
     },
     "meta": {
       "distributed": false,
+      "max_tick_unit": "total_t",
       "max_session": 4,
       "max_trial": 190,
       "search": "RandomSearch",

--- a/slm_lab/spec/experimental/pendulum.json
+++ b/slm_lab/spec/experimental/pendulum.json
@@ -53,7 +53,6 @@
       "name": "Pendulum-v0",
       "max_t": null,
       "max_tick": 500000,
-      "save_frequency": 20000,
     }],
     "body": {
       "product": "outer",
@@ -61,6 +60,7 @@
     },
     "meta": {
       "distributed": false,
+      "eval_frequency": 1000,
       "max_tick_unit": "total_t",
       "max_session": 4,
       "max_trial": 190,
@@ -150,7 +150,6 @@
       "name": "Pendulum-v0",
       "max_t": null,
       "max_tick": 500000,
-      "save_frequency": 20000,
     }],
     "body": {
       "product": "outer",
@@ -158,6 +157,7 @@
     },
     "meta": {
       "distributed": false,
+      "eval_frequency": 1000,
       "max_tick_unit": "total_t",
       "max_session": 4,
       "max_trial": 190,
@@ -244,7 +244,6 @@
       "name": "Pendulum-v0",
       "max_t": null,
       "max_tick": 500000,
-      "save_frequency": 20000,
     }],
     "body": {
       "product": "outer",
@@ -252,6 +251,7 @@
     },
     "meta": {
       "distributed": false,
+      "eval_frequency": 1000,
       "max_tick_unit": "total_t",
       "max_session": 4,
       "max_trial": 190,
@@ -341,7 +341,6 @@
       "name": "Pendulum-v0",
       "max_t": null,
       "max_tick": 500000,
-      "save_frequency": 20000,
     }],
     "body": {
       "product": "outer",
@@ -349,6 +348,7 @@
     },
     "meta": {
       "distributed": false,
+      "eval_frequency": 1000,
       "max_tick_unit": "total_t",
       "max_session": 4,
       "max_trial": 190,
@@ -442,7 +442,6 @@
       "name": "Pendulum-v0",
       "max_t": null,
       "max_tick": 500000,
-      "save_frequency": 25000,
     }],
     "body": {
       "product": "outer",
@@ -450,6 +449,7 @@
     },
     "meta": {
       "distributed": false,
+      "eval_frequency": 1000,
       "max_tick_unit": "total_t",
       "max_session": 4,
       "max_trial": 190,

--- a/slm_lab/spec/experimental/ppo.json
+++ b/slm_lab/spec/experimental/ppo.json
@@ -58,7 +58,6 @@
       "name": "CartPole-v0",
       "max_t": null,
       "max_tick": 500,
-      "save_frequency": 1000
     }],
     "body": {
       "product": "outer",
@@ -66,6 +65,7 @@
     },
     "meta": {
       "distributed": false,
+      "eval_frequency": 1000,
       "max_tick_unit": "epi",
       "max_session": 4,
       "max_trial": 100,
@@ -150,7 +150,6 @@
       "name": "CartPole-v0",
       "max_t": null,
       "max_tick": 500,
-      "save_frequency": 1000
     }],
     "body": {
       "product": "outer",
@@ -158,6 +157,7 @@
     },
     "meta": {
       "distributed": false,
+      "eval_frequency": 1000,
       "max_tick_unit": "epi",
       "max_session": 1,
       "max_trial": 100,
@@ -246,7 +246,6 @@
       "name": "CartPole-v0",
       "max_t": null,
       "max_tick": 500,
-      "save_frequency": 1000
     }],
     "body": {
       "product": "outer",
@@ -254,6 +253,7 @@
     },
     "meta": {
       "distributed": false,
+      "eval_frequency": 1000,
       "max_tick_unit": "epi",
       "max_session": 4,
       "max_trial": 100,
@@ -342,7 +342,6 @@
       "name": "CartPole-v0",
       "max_t": null,
       "max_tick": 500,
-      "save_frequency": 1000
     }],
     "body": {
       "product": "outer",
@@ -350,6 +349,7 @@
     },
     "meta": {
       "distributed": false,
+      "eval_frequency": 1000,
       "max_tick_unit": "epi",
       "max_session": 4,
       "max_trial": 100,
@@ -434,7 +434,6 @@
       "name": "Pendulum-v0",
       "max_t": null,
       "max_tick": 500,
-      "save_frequency": 1000
     }],
     "body": {
       "product": "outer",
@@ -442,6 +441,7 @@
     },
     "meta": {
       "distributed": false,
+      "eval_frequency": 1000,
       "max_tick_unit": "epi",
       "max_session": 4,
       "max_trial": 100,
@@ -526,7 +526,6 @@
       "name": "Pendulum-v0",
       "max_t": null,
       "max_tick": 500,
-      "save_frequency": 1000
     }],
     "body": {
       "product": "outer",
@@ -534,6 +533,7 @@
     },
     "meta": {
       "distributed": false,
+      "eval_frequency": 1000,
       "max_tick_unit": "epi",
       "max_session": 4,
       "max_trial": 100,
@@ -622,7 +622,6 @@
       "name": "Pendulum-v0",
       "max_t": null,
       "max_tick": 500,
-      "save_frequency": 1000
     }],
     "body": {
       "product": "outer",
@@ -630,6 +629,7 @@
     },
     "meta": {
       "distributed": false,
+      "eval_frequency": 1000,
       "max_tick_unit": "epi",
       "max_session": 4,
       "max_trial": 100,
@@ -718,7 +718,6 @@
       "name": "Pendulum-v0",
       "max_t": null,
       "max_tick": 500,
-      "save_frequency": 1000
     }],
     "body": {
       "product": "outer",
@@ -726,6 +725,7 @@
     },
     "meta": {
       "distributed": false,
+      "eval_frequency": 1000,
       "max_tick_unit": "epi",
       "max_session": 4,
       "max_trial": 100,
@@ -822,6 +822,7 @@
     },
     "meta": {
       "distributed": false,
+      "eval_frequency": 1000,
       "max_tick_unit": "epi",
       "max_session": 1,
       "max_trial": 1,
@@ -899,6 +900,7 @@
     },
     "meta": {
       "distributed": false,
+      "eval_frequency": 1000,
       "max_tick_unit": "epi",
       "max_session": 1,
       "max_trial": 1,
@@ -977,6 +979,7 @@
     },
     "meta": {
       "distributed": false,
+      "eval_frequency": 1000,
       "max_tick_unit": "epi",
       "max_session": 1,
       "max_trial": 1,

--- a/slm_lab/spec/experimental/ppo.json
+++ b/slm_lab/spec/experimental/ppo.json
@@ -57,7 +57,6 @@
     "env": [{
       "name": "CartPole-v0",
       "max_t": null,
-      "max_tick_unit": "epi",
       "max_tick": 500,
       "save_frequency": 1000
     }],
@@ -67,6 +66,7 @@
     },
     "meta": {
       "distributed": false,
+      "max_tick_unit": "epi",
       "max_session": 4,
       "max_trial": 100,
       "search": "RandomSearch"
@@ -149,7 +149,6 @@
     "env": [{
       "name": "CartPole-v0",
       "max_t": null,
-      "max_tick_unit": "epi",
       "max_tick": 500,
       "save_frequency": 1000
     }],
@@ -159,6 +158,7 @@
     },
     "meta": {
       "distributed": false,
+      "max_tick_unit": "epi",
       "max_session": 1,
       "max_trial": 100,
       "search": "RandomSearch"
@@ -245,7 +245,6 @@
     "env": [{
       "name": "CartPole-v0",
       "max_t": null,
-      "max_tick_unit": "epi",
       "max_tick": 500,
       "save_frequency": 1000
     }],
@@ -255,6 +254,7 @@
     },
     "meta": {
       "distributed": false,
+      "max_tick_unit": "epi",
       "max_session": 4,
       "max_trial": 100,
       "search": "RandomSearch"
@@ -341,7 +341,6 @@
     "env": [{
       "name": "CartPole-v0",
       "max_t": null,
-      "max_tick_unit": "epi",
       "max_tick": 500,
       "save_frequency": 1000
     }],
@@ -351,6 +350,7 @@
     },
     "meta": {
       "distributed": false,
+      "max_tick_unit": "epi",
       "max_session": 4,
       "max_trial": 100,
       "search": "RandomSearch"
@@ -433,7 +433,6 @@
     "env": [{
       "name": "Pendulum-v0",
       "max_t": null,
-      "max_tick_unit": "epi",
       "max_tick": 500,
       "save_frequency": 1000
     }],
@@ -443,6 +442,7 @@
     },
     "meta": {
       "distributed": false,
+      "max_tick_unit": "epi",
       "max_session": 4,
       "max_trial": 100,
       "search": "RandomSearch"
@@ -525,7 +525,6 @@
     "env": [{
       "name": "Pendulum-v0",
       "max_t": null,
-      "max_tick_unit": "epi",
       "max_tick": 500,
       "save_frequency": 1000
     }],
@@ -535,6 +534,7 @@
     },
     "meta": {
       "distributed": false,
+      "max_tick_unit": "epi",
       "max_session": 4,
       "max_trial": 100,
       "search": "RandomSearch"
@@ -621,7 +621,6 @@
     "env": [{
       "name": "Pendulum-v0",
       "max_t": null,
-      "max_tick_unit": "epi",
       "max_tick": 500,
       "save_frequency": 1000
     }],
@@ -631,6 +630,7 @@
     },
     "meta": {
       "distributed": false,
+      "max_tick_unit": "epi",
       "max_session": 4,
       "max_trial": 100,
       "search": "RandomSearch"
@@ -717,7 +717,6 @@
     "env": [{
       "name": "Pendulum-v0",
       "max_t": null,
-      "max_tick_unit": "epi",
       "max_tick": 500,
       "save_frequency": 1000
     }],
@@ -727,6 +726,7 @@
     },
     "meta": {
       "distributed": false,
+      "max_tick_unit": "epi",
       "max_session": 4,
       "max_trial": 100,
       "search": "RandomSearch"
@@ -814,7 +814,6 @@
     "env": [{
       "name": "Breakout-v0",
       "max_t": null,
-      "max_tick_unit": "epi",
       "max_tick": 1
     }],
     "body": {
@@ -823,6 +822,7 @@
     },
     "meta": {
       "distributed": false,
+      "max_tick_unit": "epi",
       "max_session": 1,
       "max_trial": 1,
       "search": "RandomSearch"
@@ -891,7 +891,6 @@
     "env": [{
       "name": "Breakout-v0",
       "max_t": null,
-      "max_tick_unit": "epi",
       "max_tick": 1
     }],
     "body": {
@@ -900,6 +899,7 @@
     },
     "meta": {
       "distributed": false,
+      "max_tick_unit": "epi",
       "max_session": 1,
       "max_trial": 1,
       "search": "RandomSearch"
@@ -969,7 +969,6 @@
       "name": "vizdoom-v0",
       "cfg_name": "take_cover",
       "max_t": null,
-      "max_tick_unit": "epi",
       "max_tick": 100
     }],
     "body": {
@@ -978,6 +977,7 @@
     },
     "meta": {
       "distributed": false,
+      "max_tick_unit": "epi",
       "max_session": 1,
       "max_trial": 1,
       "search": "RandomSearch"

--- a/slm_lab/spec/experimental/ppo_sil.json
+++ b/slm_lab/spec/experimental/ppo_sil.json
@@ -65,7 +65,6 @@
       "name": "CartPole-v0",
       "max_t": null,
       "max_tick": 500,
-      "save_frequency": 1000
     }],
     "body": {
       "product": "outer",
@@ -73,6 +72,7 @@
     },
     "meta": {
       "distributed": false,
+      "eval_frequency": 1000,
       "max_tick_unit": "epi",
       "max_session": 4,
       "max_trial": 100,
@@ -166,7 +166,6 @@
       "name": "CartPole-v0",
       "max_t": null,
       "max_tick": 400,
-      "save_frequency": 300
     }],
     "body": {
       "product": "outer",
@@ -174,6 +173,7 @@
     },
     "meta": {
       "distributed": false,
+      "eval_frequency": 1000,
       "max_tick_unit": "epi",
       "max_session": 4,
       "max_trial": 100,
@@ -271,7 +271,6 @@
       "name": "CartPole-v0",
       "max_t": null,
       "max_tick": 500,
-      "save_frequency": 1000
     }],
     "body": {
       "product": "outer",
@@ -279,6 +278,7 @@
     },
     "meta": {
       "distributed": false,
+      "eval_frequency": 1000,
       "max_tick_unit": "epi",
       "max_session": 4,
       "max_trial": 100,
@@ -376,7 +376,6 @@
       "name": "CartPole-v0",
       "max_t": null,
       "max_tick": 500,
-      "save_frequency": 1000
     }],
     "body": {
       "product": "outer",
@@ -384,6 +383,7 @@
     },
     "meta": {
       "distributed": false,
+      "eval_frequency": 1000,
       "max_tick_unit": "epi",
       "max_session": 4,
       "max_trial": 100,
@@ -477,7 +477,6 @@
       "name": "Pendulum-v0",
       "max_t": null,
       "max_tick": 500,
-      "save_frequency": 1000
     }],
     "body": {
       "product": "outer",
@@ -485,6 +484,7 @@
     },
     "meta": {
       "distributed": false,
+      "eval_frequency": 1000,
       "max_tick_unit": "epi",
       "max_session": 4,
       "max_trial": 100,
@@ -578,7 +578,6 @@
       "name": "Pendulum-v0",
       "max_t": null,
       "max_tick": 500,
-      "save_frequency": 1000
     }],
     "body": {
       "product": "outer",
@@ -586,6 +585,7 @@
     },
     "meta": {
       "distributed": false,
+      "eval_frequency": 1000,
       "max_tick_unit": "epi",
       "max_session": 4,
       "max_trial": 100,
@@ -683,7 +683,6 @@
       "name": "Pendulum-v0",
       "max_t": null,
       "max_tick": 500,
-      "save_frequency": 1000
     }],
     "body": {
       "product": "outer",
@@ -691,6 +690,7 @@
     },
     "meta": {
       "distributed": false,
+      "eval_frequency": 1000,
       "max_tick_unit": "epi",
       "max_session": 4,
       "max_trial": 100,
@@ -788,7 +788,6 @@
       "name": "Pendulum-v0",
       "max_t": null,
       "max_tick": 500,
-      "save_frequency": 1000
     }],
     "body": {
       "product": "outer",
@@ -796,6 +795,7 @@
     },
     "meta": {
       "distributed": false,
+      "eval_frequency": 1000,
       "max_tick_unit": "epi",
       "max_session": 4,
       "max_trial": 100,

--- a/slm_lab/spec/experimental/ppo_sil.json
+++ b/slm_lab/spec/experimental/ppo_sil.json
@@ -64,7 +64,6 @@
     "env": [{
       "name": "CartPole-v0",
       "max_t": null,
-      "max_tick_unit": "epi",
       "max_tick": 500,
       "save_frequency": 1000
     }],
@@ -74,6 +73,7 @@
     },
     "meta": {
       "distributed": false,
+      "max_tick_unit": "epi",
       "max_session": 4,
       "max_trial": 100,
       "search": "RandomSearch"
@@ -165,7 +165,6 @@
     "env": [{
       "name": "CartPole-v0",
       "max_t": null,
-      "max_tick_unit": "epi",
       "max_tick": 400,
       "save_frequency": 300
     }],
@@ -175,6 +174,7 @@
     },
     "meta": {
       "distributed": false,
+      "max_tick_unit": "epi",
       "max_session": 4,
       "max_trial": 100,
       "search": "RandomSearch"
@@ -270,7 +270,6 @@
     "env": [{
       "name": "CartPole-v0",
       "max_t": null,
-      "max_tick_unit": "epi",
       "max_tick": 500,
       "save_frequency": 1000
     }],
@@ -280,6 +279,7 @@
     },
     "meta": {
       "distributed": false,
+      "max_tick_unit": "epi",
       "max_session": 4,
       "max_trial": 100,
       "search": "RandomSearch"
@@ -375,7 +375,6 @@
     "env": [{
       "name": "CartPole-v0",
       "max_t": null,
-      "max_tick_unit": "epi",
       "max_tick": 500,
       "save_frequency": 1000
     }],
@@ -385,6 +384,7 @@
     },
     "meta": {
       "distributed": false,
+      "max_tick_unit": "epi",
       "max_session": 4,
       "max_trial": 100,
       "search": "RandomSearch"
@@ -476,7 +476,6 @@
     "env": [{
       "name": "Pendulum-v0",
       "max_t": null,
-      "max_tick_unit": "epi",
       "max_tick": 500,
       "save_frequency": 1000
     }],
@@ -486,6 +485,7 @@
     },
     "meta": {
       "distributed": false,
+      "max_tick_unit": "epi",
       "max_session": 4,
       "max_trial": 100,
       "search": "RandomSearch"
@@ -577,7 +577,6 @@
     "env": [{
       "name": "Pendulum-v0",
       "max_t": null,
-      "max_tick_unit": "epi",
       "max_tick": 500,
       "save_frequency": 1000
     }],
@@ -587,6 +586,7 @@
     },
     "meta": {
       "distributed": false,
+      "max_tick_unit": "epi",
       "max_session": 4,
       "max_trial": 100,
       "search": "RandomSearch"
@@ -682,7 +682,6 @@
     "env": [{
       "name": "Pendulum-v0",
       "max_t": null,
-      "max_tick_unit": "epi",
       "max_tick": 500,
       "save_frequency": 1000
     }],
@@ -692,6 +691,7 @@
     },
     "meta": {
       "distributed": false,
+      "max_tick_unit": "epi",
       "max_session": 4,
       "max_trial": 100,
       "search": "RandomSearch"
@@ -787,7 +787,6 @@
     "env": [{
       "name": "Pendulum-v0",
       "max_t": null,
-      "max_tick_unit": "epi",
       "max_tick": 500,
       "save_frequency": 1000
     }],
@@ -797,6 +796,7 @@
     },
     "meta": {
       "distributed": false,
+      "max_tick_unit": "epi",
       "max_session": 4,
       "max_trial": 100,
       "search": "RandomSearch"

--- a/slm_lab/spec/experimental/reinforce.json
+++ b/slm_lab/spec/experimental/reinforce.json
@@ -45,7 +45,6 @@
       "name": "CartPole-v0",
       "max_t": null,
       "max_tick": 400,
-      "save_frequency": 300
     }],
     "body": {
       "product": "outer",
@@ -53,6 +52,7 @@
     },
     "meta": {
       "distributed": false,
+      "eval_frequency": 1000,
       "max_tick_unit": "epi",
       "max_session": 4,
       "max_trial": 100,
@@ -122,7 +122,6 @@
       "name": "CartPole-v0",
       "max_t": null,
       "max_tick": 500,
-      "save_frequency": 1000
     }],
     "body": {
       "product": "outer",
@@ -130,6 +129,7 @@
     },
     "meta": {
       "distributed": false,
+      "eval_frequency": 1000,
       "max_tick_unit": "epi",
       "max_session": 4,
       "max_trial": 100,
@@ -195,7 +195,6 @@
       "name": "Pendulum-v0",
       "max_t": null,
       "max_tick": 500,
-      "save_frequency": 1000
     }],
     "body": {
       "product": "outer",
@@ -203,6 +202,7 @@
     },
     "meta": {
       "distributed": false,
+      "eval_frequency": 1000,
       "max_tick_unit": "epi",
       "max_session": 4,
       "max_trial": 100,
@@ -272,7 +272,6 @@
       "name": "Pendulum-v0",
       "max_t": null,
       "max_tick": 500,
-      "save_frequency": 1000
     }],
     "body": {
       "product": "outer",
@@ -280,6 +279,7 @@
     },
     "meta": {
       "distributed": false,
+      "eval_frequency": 1000,
       "max_tick_unit": "epi",
       "max_session": 4,
       "max_trial": 100,
@@ -358,6 +358,7 @@
     },
     "meta": {
       "distributed": false,
+      "eval_frequency": 1000,
       "max_tick_unit": "epi",
       "max_session": 1,
       "max_trial": 1,
@@ -426,6 +427,7 @@
     },
     "meta": {
       "distributed": false,
+      "eval_frequency": 1000,
       "max_tick_unit": "epi",
       "max_session": 1,
       "max_trial": 1,

--- a/slm_lab/spec/experimental/reinforce.json
+++ b/slm_lab/spec/experimental/reinforce.json
@@ -44,7 +44,6 @@
     "env": [{
       "name": "CartPole-v0",
       "max_t": null,
-      "max_tick_unit": "epi",
       "max_tick": 400,
       "save_frequency": 300
     }],
@@ -54,6 +53,7 @@
     },
     "meta": {
       "distributed": false,
+      "max_tick_unit": "epi",
       "max_session": 4,
       "max_trial": 100,
       "search": "RandomSearch"
@@ -121,7 +121,6 @@
     "env": [{
       "name": "CartPole-v0",
       "max_t": null,
-      "max_tick_unit": "epi",
       "max_tick": 500,
       "save_frequency": 1000
     }],
@@ -131,6 +130,7 @@
     },
     "meta": {
       "distributed": false,
+      "max_tick_unit": "epi",
       "max_session": 4,
       "max_trial": 100,
       "search": "RandomSearch"
@@ -194,7 +194,6 @@
     "env": [{
       "name": "Pendulum-v0",
       "max_t": null,
-      "max_tick_unit": "epi",
       "max_tick": 500,
       "save_frequency": 1000
     }],
@@ -204,6 +203,7 @@
     },
     "meta": {
       "distributed": false,
+      "max_tick_unit": "epi",
       "max_session": 4,
       "max_trial": 100,
       "search": "RandomSearch"
@@ -271,7 +271,6 @@
     "env": [{
       "name": "Pendulum-v0",
       "max_t": null,
-      "max_tick_unit": "epi",
       "max_tick": 500,
       "save_frequency": 1000
     }],
@@ -281,6 +280,7 @@
     },
     "meta": {
       "distributed": false,
+      "max_tick_unit": "epi",
       "max_session": 4,
       "max_trial": 100,
       "search": "RandomSearch"
@@ -350,7 +350,6 @@
     "env": [{
       "name": "Breakout-v0",
       "max_t": null,
-      "max_tick_unit": "epi",
       "max_tick": 1
     }],
     "body": {
@@ -359,6 +358,7 @@
     },
     "meta": {
       "distributed": false,
+      "max_tick_unit": "epi",
       "max_session": 1,
       "max_trial": 1,
       "search": "RandomSearch"
@@ -418,7 +418,6 @@
       "name": "vizdoom-v0",
       "cfg_name": "basic",
       "max_t": null,
-      "max_tick_unit": "epi",
       "max_tick": 100
     }],
     "body": {
@@ -427,6 +426,7 @@
     },
     "meta": {
       "distributed": false,
+      "max_tick_unit": "epi",
       "max_session": 1,
       "max_trial": 1,
       "search": "RandomSearch"

--- a/slm_lab/spec/experimental/sarsa.json
+++ b/slm_lab/spec/experimental/sarsa.json
@@ -44,7 +44,6 @@
       "name": "CartPole-v0",
       "max_t": null,
       "max_tick": 250,
-      "save_frequency": 1000
     }],
     "body": {
       "product": "outer",
@@ -52,6 +51,7 @@
     },
     "meta": {
       "distributed": false,
+      "eval_frequency": 1000,
       "max_tick_unit": "epi",
       "max_session": 4,
       "max_trial": 100,
@@ -124,7 +124,6 @@
       "name": "CartPole-v0",
       "max_t": null,
       "max_tick": 250,
-      "save_frequency": 1000
     }],
     "body": {
       "product": "outer",
@@ -132,6 +131,7 @@
     },
     "meta": {
       "distributed": false,
+      "eval_frequency": 1000,
       "max_tick_unit": "epi",
       "max_session": 4,
       "max_trial": 100,
@@ -208,7 +208,6 @@
       "name": "CartPole-v0",
       "max_t": null,
       "max_tick": 250,
-      "save_frequency": 1000
     }],
     "body": {
       "product": "outer",
@@ -216,6 +215,7 @@
     },
     "meta": {
       "distributed": false,
+      "eval_frequency": 1000,
       "max_tick_unit": "epi",
       "max_session": 4,
       "max_trial": 100,
@@ -292,7 +292,6 @@
       "name": "CartPole-v0",
       "max_t": null,
       "max_tick": 250,
-      "save_frequency": 1000
     }],
     "body": {
       "product": "outer",
@@ -300,6 +299,7 @@
     },
     "meta": {
       "distributed": false,
+      "eval_frequency": 1000,
       "max_tick_unit": "epi",
       "max_session": 4,
       "max_trial": 100,
@@ -385,6 +385,7 @@
     },
     "meta": {
       "distributed": false,
+      "eval_frequency": 1000,
       "max_tick_unit": "epi",
       "max_session": 1,
       "max_trial": 1,
@@ -449,6 +450,7 @@
     },
     "meta": {
       "distributed": false,
+      "eval_frequency": 1000,
       "max_tick_unit": "epi",
       "max_session": 1,
       "max_trial": 1,

--- a/slm_lab/spec/experimental/sarsa.json
+++ b/slm_lab/spec/experimental/sarsa.json
@@ -43,7 +43,6 @@
     "env": [{
       "name": "CartPole-v0",
       "max_t": null,
-      "max_tick_unit": "epi",
       "max_tick": 250,
       "save_frequency": 1000
     }],
@@ -53,6 +52,7 @@
     },
     "meta": {
       "distributed": false,
+      "max_tick_unit": "epi",
       "max_session": 4,
       "max_trial": 100,
       "search": "RandomSearch"
@@ -123,7 +123,6 @@
     "env": [{
       "name": "CartPole-v0",
       "max_t": null,
-      "max_tick_unit": "epi",
       "max_tick": 250,
       "save_frequency": 1000
     }],
@@ -133,6 +132,7 @@
     },
     "meta": {
       "distributed": false,
+      "max_tick_unit": "epi",
       "max_session": 4,
       "max_trial": 100,
       "search": "RandomSearch"
@@ -207,7 +207,6 @@
     "env": [{
       "name": "CartPole-v0",
       "max_t": null,
-      "max_tick_unit": "epi",
       "max_tick": 250,
       "save_frequency": 1000
     }],
@@ -217,6 +216,7 @@
     },
     "meta": {
       "distributed": false,
+      "max_tick_unit": "epi",
       "max_session": 4,
       "max_trial": 100,
       "search": "RandomSearch"
@@ -291,7 +291,6 @@
     "env": [{
       "name": "CartPole-v0",
       "max_t": null,
-      "max_tick_unit": "epi",
       "max_tick": 250,
       "save_frequency": 1000
     }],
@@ -301,6 +300,7 @@
     },
     "meta": {
       "distributed": false,
+      "max_tick_unit": "epi",
       "max_session": 4,
       "max_trial": 100,
       "search": "RandomSearch"
@@ -377,7 +377,6 @@
     "env": [{
       "name": "Breakout-v0",
       "max_t": null,
-      "max_tick_unit": "epi",
       "max_tick": 1
     }],
     "body": {
@@ -386,6 +385,7 @@
     },
     "meta": {
       "distributed": false,
+      "max_tick_unit": "epi",
       "max_session": 1,
       "max_trial": 1,
       "search": "RandomSearch"
@@ -441,7 +441,6 @@
     "env": [{
       "name": "Breakout-v0",
       "max_t": null,
-      "max_tick_unit": "epi",
       "max_tick": 1
     }],
     "body": {
@@ -450,6 +449,7 @@
     },
     "meta": {
       "distributed": false,
+      "max_tick_unit": "epi",
       "max_session": 1,
       "max_trial": 1,
       "search": "RandomSearch"

--- a/slm_lab/spec/experimental/sil.json
+++ b/slm_lab/spec/experimental/sil.json
@@ -60,7 +60,6 @@
       "name": "CartPole-v0",
       "max_t": null,
       "max_tick": 400,
-      "save_frequency": 300
     }],
     "body": {
       "product": "outer",
@@ -68,6 +67,7 @@
     },
     "meta": {
       "distributed": false,
+      "eval_frequency": 1000,
       "max_tick_unit": "epi",
       "max_session": 4,
       "max_trial": 100,
@@ -156,7 +156,6 @@
       "name": "CartPole-v0",
       "max_t": null,
       "max_tick": 500,
-      "save_frequency": 1000
     }],
     "body": {
       "product": "outer",
@@ -164,6 +163,7 @@
     },
     "meta": {
       "distributed": false,
+      "eval_frequency": 1000,
       "max_tick_unit": "epi",
       "max_session": 4,
       "max_trial": 100,
@@ -256,7 +256,6 @@
       "name": "CartPole-v0",
       "max_t": null,
       "max_tick": 500,
-      "save_frequency": 1000
     }],
     "body": {
       "product": "outer",
@@ -264,6 +263,7 @@
     },
     "meta": {
       "distributed": false,
+      "eval_frequency": 1000,
       "max_tick_unit": "epi",
       "max_session": 4,
       "max_trial": 100,
@@ -356,7 +356,6 @@
       "name": "CartPole-v0",
       "max_t": null,
       "max_tick": 500,
-      "save_frequency": 1000
     }],
     "body": {
       "product": "outer",
@@ -364,6 +363,7 @@
     },
     "meta": {
       "distributed": false,
+      "eval_frequency": 1000,
       "max_tick_unit": "epi",
       "max_session": 4,
       "max_trial": 100,
@@ -452,7 +452,6 @@
       "name": "Pendulum-v0",
       "max_t": null,
       "max_tick": 500,
-      "save_frequency": 1000
     }],
     "body": {
       "product": "outer",
@@ -460,6 +459,7 @@
     },
     "meta": {
       "distributed": false,
+      "eval_frequency": 1000,
       "max_tick_unit": "epi",
       "max_session": 4,
       "max_trial": 100,
@@ -548,7 +548,6 @@
       "name": "Pendulum-v0",
       "max_t": null,
       "max_tick": 500,
-      "save_frequency": 1000
     }],
     "body": {
       "product": "outer",
@@ -556,6 +555,7 @@
     },
     "meta": {
       "distributed": false,
+      "eval_frequency": 1000,
       "max_tick_unit": "epi",
       "max_session": 4,
       "max_trial": 100,
@@ -648,7 +648,6 @@
       "name": "Pendulum-v0",
       "max_t": null,
       "max_tick": 500,
-      "save_frequency": 1000
     }],
     "body": {
       "product": "outer",
@@ -656,6 +655,7 @@
     },
     "meta": {
       "distributed": false,
+      "eval_frequency": 1000,
       "max_tick_unit": "epi",
       "max_session": 4,
       "max_trial": 100,
@@ -748,7 +748,6 @@
       "name": "Pendulum-v0",
       "max_t": null,
       "max_tick": 500,
-      "save_frequency": 1000
     }],
     "body": {
       "product": "outer",
@@ -756,6 +755,7 @@
     },
     "meta": {
       "distributed": false,
+      "eval_frequency": 1000,
       "max_tick_unit": "epi",
       "max_session": 4,
       "max_trial": 100,
@@ -856,6 +856,7 @@
     },
     "meta": {
       "distributed": false,
+      "eval_frequency": 1000,
       "max_tick_unit": "epi",
       "max_session": 1,
       "max_trial": 1,
@@ -935,6 +936,7 @@
     },
     "meta": {
       "distributed": false,
+      "eval_frequency": 1000,
       "max_tick_unit": "epi",
       "max_session": 1,
       "max_trial": 1,

--- a/slm_lab/spec/experimental/sil.json
+++ b/slm_lab/spec/experimental/sil.json
@@ -59,7 +59,6 @@
     "env": [{
       "name": "CartPole-v0",
       "max_t": null,
-      "max_tick_unit": "epi",
       "max_tick": 400,
       "save_frequency": 300
     }],
@@ -69,6 +68,7 @@
     },
     "meta": {
       "distributed": false,
+      "max_tick_unit": "epi",
       "max_session": 4,
       "max_trial": 100,
       "search": "RandomSearch"
@@ -155,7 +155,6 @@
     "env": [{
       "name": "CartPole-v0",
       "max_t": null,
-      "max_tick_unit": "epi",
       "max_tick": 500,
       "save_frequency": 1000
     }],
@@ -165,6 +164,7 @@
     },
     "meta": {
       "distributed": false,
+      "max_tick_unit": "epi",
       "max_session": 4,
       "max_trial": 100,
       "search": "RandomSearch"
@@ -255,7 +255,6 @@
     "env": [{
       "name": "CartPole-v0",
       "max_t": null,
-      "max_tick_unit": "epi",
       "max_tick": 500,
       "save_frequency": 1000
     }],
@@ -265,6 +264,7 @@
     },
     "meta": {
       "distributed": false,
+      "max_tick_unit": "epi",
       "max_session": 4,
       "max_trial": 100,
       "search": "RandomSearch"
@@ -355,7 +355,6 @@
     "env": [{
       "name": "CartPole-v0",
       "max_t": null,
-      "max_tick_unit": "epi",
       "max_tick": 500,
       "save_frequency": 1000
     }],
@@ -365,6 +364,7 @@
     },
     "meta": {
       "distributed": false,
+      "max_tick_unit": "epi",
       "max_session": 4,
       "max_trial": 100,
       "search": "RandomSearch"
@@ -451,7 +451,6 @@
     "env": [{
       "name": "Pendulum-v0",
       "max_t": null,
-      "max_tick_unit": "epi",
       "max_tick": 500,
       "save_frequency": 1000
     }],
@@ -461,6 +460,7 @@
     },
     "meta": {
       "distributed": false,
+      "max_tick_unit": "epi",
       "max_session": 4,
       "max_trial": 100,
       "search": "RandomSearch"
@@ -547,7 +547,6 @@
     "env": [{
       "name": "Pendulum-v0",
       "max_t": null,
-      "max_tick_unit": "epi",
       "max_tick": 500,
       "save_frequency": 1000
     }],
@@ -557,6 +556,7 @@
     },
     "meta": {
       "distributed": false,
+      "max_tick_unit": "epi",
       "max_session": 4,
       "max_trial": 100,
       "search": "RandomSearch"
@@ -647,7 +647,6 @@
     "env": [{
       "name": "Pendulum-v0",
       "max_t": null,
-      "max_tick_unit": "epi",
       "max_tick": 500,
       "save_frequency": 1000
     }],
@@ -657,6 +656,7 @@
     },
     "meta": {
       "distributed": false,
+      "max_tick_unit": "epi",
       "max_session": 4,
       "max_trial": 100,
       "search": "RandomSearch"
@@ -747,7 +747,6 @@
     "env": [{
       "name": "Pendulum-v0",
       "max_t": null,
-      "max_tick_unit": "epi",
       "max_tick": 500,
       "save_frequency": 1000
     }],
@@ -757,6 +756,7 @@
     },
     "meta": {
       "distributed": false,
+      "max_tick_unit": "epi",
       "max_session": 4,
       "max_trial": 100,
       "search": "RandomSearch"
@@ -848,7 +848,6 @@
     "env": [{
       "name": "Breakout-v0",
       "max_t": null,
-      "max_tick_unit": "epi",
       "max_tick": 1
     }],
     "body": {
@@ -857,6 +856,7 @@
     },
     "meta": {
       "distributed": false,
+      "max_tick_unit": "epi",
       "max_session": 1,
       "max_trial": 1,
       "search": "RandomSearch"
@@ -927,7 +927,6 @@
     "env": [{
       "name": "Breakout-v0",
       "max_t": null,
-      "max_tick_unit": "epi",
       "max_tick": 1
     }],
     "body": {
@@ -936,6 +935,7 @@
     },
     "meta": {
       "distributed": false,
+      "max_tick_unit": "epi",
       "max_session": 1,
       "max_trial": 1,
       "search": "RandomSearch"

--- a/slm_lab/spec/random.json
+++ b/slm_lab/spec/random.json
@@ -13,7 +13,6 @@
     "env": [{
       "name": "CartPole-v0",
       "max_t": null,
-      "max_tick_unit": "epi",
       "max_tick": 100
     }],
     "body": {
@@ -22,6 +21,7 @@
     },
     "meta": {
       "distributed": false,
+      "max_tick_unit": "epi",
       "max_session": 5,
       "max_trial": 1,
       "search": "RandomSearch"
@@ -41,7 +41,6 @@
     "env": [{
       "name": "Pendulum-v0",
       "max_t": null,
-      "max_tick_unit": "epi",
       "max_tick": 100
     }],
     "body": {
@@ -50,6 +49,7 @@
     },
     "meta": {
       "distributed": false,
+      "max_tick_unit": "epi",
       "max_session": 5,
       "max_trial": 1,
       "search": "RandomSearch"
@@ -69,7 +69,6 @@
     "env": [{
       "name": "2DBall",
       "max_t": 1000,
-      "max_tick_unit": "epi",
       "max_tick": 100
     }],
     "body": {
@@ -78,6 +77,7 @@
     },
     "meta": {
       "distributed": false,
+      "max_tick_unit": "epi",
       "max_session": 5,
       "max_trial": 1,
       "search": "RandomSearch"

--- a/slm_lab/spec/random.json
+++ b/slm_lab/spec/random.json
@@ -21,6 +21,7 @@
     },
     "meta": {
       "distributed": false,
+      "eval_frequency": 1000,
       "max_tick_unit": "epi",
       "max_session": 5,
       "max_trial": 1,
@@ -49,6 +50,7 @@
     },
     "meta": {
       "distributed": false,
+      "eval_frequency": 1000,
       "max_tick_unit": "epi",
       "max_session": 5,
       "max_trial": 1,
@@ -77,6 +79,7 @@
     },
     "meta": {
       "distributed": false,
+      "eval_frequency": 1000,
       "max_tick_unit": "epi",
       "max_session": 5,
       "max_trial": 1,

--- a/slm_lab/spec/spec_util.py
+++ b/slm_lab/spec/spec_util.py
@@ -36,6 +36,7 @@ SPEC_FORMAT = {
     },
     "meta": {
         "distributed": bool,
+        "eval_frequency": int,
         "max_tick_unit": str,
         "max_session": int,
         "max_trial": (type(None), int),
@@ -178,7 +179,7 @@ def override_test_spec(spec):
     for env_spec in spec['env']:
         env_spec['max_t'] = 20
         env_spec['max_tick'] = 3
-        env_spec['save_frequency'] = 1000
+    spec['meta']['eval_frequency'] = 1000
     spec['meta']['max_tick_unit'] = 'epi'
     spec['meta']['max_session'] = 1
     spec['meta']['max_trial'] = 2

--- a/slm_lab/spec/spec_util.py
+++ b/slm_lab/spec/spec_util.py
@@ -29,7 +29,6 @@ SPEC_FORMAT = {
         "name": str,
         "max_t": (type(None), int),
         "max_tick": int,
-        "max_tick_unit": str,
     }],
     "body": {
         "product": ["outer", "inner", "custom"],
@@ -37,6 +36,7 @@ SPEC_FORMAT = {
     },
     "meta": {
         "distributed": bool,
+        "max_tick_unit": str,
         "max_session": int,
         "max_trial": (type(None), int),
         "search": str,
@@ -178,8 +178,8 @@ def override_test_spec(spec):
     for env_spec in spec['env']:
         env_spec['max_t'] = 20
         env_spec['max_tick'] = 3
-        env_spec['max_tick_unit'] = 'epi'
         env_spec['save_frequency'] = 1000
+    spec['meta']['max_tick_unit'] = 'epi'
     spec['meta']['max_session'] = 1
     spec['meta']['max_trial'] = 2
     return spec

--- a/test/experiment/test_control.py
+++ b/test/experiment/test_control.py
@@ -35,7 +35,7 @@ def test_trial(test_spec, test_info_space):
 def test_trial_demo(test_info_space):
     spec = spec_util.get('demo.json', 'dqn_cartpole')
     spec = spec_util.override_test_spec(spec)
-    spec['env'][0]['save_frequency'] = 1
+    spec['meta']['eval_frequency'] = 1
     test_info_space.tick('trial')
     trial_data = Trial(spec, test_info_space).run()
     assert isinstance(trial_data, pd.DataFrame)

--- a/test/experiment/test_control.py
+++ b/test/experiment/test_control.py
@@ -18,7 +18,7 @@ def test_session_total_t(test_spec, test_info_space):
     spec = deepcopy(test_spec)
     env_spec = spec['env'][0]
     env_spec['max_tick'] = 30
-    env_spec['max_tick_unit'] = 'total_t'
+    spec['meta']['max_tick_unit'] = 'total_t'
     session = Session(spec, test_info_space)
     assert session.env.max_tick_unit == 'total_t'
     session_data = session.run()


### PR DESCRIPTION
## Eval rework
This PR adds an eval mode that is the same as OpenAI baseline. Spawn 2 environments, 1 for training and 1 more eval. In the same process (blocking), run training as usual, then at ckpt, run an episode on eval env and update stats.

The logic for the stats are the same as before, except the original `body.df` is now split into two: `body.train_df` and `body.eval_df`. Eval df uses the main env stats except for `t, reward` to reflect progress on eval env. Correspondingly, session analysis also produces both versions of data.

Data from `body.eval_df` is used to generate `session_df, session_graph, session_fitness_df`, whereas the data from `body.train_df` is used to generate a new set of `trainsession_df, trainsession_graph, trainsession_fitness_df` for debugging.

The previous process-based eval functionality is kept, but is now considered as `parallel_eval`. This can be useful for more robust checkpointing and eval.

Additionally:
- spec key `env.e.save_frequency` is generalized to `meta.eval_frequency`
- spec key `env.e.max_tick_unit` is generalized to `meta.max_tick_unit`
- `body.log_summary()` now directly print from `eval_df, train_df`
- truly group all update methods into `agent.update()` method to allow for clean eval mode
- group all adhoc variable updates (entropy, log_prob, grad_norm) under its methods
- introduce `ctx_lab_mode` for contextual lab mode to run eval loop with context
- introduce `run_eval_episode` for eval mode
- set variables such as `explore_var` to `end_val` using eval context, and restore after context
- update specs

## Refactor
- declare lab modes `EVAL_MODES, TRAIN_MODES`; refactor by introducing `util.in_eval_lab_modes()`
- purge `body.last_loss` in favor of a single `body.loss`
- make `NoOpLRScheduler` API consistent
- purge useless computations in memory, etc.

