### PR TITLE
add live trial graph

### DIFF
--- a/slm_lab/env/base.py
+++ b/slm_lab/env/base.py
@@ -3,6 +3,7 @@ from gym import spaces
 from slm_lab.lib import logger, util
 from slm_lab.lib.decorator import lab_api
 import numpy as np
+import time
 
 ENV_DATA_NAMES = ['reward', 'state', 'done']
 NUM_EVAL_EPI = 100  # set the number of episodes to eval a model ckpt
@@ -38,10 +39,14 @@ class Clock:
         self.t = 0
         self.total_t = 0
         self.epi = -1  # offset so epi is 0 when it gets ticked at start
+        self.start_wall_t = time.time()
 
-    def to_step(self):
-        '''Step signal from clock_speed. Step only if the base unit of time in this clock has moved. Used to control if env of different clock_speed should step()'''
-        return self.ticks % self.clock_speed == 0
+    def get(self, unit='t'):
+        return getattr(self, unit)
+
+    def get_elapsed_wall_t(self):
+        '''Calculate the elapsed wall time (int seconds) since self.start_wall_t'''
+        return int(time.time() - self.start_wall_t)
 
     def tick(self, unit='t'):
         if unit == 't':  # timestep
@@ -57,8 +62,9 @@ class Clock:
         else:
             raise KeyError
 
-    def get(self, unit='t'):
-        return getattr(self, unit)
+    def to_step(self):
+        '''Step signal from clock_speed. Step only if the base unit of time in this clock has moved. Used to control if env of different clock_speed should step()'''
+        return self.ticks % self.clock_speed == 0
 
 
 class BaseEnv(ABC):

--- a/slm_lab/experiment/analysis.py
+++ b/slm_lab/experiment/analysis.py
@@ -554,7 +554,7 @@ def _analyze_session(session, session_data, body_df_kind='eval'):
     return session_fitness_df
 
 
-def analyze_session(session, tmp_space_session_sub=False):
+def analyze_session(session, eager_analyze_trial=False, tmp_space_session_sub=False):
     '''
     Gather session data, plot, and return fitness df for high level agg.
     @returns {DataFrame} session_fitness_df Single-row df of session fitness vector (avg over aeb), indexed with session index.
@@ -564,6 +564,14 @@ def analyze_session(session, tmp_space_session_sub=False):
     session_fitness_df = _analyze_session(session, session_data, body_df_kind='train')
     session_data = get_session_data(session, body_df_kind='eval', tmp_space_session_sub=tmp_space_session_sub)
     session_fitness_df = _analyze_session(session, session_data, body_df_kind='eval')
+    if eager_analyze_trial:
+        # for live trial graph, analyze trial after analyzing session, this only takes a second
+        from slm_lab.experiment import retro_analysis
+        prepath = util.get_prepath(session.spec, session.info_space, unit='session')
+        # use new ones to prevent side effects
+        spec, info_space = util.prepath_to_spec_info_space(prepath)
+        predir, _, _, _, _, _ = util.prepath_split(prepath)
+        retro_analysis.analyze_eval_trial(spec, info_space, predir)
     return session_fitness_df
 
 

--- a/slm_lab/experiment/control.py
+++ b/slm_lab/experiment/control.py
@@ -61,7 +61,7 @@ class Session:
             if analysis.new_best(agent):
                 agent.save(ckpt='best')
             if tick > 0:  # nothing to analyze at start
-                analysis.analyze_session(self)
+                analysis.analyze_session(self, eager_analyze_trial=True)
 
     def run_eval_episode(self):
         with util.ctx_lab_mode('eval'):  # enter eval context

--- a/slm_lab/experiment/control.py
+++ b/slm_lab/experiment/control.py
@@ -108,9 +108,6 @@ class Session:
     def run(self):
         while self.env.clock.get(self.env.max_tick_unit) < self.env.max_tick:
             self.run_episode()
-            if not util.in_eval_lab_modes() and analysis.all_solved(self.agent):
-                logger.info('All environments solved. Early exit.')
-                break
         retro_analysis.try_wait_parallel_eval(self)
         self.data = analysis.analyze_session(self)  # session fitness
         self.close()

--- a/slm_lab/experiment/monitor.py
+++ b/slm_lab/experiment/monitor.py
@@ -119,7 +119,7 @@ class Body:
         # dataframes to track data for analysis.analyze_session
         # track training data within run_episode
         self.train_df = pd.DataFrame(columns=[
-            'epi', 'total_t', 't', 'reward', 'loss', 'lr',
+            'epi', 'total_t', 't', 'wall_t', 'reward', 'loss', 'lr',
             'explore_var', 'entropy_coef', 'entropy', 'log_prob', 'grad_norm'])
         # track eval data within run_eval_episode. the same as train_df except for reward
         self.eval_df = self.train_df.copy()
@@ -159,6 +159,7 @@ class Body:
             'total_t': self.env.clock.get('total_t'),
             # t and reward are measured from a given env or eval_env
             't': env.clock.get('t'),
+            'wall_t': env.clock.get_elapsed_wall_t(),
             'reward': total_reward,
             'loss': self.loss,
             'lr': self.get_mean_lr(),

--- a/slm_lab/experiment/retro_analysis.py
+++ b/slm_lab/experiment/retro_analysis.py
@@ -83,7 +83,7 @@ def analyze_eval_trial(spec, info_space, predir):
     analysis.analyze_trial(trial)
 
 
-def run_parallel_eval(spec, info_space, ckpt):
+def parallel_eval(spec, info_space, ckpt):
     '''
     Calls a subprocess to run lab in eval mode with the constructed ckpt prepath, same as how one would manually run the bash cmd
     @example
