### PR TITLE
redesign fitness to be more robust and intuitive

### DIFF
--- a/slm_lab/experiment/analysis.py
+++ b/slm_lab/experiment/analysis.py
@@ -28,15 +28,8 @@ Fitness analysis
 
 def calc_strength_sr(aeb_df, rand_reward, std_reward):
     '''
-    Given an agent reward at a checkpoint, normalize it with a given baseline rand_reward and solution std_reward, i.e.
+    Calculate strength for each reward as
     strength = (reward - rand_reward) / (std_reward - rand_reward)
-    Agent strength in fitness is its maximum strength
-
-    **Properties:**
-    - random agent has strength 0, standard agent has strength 1.
-    - strength is standardized to be independent of the actual sign and scale of raw reward
-    - scales relative to std_reward: if an agent achieve x2 std_reward, the strength is x2, and so on.
-    This allows for standard comparison between agents on the same problem using an intuitive measurement of strength. With proper scaling by a difficulty factor, we can compare across problems of different difficulties.
     '''
     return (aeb_df['reward'] - rand_reward) / (std_reward - rand_reward)
 

--- a/slm_lab/spec/_fitness_std.json
+++ b/slm_lab/spec/_fitness_std.json
@@ -12,7 +12,7 @@
   "CartPole-v0": {
     "rand_epi_reward": 22,
     "std_epi_reward": 195,
-    "std_timestep": 100000
+    "std_timestep": 50000
   },
   "MountainCar-v0": {
     "rand_epi_reward": -200,

--- a/slm_lab/spec/_fitness_std.json
+++ b/slm_lab/spec/_fitness_std.json
@@ -7,91 +7,91 @@
   "Acrobot-v1": {
     "rand_epi_reward": -500,
     "std_epi_reward": -50,
-    "std_timestep": 20000
+    "std_timestep": 200000
   },
   "CartPole-v0": {
     "rand_epi_reward": 22,
     "std_epi_reward": 195,
-    "std_timestep": 5000
+    "std_timestep": 100000
   },
   "MountainCar-v0": {
     "rand_epi_reward": -200,
     "std_epi_reward": -110,
-    "std_timestep": 60000
+    "std_timestep": 200000
   },
   "MountainCarContinuous-v0": {
     "rand_epi_reward": -33,
     "std_epi_reward": 90,
-    "std_timestep": 60000
+    "std_timestep": 200000
   },
   "Pendulum-v0": {
     "rand_epi_reward": -1200,
     "std_epi_reward": -130,
-    "std_timestep": 40000
+    "std_timestep": 200000
   },
   "BipedalWalker-v2": {
     "rand_epi_reward": -100,
     "std_epi_reward": 300 ,
-    "std_timestep": 100000
+    "std_timestep": 200000
   },
   "BipedalWalkerHardcore-v2": {
     "rand_epi_reward": -100,
     "std_epi_reward": 300,
-    "std_timestep": 100000
+    "std_timestep": 200000
   },
   "CarRacing-v0": {
     "rand_epi_reward": -100,
     "std_epi_reward": 900,
-    "std_timestep": 100000
+    "std_timestep": 200000
   },
   "LunarLander-v2": {
     "rand_epi_reward": -250,
     "std_epi_reward": 200,
-    "std_timestep": 150000
+    "std_timestep": 300000
   },
   "LunarLanderContinuous-v2": {
     "rand_epi_reward": -250,
     "std_epi_reward": 200,
-    "std_timestep": 150000
+    "std_timestep": 300000
   },
   "BeamRiderNoFrameskip-v4": {
     "rand_epi_reward": 363.9,
     "std_epi_reward": 6846,
-    "std_timestep": 1000000
+    "std_timestep": 10000000
   },
   "BreakoutNoFrameskip-v4": {
     "rand_epi_reward": 1.7,
     "std_epi_reward": 401.2,
-    "std_timestep": 1000000
+    "std_timestep": 10000000
   },
   "EnduroNoFrameskip-v4": {
     "rand_epi_reward": 0,
     "std_epi_reward": 301.8,
-    "std_timestep": 1000000
+    "std_timestep": 10000000
   },
   "MsPacmanNoFrameskip-v4": {
     "rand_epi_reward": 307.3,
     "std_epi_reward": 2311,
-    "std_timestep": 1000000
+    "std_timestep": 10000000
   },
   "PongNoFrameskip-v4": {
     "rand_epi_reward": -20.7,
     "std_epi_reward": 18.9,
-    "std_timestep": 1000000
+    "std_timestep": 10000000
   },
   "QbertNoFrameskip-v4": {
     "rand_epi_reward": 163.9,
     "std_epi_reward": 10596,
-    "std_timestep": 1000000
+    "std_timestep": 10000000
   },
   "SeaquestNoFrameskip-v4": {
     "rand_epi_reward": 68.4,
     "std_epi_reward": 5286,
-    "std_timestep": 1000000
+    "std_timestep": 10000000
   },
   "SpaceInvadersNoFrameskip-v4": {
     "rand_epi_reward": 148,
     "std_epi_reward": 1976,
-    "std_timestep": 1000000
+    "std_timestep": 10000000
   },
 }


### PR DESCRIPTION
## redesign fitness
- improve calculation of fitness metrics to be more robust, intuitive, and simple
- use moving average strength and consider whole series as data input
- update standard accordingly

see updates:

```python
def calc_strength(aeb_df):
    '''
    Strength of an agent in fitness is its maximum strength_ma. Moving average is used to denoise signal.
    For an agent total reward at a time, calculate strength by normalizing it with a given baseline rand_reward and solution std_reward, i.e.
    strength = (reward - rand_reward) / (std_reward - rand_reward)

    **Properties:**
    - random agent has strength 0, standard agent has strength 1.
    - strength is standardized to be independent of the actual sign and scale of raw reward
    - scales relative to std_reward: if an agent achieve x2 std_reward, the strength is x2, and so on.
    This allows for standard comparison between agents on the same problem using an intuitive measurement of strength. With proper scaling by a difficulty factor, we can compare across problems of different difficulties.
    '''
    return aeb_df['strength_ma'].max()


def calc_speed(aeb_df, std_timestep):
    '''
    Find the maximum strength_ma, and the time to first reach it. Then the strength/time divided by the standard std_strength/std_timestep is speed, i.e.
    speed = (max_strength_ma / timestep_to_first_reach) / (std_strength / std_timestep)
    **Properties:**
    - random agent has speed 0, standard agent has speed 1.
    - if both agents reach the same max strength_ma, and one reaches it in half the timesteps, it is twice as fast.
    - speed is standardized regardless of the scaling of absolute timesteps, or even the max strength attained
    This allows an intuitive measurement of learning speed and the standard comparison between agents on the same problem.
    '''
    first_max_idx = aeb_df['strength_ma'].idxmax()  # this returns the first max
    max_row = aeb_df.loc[first_max_idx]
    std_strength = 1.
    speed = (max_row['strength_ma'] / max_row['total_t']) / (std_strength / std_timestep)
    return speed


def calc_stability(aeb_df):
    '''
    Stability = fraction of monotonically increasing elements in the denoised series of strength_ma
    **Properties:**
    - stable agent has value 1, unstable agent < 1, and non-solution = 0.
    - uses strength_ma to be more robust to noise
    - sharp gain in strength is considered stable
    - monotonically increasing implies strength can keep growing and as long as it does not fall much, it is considered stable
    '''
    mono_inc_sr = np.diff(aeb_df['strength_ma']) >= 0
    stability = mono_inc_sr.sum() / mono_inc_sr.size
    return stability
```