@@ -104,7 +104,7 @@ def run_parallel_eval(session, agent, env):
         ckpt = f'epi{env.clock.epi}-totalt{env.clock.total_t}'
         agent.save(ckpt=ckpt)
         # set reference to eval process for handling
-        session.eval_proc = run_parallel_eval(session.spec, session.info_space, ckpt)
+        session.eval_proc = parallel_eval(session.spec, session.info_space, ckpt)
 
 
 def try_wait_parallel_eval(session):
@@ -118,7 +118,7 @@ def run_parallel_eval_from_prepath(prepath):
     '''Used by retro_eval'''
     spec, info_space = util.prepath_to_spec_info_space(prepath)
     ckpt = util.find_ckpt(prepath)
-    return run_parallel_eval(spec, info_space, ckpt)
+    return parallel_eval(spec, info_space, ckpt)
 
 
 def run_wait_eval(prepath):

--- a/slm_lab/spec/demo.json
+++ b/slm_lab/spec/demo.json
@@ -52,7 +52,7 @@
     "env": [{
       "name": "CartPole-v0",
       "max_t": null,
-      "max_tick": 10000
+      "max_tick": 30000
     }],
     "body": {
       "product": "outer",

--- a/test/experiment/test_control.py
+++ b/test/experiment/test_control.py
@@ -1,5 +1,6 @@
 from copy import deepcopy
 from slm_lab.experiment.control import Session, Trial, Experiment
+from slm_lab.experiment import analysis
 from slm_lab.lib import util
 from slm_lab.spec import spec_util
 import pandas as pd
@@ -7,14 +8,18 @@ import pytest
 
 
 def test_session(test_spec, test_info_space):
+    test_info_space.tick('trial')
     test_info_space.tick('session')
+    analysis.save_spec(test_spec, test_info_space, unit='trial')
     session = Session(test_spec, test_info_space)
     session_data = session.run()
     assert isinstance(session_data, pd.DataFrame)
 
 
 def test_session_total_t(test_spec, test_info_space):
+    test_info_space.tick('trial')
     test_info_space.tick('session')
+    analysis.save_spec(test_spec, test_info_space, unit='trial')
     spec = deepcopy(test_spec)
     env_spec = spec['env'][0]
     env_spec['max_tick'] = 30
@@ -27,6 +32,7 @@ def test_session_total_t(test_spec, test_info_space):
 
 def test_trial(test_spec, test_info_space):
     test_info_space.tick('trial')
+    analysis.save_spec(test_spec, test_info_space, unit='trial')
     trial = Trial(test_spec, test_info_space)
     trial_data = trial.run()
     assert isinstance(trial_data, pd.DataFrame)
@@ -34,6 +40,7 @@ def test_trial(test_spec, test_info_space):
 
 def test_trial_demo(test_info_space):
     spec = spec_util.get('demo.json', 'dqn_cartpole')
+    analysis.save_spec(spec, test_info_space, unit='experiment')
     spec = spec_util.override_test_spec(spec)
     spec['meta']['eval_frequency'] = 1
     test_info_space.tick('trial')
@@ -43,6 +50,7 @@ def test_trial_demo(test_info_space):
 
 def test_experiment(test_info_space):
     spec = spec_util.get('demo.json', 'dqn_cartpole')
+    analysis.save_spec(spec, test_info_space, unit='experiment')
     spec = spec_util.override_test_spec(spec)
     test_info_space.tick('experiment')
     experiment_data = Experiment(spec, test_info_space).run()


### PR DESCRIPTION
## add live trial graph
- move context logic within `run_eval_episode`, ensure variable update ok
- rename `parallel_eval method` name conflict
- add `eager_analyze_trial` option for live trial graph
- increase demo length
- add wall time in seconds to `Clock`
- remove early exit logic