### PR TITLE
Refactor DDQN network switching

### DIFF
--- a/slm_lab/agent/algorithm/dqn.py
+++ b/slm_lab/agent/algorithm/dqn.py
@@ -219,13 +219,9 @@ class DQNBase(VanillaDQN):
             if self.net.update_type == 'replace':
                 logger.debug('Updating target_net by replacing')
                 net_util.copy(self.net, self.target_net)
-                self.online_net = self.target_net
-                self.eval_net = self.target_net
             elif self.net.update_type == 'polyak':
                 logger.debug('Updating net by averaging')
                 net_util.polyak_update(self.net, self.target_net, self.net.polyak_coef)
-                self.online_net = self.target_net
-                self.eval_net = self.target_net
             else:
                 raise ValueError('Unknown net.update_type. Should be "replace" or "polyak". Exiting.')
 
@@ -292,14 +288,3 @@ class DoubleDQN(DQN):
         super(DoubleDQN, self).init_nets(global_nets)
         self.online_net = self.net
         self.eval_net = self.target_net
-
-    def update_nets(self):
-        res = super(DoubleDQN, self).update_nets()
-        total_t = self.body.env.clock.total_t
-        if self.net.update_type == 'replace':
-            if total_t % self.net.update_frequency == 0:
-                self.online_net = self.net
-                self.eval_net = self.target_net
-        elif self.net.update_type == 'polyak':
-            self.online_net = self.net
-            self.eval_net = self.target_net

--- a/slm_lab/agent/algorithm/dqn.py
+++ b/slm_lab/agent/algorithm/dqn.py
@@ -285,24 +285,6 @@ class DoubleDQN(DQN):
     '''
     @lab_api
     def init_nets(self, global_nets=None):
-        '''Initialize networks'''
-        super(DoubleDQN, self).init_nets(global_nets=global_nets)
-        if global_nets is None:
-            in_dim = self.body.state_dim
-            out_dim = net_util.get_out_dim(self.body)
-            NetClass = getattr(net, self.net_spec['type'])
-            self.target_net_2 = NetClass(self.net_spec, in_dim, out_dim)
-            self.net_names = ['net', 'target_net', 'target_net_2']
-        self.post_init_nets()
-        self.online_net = self.target_net_2
+        super(DoubleDQN, self).init_nets(global_nets)
+        self.online_net = self.net
         self.eval_net = self.target_net
-
-    def update_nets(self):
-        super(DoubleDQN, self).update_nets()
-        total_t = self.body.env.clock.total_t
-        if total_t % self.net.update_frequency_short == 0:
-            if self.net.update_type == 'replace':
-                logger.debug('Updating target_net_2 by replacing')
-                net_util.copy(self.net, self.target_net_2)
-            else:
-                raise ValueError('Unknown net.update_type. Should be "replace" or "polyak". Exiting.')

--- a/slm_lab/agent/net/conv.py
+++ b/slm_lab/agent/net/conv.py
@@ -48,6 +48,7 @@ class ConvNet(Net, nn.Module):
         },
         "update_type": "replace",
         "update_frequency": 10000,
+        "update_frequency_short": 1000,
         "polyak_coef": 0.9,
         "gpu": true
     }
@@ -69,6 +70,7 @@ class ConvNet(Net, nn.Module):
         lr_scheduler_spec: Pytorch optim.lr_scheduler
         update_type: method to update network weights: 'replace' or 'polyak'
         update_frequency: how many total timesteps per update
+        update_frequency_short: how many total timesteps per update for the 2nd target net (used for DoubleDQN)
         polyak_coef: ratio of polyak weight update
         gpu: whether to train using a GPU. Note this will only work if a GPU is available, othewise setting gpu=True does nothing
         '''
@@ -85,6 +87,7 @@ class ConvNet(Net, nn.Module):
             lr_scheduler_spec=None,
             update_type='replace',
             update_frequency=1,
+            update_frequency_short=1,
             polyak_coef=0.0,
             gpu=False,
         ))
@@ -100,6 +103,7 @@ class ConvNet(Net, nn.Module):
             'lr_scheduler_spec',
             'update_type',
             'update_frequency',
+            'update_frequency_short',
             'polyak_coef',
             'gpu',
         ])

--- a/slm_lab/agent/net/conv.py
+++ b/slm_lab/agent/net/conv.py
@@ -48,7 +48,6 @@ class ConvNet(Net, nn.Module):
         },
         "update_type": "replace",
         "update_frequency": 10000,
-        "update_frequency_short": 1000,
         "polyak_coef": 0.9,
         "gpu": true
     }
@@ -70,7 +69,6 @@ class ConvNet(Net, nn.Module):
         lr_scheduler_spec: Pytorch optim.lr_scheduler
         update_type: method to update network weights: 'replace' or 'polyak'
         update_frequency: how many total timesteps per update
-        update_frequency_short: how many total timesteps per update for the 2nd target net (used for DoubleDQN)
         polyak_coef: ratio of polyak weight update
         gpu: whether to train using a GPU. Note this will only work if a GPU is available, othewise setting gpu=True does nothing
         '''
@@ -87,7 +85,6 @@ class ConvNet(Net, nn.Module):
             lr_scheduler_spec=None,
             update_type='replace',
             update_frequency=1,
-            update_frequency_short=1,
             polyak_coef=0.0,
             gpu=False,
         ))
@@ -103,7 +100,6 @@ class ConvNet(Net, nn.Module):
             'lr_scheduler_spec',
             'update_type',
             'update_frequency',
-            'update_frequency_short',
             'polyak_coef',
             'gpu',
         ])

--- a/slm_lab/agent/net/mlp.py
+++ b/slm_lab/agent/net/mlp.py
@@ -36,6 +36,7 @@ class MLPNet(Net, nn.Module):
         },
         "update_type": "replace",
         "update_frequency": 1,
+        "update_frequency_short": 1,
         "polyak_coef": 0.9,
         "gpu": true
     }
@@ -53,6 +54,7 @@ class MLPNet(Net, nn.Module):
         lr_scheduler_spec: Pytorch optim.lr_scheduler
         update_type: method to update network weights: 'replace' or 'polyak'
         update_frequency: how many total timesteps per update
+        update_frequency_short: how many total timesteps per update for the 2nd target net (used for DoubleDQN)
         polyak_coef: ratio of polyak weight update
         gpu: whether to train using a GPU. Note this will only work if a GPU is available, othewise setting gpu=True does nothing
         '''
@@ -67,6 +69,7 @@ class MLPNet(Net, nn.Module):
             lr_scheduler_spec=None,
             update_type='replace',
             update_frequency=1,
+            update_frequency_short=1,
             polyak_coef=0.0,
             gpu=False,
         ))
@@ -81,6 +84,7 @@ class MLPNet(Net, nn.Module):
             'lr_scheduler_spec',
             'update_type',
             'update_frequency',
+            'update_frequency_short',
             'polyak_coef',
             'gpu',
         ])

--- a/slm_lab/agent/net/mlp.py
+++ b/slm_lab/agent/net/mlp.py
@@ -36,7 +36,6 @@ class MLPNet(Net, nn.Module):
         },
         "update_type": "replace",
         "update_frequency": 1,
-        "update_frequency_short": 1,
         "polyak_coef": 0.9,
         "gpu": true
     }
@@ -54,7 +53,6 @@ class MLPNet(Net, nn.Module):
         lr_scheduler_spec: Pytorch optim.lr_scheduler
         update_type: method to update network weights: 'replace' or 'polyak'
         update_frequency: how many total timesteps per update
-        update_frequency_short: how many total timesteps per update for the 2nd target net (used for DoubleDQN)
         polyak_coef: ratio of polyak weight update
         gpu: whether to train using a GPU. Note this will only work if a GPU is available, othewise setting gpu=True does nothing
         '''
@@ -69,7 +67,6 @@ class MLPNet(Net, nn.Module):
             lr_scheduler_spec=None,
             update_type='replace',
             update_frequency=1,
-            update_frequency_short=1,
             polyak_coef=0.0,
             gpu=False,
         ))
@@ -84,7 +81,6 @@ class MLPNet(Net, nn.Module):
             'lr_scheduler_spec',
             'update_type',
             'update_frequency',
-            'update_frequency_short',
             'polyak_coef',
             'gpu',
         ])

--- a/slm_lab/agent/net/recurrent.py
+++ b/slm_lab/agent/net/recurrent.py
@@ -47,7 +47,6 @@ class RecurrentNet(Net, nn.Module):
         },
         "update_type": "replace",
         "update_frequency": 1,
-        "update_frequency_short": 1,
         "polyak_coef": 0.9,
         "gpu": true
     }
@@ -70,7 +69,6 @@ class RecurrentNet(Net, nn.Module):
         lr_scheduler_spec: Pytorch optim.lr_scheduler
         update_type: method to update network weights: 'replace' or 'polyak'
         update_frequency: how many total timesteps per update
-        update_frequency_short: how many total timesteps per update for the 2nd target net (used for DoubleDQN)
         polyak_coef: ratio of polyak weight update
         gpu: whether to train using a GPU. Note this will only work if a GPU is available, othewise setting gpu=True does nothing
         '''
@@ -88,7 +86,6 @@ class RecurrentNet(Net, nn.Module):
             lr_scheduler_spec=None,
             update_type='replace',
             update_frequency=1,
-            update_frequency_short=1,
             polyak_coef=0.0,
             gpu=False,
         ))
@@ -107,7 +104,6 @@ class RecurrentNet(Net, nn.Module):
             'lr_scheduler_spec',
             'update_type',
             'update_frequency',
-            'update_frequency_short',
             'polyak_coef',
             'gpu',
         ])

--- a/slm_lab/agent/net/recurrent.py
+++ b/slm_lab/agent/net/recurrent.py
@@ -47,6 +47,7 @@ class RecurrentNet(Net, nn.Module):
         },
         "update_type": "replace",
         "update_frequency": 1,
+        "update_frequency_short": 1,
         "polyak_coef": 0.9,
         "gpu": true
     }
@@ -69,6 +70,7 @@ class RecurrentNet(Net, nn.Module):
         lr_scheduler_spec: Pytorch optim.lr_scheduler
         update_type: method to update network weights: 'replace' or 'polyak'
         update_frequency: how many total timesteps per update
+        update_frequency_short: how many total timesteps per update for the 2nd target net (used for DoubleDQN)
         polyak_coef: ratio of polyak weight update
         gpu: whether to train using a GPU. Note this will only work if a GPU is available, othewise setting gpu=True does nothing
         '''
@@ -86,6 +88,7 @@ class RecurrentNet(Net, nn.Module):
             lr_scheduler_spec=None,
             update_type='replace',
             update_frequency=1,
+            update_frequency_short=1,
             polyak_coef=0.0,
             gpu=False,
         ))
@@ -104,6 +107,7 @@ class RecurrentNet(Net, nn.Module):
             'lr_scheduler_spec',
             'update_type',
             'update_frequency',
+            'update_frequency_short',
             'polyak_coef',
             'gpu',
         ])

--- a/slm_lab/spec/experimental/ddqn_beamrider.json
+++ b/slm_lab/spec/experimental/ddqn_beamrider.json
@@ -1,5 +1,5 @@
 {
-  "ddqn_beamrider": {
+  "ddqn_beamrider_2k": {
     "agent": [{
       "name": "DoubleDQN",
       "algorithm": {
@@ -48,7 +48,7 @@
         },
         "lr_scheduler_spec": null,
         "update_type": "replace",
-        "update_frequency": 1000,
+        "update_frequency": 2000,
         "gpu": true
       }
     }],

--- a/slm_lab/spec/experimental/ddqn_beamrider.json
+++ b/slm_lab/spec/experimental/ddqn_beamrider.json
@@ -51,7 +51,7 @@
         },
         "lr_scheduler_spec": null,
         "update_type": "replace",
-        "update_frequency": 5000,
+        "update_frequency": 1000,
         "gpu": true
       }
     }],

--- a/slm_lab/spec/experimental/ddqn_beamrider.json
+++ b/slm_lab/spec/experimental/ddqn_beamrider.json
@@ -48,7 +48,7 @@
         },
         "lr_scheduler_spec": null,
         "update_type": "replace",
-        "update_frequency": 3000,
+        "update_frequency": 1000,
         "gpu": true
       }
     }],

--- a/slm_lab/spec/experimental/ddqn_beamrider.json
+++ b/slm_lab/spec/experimental/ddqn_beamrider.json
@@ -48,7 +48,7 @@
         },
         "lr_scheduler_spec": null,
         "update_type": "replace",
-        "update_frequency": 1000,
+        "update_frequency": 3000,
         "gpu": true
       }
     }],

--- a/slm_lab/spec/experimental/ddqn_beamrider.json
+++ b/slm_lab/spec/experimental/ddqn_beamrider.json
@@ -44,7 +44,7 @@
         },
         "optim_spec": {
           "name": "RMSprop",
-          "lr": 2.5e-4,
+          "lr": 7.5e-4,
           "alpha": 0.95,
           "eps": 1e-1,
           "momentum": 0.95

--- a/slm_lab/spec/experimental/ddqn_beamrider.json
+++ b/slm_lab/spec/experimental/ddqn_beamrider.json
@@ -26,9 +26,6 @@
         "max_size": 200000,
         "stack_len": 4,
         "use_cer": false,
-        "alpha": 0.6,
-        "epsilon": 1e-6,
-
       },
       "net": {
         "type": "ConvNet",
@@ -53,9 +50,8 @@
           "momentum": 0.95
         },
         "lr_scheduler_spec": null,
-        "update_type": "polyak",
-        "update_frequency": 10,
-        "polyak_coef": 0.992,
+        "update_type": "replace",
+        "update_frequency": 5000,
         "gpu": true
       }
     }],

--- a/slm_lab/spec/experimental/ddqn_beamrider.json
+++ b/slm_lab/spec/experimental/ddqn_beamrider.json
@@ -43,16 +43,12 @@
           "name": "SmoothL1Loss"
         },
         "optim_spec": {
-          "name": "RMSprop",
-          "lr": 2.5e-4,
-          "alpha": 0.95,
-          "eps": 1e-1,
-          "momentum": 0.95
+          "name": "Adam",
+          "lr": 1e-4,
         },
         "lr_scheduler_spec": null,
         "update_type": "replace",
-        "update_frequency": 5000,
-        "update_frequency_short": 2500,
+        "update_frequency": 1000,
         "gpu": true
       }
     }],

--- a/slm_lab/spec/experimental/ddqn_beamrider.json
+++ b/slm_lab/spec/experimental/ddqn_beamrider.json
@@ -38,7 +38,7 @@
         "hid_layers_activation": "relu",
         "init_fn": null,
         "batch_norm": false,
-        "clip_grad_val": 1.0,
+        "clip_grad_val": 10.0,
         "loss_spec": {
           "name": "SmoothL1Loss"
         },

--- a/slm_lab/spec/experimental/ddqn_beamrider.json
+++ b/slm_lab/spec/experimental/ddqn_beamrider.json
@@ -1,5 +1,5 @@
 {
-  "ddqn_beamrider_2k": {
+  "ddqn_beamrider": {
     "agent": [{
       "name": "DoubleDQN",
       "algorithm": {
@@ -48,7 +48,7 @@
         },
         "lr_scheduler_spec": null,
         "update_type": "replace",
-        "update_frequency": 2000,
+        "update_frequency": 1000,
         "gpu": true
       }
     }],

--- a/slm_lab/spec/experimental/ddqn_beamrider.json
+++ b/slm_lab/spec/experimental/ddqn_beamrider.json
@@ -51,7 +51,8 @@
         },
         "lr_scheduler_spec": null,
         "update_type": "replace",
-        "update_frequency": 1000,
+        "update_frequency": 5000,
+        "update_frequency_short": 1000,
         "gpu": true
       }
     }],

--- a/slm_lab/spec/experimental/ddqn_beamrider.json
+++ b/slm_lab/spec/experimental/ddqn_beamrider.json
@@ -44,7 +44,7 @@
         },
         "optim_spec": {
           "name": "RMSprop",
-          "lr": 7.5e-4,
+          "lr": 2.5e-4,
           "alpha": 0.95,
           "eps": 1e-1,
           "momentum": 0.95
@@ -52,7 +52,7 @@
         "lr_scheduler_spec": null,
         "update_type": "replace",
         "update_frequency": 5000,
-        "update_frequency_short": 1000,
+        "update_frequency_short": 2500,
         "gpu": true
       }
     }],

--- a/slm_lab/spec/experimental/ddqn_breakout.json
+++ b/slm_lab/spec/experimental/ddqn_breakout.json
@@ -51,7 +51,7 @@
         },
         "lr_scheduler_spec": null,
         "update_type": "replace",
-        "update_frequency": 5000,
+        "update_frequency": 1000,
         "gpu": true
       }
     }],

--- a/slm_lab/spec/experimental/ddqn_breakout.json
+++ b/slm_lab/spec/experimental/ddqn_breakout.json
@@ -48,7 +48,7 @@
         },
         "lr_scheduler_spec": null,
         "update_type": "replace",
-        "update_frequency": 3000,
+        "update_frequency": 1000,
         "gpu": true
       }
     }],

--- a/slm_lab/spec/experimental/ddqn_breakout.json
+++ b/slm_lab/spec/experimental/ddqn_breakout.json
@@ -1,5 +1,5 @@
 {
-  "ddqn_breakout_2k": {
+  "ddqn_breakout": {
     "agent": [{
       "name": "DoubleDQN",
       "algorithm": {
@@ -48,7 +48,7 @@
         },
         "lr_scheduler_spec": null,
         "update_type": "replace",
-        "update_frequency": 2000,
+        "update_frequency": 1000,
         "gpu": true
       }
     }],

--- a/slm_lab/spec/experimental/ddqn_breakout.json
+++ b/slm_lab/spec/experimental/ddqn_breakout.json
@@ -50,9 +50,8 @@
           "momentum": 0.95
         },
         "lr_scheduler_spec": null,
-        "update_type": "polyak",
-        "update_frequency": 10,
-        "polyak_coef": 0.992,
+        "update_type": "replace",
+        "update_frequency": 5000,
         "gpu": true
       }
     }],

--- a/slm_lab/spec/experimental/ddqn_breakout.json
+++ b/slm_lab/spec/experimental/ddqn_breakout.json
@@ -48,7 +48,7 @@
         },
         "lr_scheduler_spec": null,
         "update_type": "replace",
-        "update_frequency": 1000,
+        "update_frequency": 3000,
         "gpu": true
       }
     }],

--- a/slm_lab/spec/experimental/ddqn_breakout.json
+++ b/slm_lab/spec/experimental/ddqn_breakout.json
@@ -44,7 +44,7 @@
         },
         "optim_spec": {
           "name": "RMSprop",
-          "lr": 2.5e-4,
+          "lr": 7.5e-4,
           "alpha": 0.95,
           "eps": 1e-1,
           "momentum": 0.95

--- a/slm_lab/spec/experimental/ddqn_breakout.json
+++ b/slm_lab/spec/experimental/ddqn_breakout.json
@@ -43,16 +43,12 @@
           "name": "SmoothL1Loss"
         },
         "optim_spec": {
-          "name": "RMSprop",
-          "lr": 2.5e-4,
-          "alpha": 0.95,
-          "eps": 1e-1,
-          "momentum": 0.95
+          "name": "Adam",
+          "lr": 1e-4,
         },
         "lr_scheduler_spec": null,
         "update_type": "replace",
-        "update_frequency": 5000,
-        "update_frequency_short": 2500,
+        "update_frequency": 1000,
         "gpu": true
       }
     }],

--- a/slm_lab/spec/experimental/ddqn_breakout.json
+++ b/slm_lab/spec/experimental/ddqn_breakout.json
@@ -38,7 +38,7 @@
         "hid_layers_activation": "relu",
         "init_fn": null,
         "batch_norm": false,
-        "clip_grad_val": 1.0,
+        "clip_grad_val": 10.0,
         "loss_spec": {
           "name": "SmoothL1Loss"
         },

--- a/slm_lab/spec/experimental/ddqn_breakout.json
+++ b/slm_lab/spec/experimental/ddqn_breakout.json
@@ -1,5 +1,5 @@
 {
-  "ddqn_breakout": {
+  "ddqn_breakout_2k": {
     "agent": [{
       "name": "DoubleDQN",
       "algorithm": {
@@ -48,7 +48,7 @@
         },
         "lr_scheduler_spec": null,
         "update_type": "replace",
-        "update_frequency": 1000,
+        "update_frequency": 2000,
         "gpu": true
       }
     }],

--- a/slm_lab/spec/experimental/ddqn_breakout.json
+++ b/slm_lab/spec/experimental/ddqn_breakout.json
@@ -51,7 +51,8 @@
         },
         "lr_scheduler_spec": null,
         "update_type": "replace",
-        "update_frequency": 1000,
+        "update_frequency": 5000,
+        "update_frequency_short": 1000,
         "gpu": true
       }
     }],

--- a/slm_lab/spec/experimental/ddqn_breakout.json
+++ b/slm_lab/spec/experimental/ddqn_breakout.json
@@ -44,7 +44,7 @@
         },
         "optim_spec": {
           "name": "RMSprop",
-          "lr": 7.5e-4,
+          "lr": 2.5e-4,
           "alpha": 0.95,
           "eps": 1e-1,
           "momentum": 0.95
@@ -52,7 +52,7 @@
         "lr_scheduler_spec": null,
         "update_type": "replace",
         "update_frequency": 5000,
-        "update_frequency_short": 1000,
+        "update_frequency_short": 2500,
         "gpu": true
       }
     }],

--- a/slm_lab/spec/experimental/ddqn_enduro.json
+++ b/slm_lab/spec/experimental/ddqn_enduro.json
@@ -48,7 +48,7 @@
         },
         "lr_scheduler_spec": null,
         "update_type": "replace",
-        "update_frequency": 1000,
+        "update_frequency": 2000,
         "gpu": true
       }
     }],

--- a/slm_lab/spec/experimental/ddqn_enduro.json
+++ b/slm_lab/spec/experimental/ddqn_enduro.json
@@ -1,5 +1,5 @@
 {
-  "ddqn_enduro": {
+  "ddqn_enduro_2k": {
     "agent": [{
       "name": "DoubleDQN",
       "algorithm": {

--- a/slm_lab/spec/experimental/ddqn_enduro.json
+++ b/slm_lab/spec/experimental/ddqn_enduro.json
@@ -43,15 +43,12 @@
           "name": "SmoothL1Loss"
         },
         "optim_spec": {
-          "name": "RMSprop",
-          "lr": 2.5e-4,
-          "alpha": 0.95,
-          "eps": 1e-1,
-          "momentum": 0.95
+          "name": "Adam",
+          "lr": 1e-4,
         },
         "lr_scheduler_spec": null,
         "update_type": "replace",
-        "update_frequency": 5000,
+        "update_frequency": 1000,
         "gpu": true
       }
     }],

--- a/slm_lab/spec/experimental/ddqn_enduro.json
+++ b/slm_lab/spec/experimental/ddqn_enduro.json
@@ -48,7 +48,7 @@
         },
         "lr_scheduler_spec": null,
         "update_type": "replace",
-        "update_frequency": 3000,
+        "update_frequency": 1000,
         "gpu": true
       }
     }],

--- a/slm_lab/spec/experimental/ddqn_enduro.json
+++ b/slm_lab/spec/experimental/ddqn_enduro.json
@@ -50,9 +50,8 @@
           "momentum": 0.95
         },
         "lr_scheduler_spec": null,
-        "update_type": "polyak",
-        "update_frequency": 10,
-        "polyak_coef": 0.992,
+        "update_type": "replace",
+        "update_frequency": 5000,
         "gpu": true
       }
     }],

--- a/slm_lab/spec/experimental/ddqn_enduro.json
+++ b/slm_lab/spec/experimental/ddqn_enduro.json
@@ -1,5 +1,5 @@
 {
-  "ddqn_enduro_2k": {
+  "ddqn_enduro": {
     "agent": [{
       "name": "DoubleDQN",
       "algorithm": {
@@ -48,7 +48,7 @@
         },
         "lr_scheduler_spec": null,
         "update_type": "replace",
-        "update_frequency": 2000,
+        "update_frequency": 1000,
         "gpu": true
       }
     }],

--- a/slm_lab/spec/experimental/ddqn_enduro.json
+++ b/slm_lab/spec/experimental/ddqn_enduro.json
@@ -48,7 +48,7 @@
         },
         "lr_scheduler_spec": null,
         "update_type": "replace",
-        "update_frequency": 1000,
+        "update_frequency": 3000,
         "gpu": true
       }
     }],

--- a/slm_lab/spec/experimental/ddqn_enduro.json
+++ b/slm_lab/spec/experimental/ddqn_enduro.json
@@ -38,7 +38,7 @@
         "hid_layers_activation": "relu",
         "init_fn": null,
         "batch_norm": false,
-        "clip_grad_val": 1.0,
+        "clip_grad_val": 10.0,
         "loss_spec": {
           "name": "SmoothL1Loss"
         },

--- a/slm_lab/spec/experimental/ddqn_mspacman.json
+++ b/slm_lab/spec/experimental/ddqn_mspacman.json
@@ -48,7 +48,7 @@
         },
         "lr_scheduler_spec": null,
         "update_type": "replace",
-        "update_frequency": 1000,
+        "update_frequency": 2000,
         "gpu": true
       }
     }],

--- a/slm_lab/spec/experimental/ddqn_mspacman.json
+++ b/slm_lab/spec/experimental/ddqn_mspacman.json
@@ -43,15 +43,12 @@
           "name": "SmoothL1Loss"
         },
         "optim_spec": {
-          "name": "RMSprop",
-          "lr": 2.5e-4,
-          "alpha": 0.95,
-          "eps": 1e-1,
-          "momentum": 0.95
+          "name": "Adam",
+          "lr": 1e-4,
         },
         "lr_scheduler_spec": null,
         "update_type": "replace",
-        "update_frequency": 5000,
+        "update_frequency": 1000,
         "gpu": true
       }
     }],

--- a/slm_lab/spec/experimental/ddqn_mspacman.json
+++ b/slm_lab/spec/experimental/ddqn_mspacman.json
@@ -1,5 +1,5 @@
 {
-  "ddqn_mspacman": {
+  "ddqn_mspacman_2k": {
     "agent": [{
       "name": "DoubleDQN",
       "algorithm": {

--- a/slm_lab/spec/experimental/ddqn_mspacman.json
+++ b/slm_lab/spec/experimental/ddqn_mspacman.json
@@ -48,7 +48,7 @@
         },
         "lr_scheduler_spec": null,
         "update_type": "replace",
-        "update_frequency": 3000,
+        "update_frequency": 1000,
         "gpu": true
       }
     }],

--- a/slm_lab/spec/experimental/ddqn_mspacman.json
+++ b/slm_lab/spec/experimental/ddqn_mspacman.json
@@ -50,9 +50,8 @@
           "momentum": 0.95
         },
         "lr_scheduler_spec": null,
-        "update_type": "polyak",
-        "update_frequency": 10,
-        "polyak_coef": 0.992,
+        "update_type": "replace",
+        "update_frequency": 5000,
         "gpu": true
       }
     }],

--- a/slm_lab/spec/experimental/ddqn_mspacman.json
+++ b/slm_lab/spec/experimental/ddqn_mspacman.json
@@ -48,7 +48,7 @@
         },
         "lr_scheduler_spec": null,
         "update_type": "replace",
-        "update_frequency": 1000,
+        "update_frequency": 3000,
         "gpu": true
       }
     }],

--- a/slm_lab/spec/experimental/ddqn_mspacman.json
+++ b/slm_lab/spec/experimental/ddqn_mspacman.json
@@ -1,5 +1,5 @@
 {
-  "ddqn_mspacman_2k": {
+  "ddqn_mspacman": {
     "agent": [{
       "name": "DoubleDQN",
       "algorithm": {
@@ -48,7 +48,7 @@
         },
         "lr_scheduler_spec": null,
         "update_type": "replace",
-        "update_frequency": 2000,
+        "update_frequency": 1000,
         "gpu": true
       }
     }],

--- a/slm_lab/spec/experimental/ddqn_mspacman.json
+++ b/slm_lab/spec/experimental/ddqn_mspacman.json
@@ -38,7 +38,7 @@
         "hid_layers_activation": "relu",
         "init_fn": null,
         "batch_norm": false,
-        "clip_grad_val": 1.0,
+        "clip_grad_val": 10.0,
         "loss_spec": {
           "name": "SmoothL1Loss"
         },

--- a/slm_lab/spec/experimental/ddqn_per_beamrider.json
+++ b/slm_lab/spec/experimental/ddqn_per_beamrider.json
@@ -1,5 +1,5 @@
 {
-  "ddqn_per_beamrider_2k": {
+  "ddqn_per_beamrider": {
     "agent": [{
       "name": "DoubleDQN",
       "algorithm": {
@@ -50,7 +50,7 @@
         },
         "lr_scheduler_spec": null,
         "update_type": "replace",
-        "update_frequency": 2000,
+        "update_frequency": 1000,
         "gpu": true
       }
     }],

--- a/slm_lab/spec/experimental/ddqn_per_beamrider.json
+++ b/slm_lab/spec/experimental/ddqn_per_beamrider.json
@@ -46,11 +46,11 @@
         },
         "optim_spec": {
           "name": "Adam",
-          "lr": 2.5e-5,
+          "lr": 5.0e-5,
         },
         "lr_scheduler_spec": null,
         "update_type": "replace",
-        "update_frequency": 3000,
+        "update_frequency": 1000,
         "gpu": true
       }
     }],

--- a/slm_lab/spec/experimental/ddqn_per_beamrider.json
+++ b/slm_lab/spec/experimental/ddqn_per_beamrider.json
@@ -50,7 +50,7 @@
         },
         "lr_scheduler_spec": null,
         "update_type": "replace",
-        "update_frequency": 1000,
+        "update_frequency": 3000,
         "gpu": true
       }
     }],

--- a/slm_lab/spec/experimental/ddqn_per_beamrider.json
+++ b/slm_lab/spec/experimental/ddqn_per_beamrider.json
@@ -40,7 +40,7 @@
         "hid_layers_activation": "relu",
         "init_fn": null,
         "batch_norm": false,
-        "clip_grad_val": 1.0,
+        "clip_grad_val": 10.0,
         "loss_spec": {
           "name": "SmoothL1Loss"
         },

--- a/slm_lab/spec/experimental/ddqn_per_beamrider.json
+++ b/slm_lab/spec/experimental/ddqn_per_beamrider.json
@@ -46,7 +46,7 @@
         },
         "optim_spec": {
           "name": "Adam",
-          "lr": 5.0e-5,
+          "lr": 2.5e-5,
         },
         "lr_scheduler_spec": null,
         "update_type": "replace",

--- a/slm_lab/spec/experimental/ddqn_per_beamrider.json
+++ b/slm_lab/spec/experimental/ddqn_per_beamrider.json
@@ -1,0 +1,81 @@
+{
+  "ddqn_beamrider": {
+    "agent": [{
+      "name": "DoubleDQN",
+      "algorithm": {
+        "name": "DoubleDQN",
+        "action_pdtype": "Argmax",
+        "action_policy": "epsilon_greedy",
+        "explore_var_spec": {
+          "name": "linear_decay",
+          "start_val": 1.0,
+          "end_val": 0.01,
+          "start_step": 10000,
+          "end_step": 1000000
+        },
+        "gamma": 0.99,
+        "training_batch_epoch": 1,
+        "training_epoch": 1,
+        "training_frequency": 4,
+        "training_start_step": 10000,
+        "normalize_state": false
+      },
+      "memory": {
+        "name": "AtariPrioritizedReplay",
+        "alpha": 0.6,
+        "epsilon": 0.0001,
+        "batch_size": 32,
+        "max_size": 200000,
+        "stack_len": 4,
+        "use_cer": false,
+      },
+      "net": {
+        "type": "ConvNet",
+        "conv_hid_layers": [
+          [32, 8, 4, 0, 1],
+          [64, 4, 2, 0, 1],
+          [64, 3, 1, 0, 1]
+        ],
+        "fc_hid_layers": [256],
+        "hid_layers_activation": "relu",
+        "init_fn": null,
+        "batch_norm": false,
+        "clip_grad_val": 1.0,
+        "loss_spec": {
+          "name": "SmoothL1Loss"
+        },
+        "optim_spec": {
+          "name": "RMSprop",
+          "lr": 6.25e-5,
+          "alpha": 0.95,
+          "eps": 1e-1,
+          "momentum": 0.95
+        },
+        "lr_scheduler_spec": null,
+        "update_type": "replace",
+        "update_frequency": 5000,
+        "gpu": true
+      }
+    }],
+    "env": [{
+      "name": "BeamRiderNoFrameskip-v4",
+      "max_t": null,
+      "max_tick": 10000000
+    }],
+    "body": {
+      "product": "outer",
+      "num": 1
+    },
+    "meta": {
+      "distributed": false,
+      "eval_frequency": 10000,
+      "max_tick_unit": "total_t",
+      "max_session": 4,
+      "max_trial": 12,
+      "search": "RandomSearch",
+      "resources": {
+        "num_cpus": 12
+      }
+    }
+  }
+}

--- a/slm_lab/spec/experimental/ddqn_per_beamrider.json
+++ b/slm_lab/spec/experimental/ddqn_per_beamrider.json
@@ -1,5 +1,5 @@
 {
-  "ddqn_per_beamrider": {
+  "ddqn_per_beamrider_2k": {
     "agent": [{
       "name": "DoubleDQN",
       "algorithm": {
@@ -50,7 +50,7 @@
         },
         "lr_scheduler_spec": null,
         "update_type": "replace",
-        "update_frequency": 1000,
+        "update_frequency": 2000,
         "gpu": true
       }
     }],

--- a/slm_lab/spec/experimental/ddqn_per_beamrider.json
+++ b/slm_lab/spec/experimental/ddqn_per_beamrider.json
@@ -1,5 +1,5 @@
 {
-  "ddqn_beamrider": {
+  "ddqn_per_beamrider": {
     "agent": [{
       "name": "DoubleDQN",
       "algorithm": {

--- a/slm_lab/spec/experimental/ddqn_per_breakout.json
+++ b/slm_lab/spec/experimental/ddqn_per_breakout.json
@@ -1,5 +1,5 @@
 {
-  "ddqn_per_breakout_2k": {
+  "ddqn_per_breakout": {
     "agent": [{
       "name": "DoubleDQN",
       "algorithm": {
@@ -50,7 +50,7 @@
         },
         "lr_scheduler_spec": null,
         "update_type": "replace",
-        "update_frequency": 2000,
+        "update_frequency": 1000,
         "gpu": true
       }
     }],

--- a/slm_lab/spec/experimental/ddqn_per_breakout.json
+++ b/slm_lab/spec/experimental/ddqn_per_breakout.json
@@ -46,11 +46,11 @@
         },
         "optim_spec": {
           "name": "Adam",
-          "lr": 2.5e-5,
+          "lr": 5.0e-5,
         },
         "lr_scheduler_spec": null,
         "update_type": "replace",
-        "update_frequency": 3000,
+        "update_frequency": 1000,
         "gpu": true
       }
     }],

--- a/slm_lab/spec/experimental/ddqn_per_breakout.json
+++ b/slm_lab/spec/experimental/ddqn_per_breakout.json
@@ -1,5 +1,5 @@
 {
-  "ddqn_per_breakout": {
+  "ddqn_per_breakout_2k": {
     "agent": [{
       "name": "DoubleDQN",
       "algorithm": {
@@ -50,7 +50,7 @@
         },
         "lr_scheduler_spec": null,
         "update_type": "replace",
-        "update_frequency": 1000,
+        "update_frequency": 2000,
         "gpu": true
       }
     }],

--- a/slm_lab/spec/experimental/ddqn_per_breakout.json
+++ b/slm_lab/spec/experimental/ddqn_per_breakout.json
@@ -50,7 +50,7 @@
         },
         "lr_scheduler_spec": null,
         "update_type": "replace",
-        "update_frequency": 1000,
+        "update_frequency": 3000,
         "gpu": true
       }
     }],

--- a/slm_lab/spec/experimental/ddqn_per_breakout.json
+++ b/slm_lab/spec/experimental/ddqn_per_breakout.json
@@ -40,7 +40,7 @@
         "hid_layers_activation": "relu",
         "init_fn": null,
         "batch_norm": false,
-        "clip_grad_val": 1.0,
+        "clip_grad_val": 10.0,
         "loss_spec": {
           "name": "SmoothL1Loss"
         },

--- a/slm_lab/spec/experimental/ddqn_per_breakout.json
+++ b/slm_lab/spec/experimental/ddqn_per_breakout.json
@@ -1,5 +1,5 @@
 {
-  "ddqn_per_beamrider": {
+  "ddqn_breakout": {
     "agent": [{
       "name": "DoubleDQN",
       "algorithm": {
@@ -27,7 +27,7 @@
         "batch_size": 32,
         "max_size": 200000,
         "stack_len": 4,
-        "use_cer": false,
+        "use_cer": false
       },
       "net": {
         "type": "ConvNet",
@@ -46,7 +46,7 @@
         },
         "optim_spec": {
           "name": "RMSprop",
-          "lr": 6.25e-5,
+          "lr": 2.5e-4,
           "alpha": 0.95,
           "eps": 1e-1,
           "momentum": 0.95
@@ -59,7 +59,7 @@
       }
     }],
     "env": [{
-      "name": "BeamRiderNoFrameskip-v4",
+      "name": "BreakoutNoFrameskip-v4",
       "max_t": null,
       "max_tick": 10000000
     }],
@@ -72,10 +72,10 @@
       "eval_frequency": 10000,
       "max_tick_unit": "total_t",
       "max_session": 4,
-      "max_trial": 12,
+      "max_trial": 16,
       "search": "RandomSearch",
       "resources": {
-        "num_cpus": 12
+        "num_cpus": 16
       }
     }
   }

--- a/slm_lab/spec/experimental/ddqn_per_breakout.json
+++ b/slm_lab/spec/experimental/ddqn_per_breakout.json
@@ -46,7 +46,7 @@
         },
         "optim_spec": {
           "name": "Adam",
-          "lr": 5.0e-5,
+          "lr": 2.5e-5,
         },
         "lr_scheduler_spec": null,
         "update_type": "replace",

--- a/slm_lab/spec/experimental/ddqn_per_breakout.json
+++ b/slm_lab/spec/experimental/ddqn_per_breakout.json
@@ -45,16 +45,12 @@
           "name": "SmoothL1Loss"
         },
         "optim_spec": {
-          "name": "RMSprop",
-          "lr": 2.5e-4,
-          "alpha": 0.95,
-          "eps": 1e-1,
-          "momentum": 0.95
+          "name": "Adam",
+          "lr": 2.5e-5,
         },
         "lr_scheduler_spec": null,
         "update_type": "replace",
-        "update_frequency": 5000,
-        "update_frequency_short": 1000,
+        "update_frequency": 1000,
         "gpu": true
       }
     }],

--- a/slm_lab/spec/experimental/ddqn_per_breakout.json
+++ b/slm_lab/spec/experimental/ddqn_per_breakout.json
@@ -1,5 +1,5 @@
 {
-  "ddqn_breakout": {
+  "ddqn_per_breakout": {
     "agent": [{
       "name": "DoubleDQN",
       "algorithm": {

--- a/slm_lab/spec/experimental/ddqn_per_enduro.json
+++ b/slm_lab/spec/experimental/ddqn_per_enduro.json
@@ -1,5 +1,5 @@
 {
-  "ddqn_per_beamrider": {
+  "ddqn_per_enduro": {
     "agent": [{
       "name": "DoubleDQN",
       "algorithm": {
@@ -27,7 +27,7 @@
         "batch_size": 32,
         "max_size": 200000,
         "stack_len": 4,
-        "use_cer": false,
+        "use_cer": false
       },
       "net": {
         "type": "ConvNet",
@@ -55,7 +55,7 @@
       }
     }],
     "env": [{
-      "name": "BeamRiderNoFrameskip-v4",
+      "name": "EnduroNoFrameskip-v4",
       "max_t": null,
       "max_tick": 10000000
     }],
@@ -68,10 +68,10 @@
       "eval_frequency": 10000,
       "max_tick_unit": "total_t",
       "max_session": 4,
-      "max_trial": 12,
+      "max_trial": 16,
       "search": "RandomSearch",
       "resources": {
-        "num_cpus": 12
+        "num_cpus": 16
       }
     }
   }

--- a/slm_lab/spec/experimental/ddqn_per_enduro.json
+++ b/slm_lab/spec/experimental/ddqn_per_enduro.json
@@ -46,11 +46,11 @@
         },
         "optim_spec": {
           "name": "Adam",
-          "lr": 2.5e-5,
+          "lr": 5.0e-5,
         },
         "lr_scheduler_spec": null,
         "update_type": "replace",
-        "update_frequency": 3000,
+        "update_frequency": 1000,
         "gpu": true
       }
     }],

--- a/slm_lab/spec/experimental/ddqn_per_enduro.json
+++ b/slm_lab/spec/experimental/ddqn_per_enduro.json
@@ -50,7 +50,7 @@
         },
         "lr_scheduler_spec": null,
         "update_type": "replace",
-        "update_frequency": 1000,
+        "update_frequency": 3000,
         "gpu": true
       }
     }],

--- a/slm_lab/spec/experimental/ddqn_per_enduro.json
+++ b/slm_lab/spec/experimental/ddqn_per_enduro.json
@@ -40,7 +40,7 @@
         "hid_layers_activation": "relu",
         "init_fn": null,
         "batch_norm": false,
-        "clip_grad_val": 1.0,
+        "clip_grad_val": 10.0,
         "loss_spec": {
           "name": "SmoothL1Loss"
         },

--- a/slm_lab/spec/experimental/ddqn_per_enduro.json
+++ b/slm_lab/spec/experimental/ddqn_per_enduro.json
@@ -46,7 +46,7 @@
         },
         "optim_spec": {
           "name": "Adam",
-          "lr": 5.0e-5,
+          "lr": 2.5e-5,
         },
         "lr_scheduler_spec": null,
         "update_type": "replace",

--- a/slm_lab/spec/experimental/ddqn_per_enduro.json
+++ b/slm_lab/spec/experimental/ddqn_per_enduro.json
@@ -50,7 +50,7 @@
         },
         "lr_scheduler_spec": null,
         "update_type": "replace",
-        "update_frequency": 1000,
+        "update_frequency": 2000,
         "gpu": true
       }
     }],

--- a/slm_lab/spec/experimental/ddqn_per_enduro.json
+++ b/slm_lab/spec/experimental/ddqn_per_enduro.json
@@ -1,5 +1,5 @@
 {
-  "ddqn_per_enduro": {
+  "ddqn_per_enduro_2k": {
     "agent": [{
       "name": "DoubleDQN",
       "algorithm": {

--- a/slm_lab/spec/experimental/ddqn_per_enduro.json
+++ b/slm_lab/spec/experimental/ddqn_per_enduro.json
@@ -1,5 +1,5 @@
 {
-  "ddqn_per_enduro_2k": {
+  "ddqn_per_enduro": {
     "agent": [{
       "name": "DoubleDQN",
       "algorithm": {
@@ -50,7 +50,7 @@
         },
         "lr_scheduler_spec": null,
         "update_type": "replace",
-        "update_frequency": 2000,
+        "update_frequency": 1000,
         "gpu": true
       }
     }],

--- a/slm_lab/spec/experimental/ddqn_per_mspacman.json
+++ b/slm_lab/spec/experimental/ddqn_per_mspacman.json
@@ -46,11 +46,11 @@
         },
         "optim_spec": {
           "name": "Adam",
-          "lr": 2.5e-5,
+          "lr": 5.0e-5,
         },
         "lr_scheduler_spec": null,
         "update_type": "replace",
-        "update_frequency": 3000,
+        "update_frequency": 1000,
         "gpu": true
       }
     }],

--- a/slm_lab/spec/experimental/ddqn_per_mspacman.json
+++ b/slm_lab/spec/experimental/ddqn_per_mspacman.json
@@ -50,7 +50,7 @@
         },
         "lr_scheduler_spec": null,
         "update_type": "replace",
-        "update_frequency": 1000,
+        "update_frequency": 3000,
         "gpu": true
       }
     }],

--- a/slm_lab/spec/experimental/ddqn_per_mspacman.json
+++ b/slm_lab/spec/experimental/ddqn_per_mspacman.json
@@ -40,7 +40,7 @@
         "hid_layers_activation": "relu",
         "init_fn": null,
         "batch_norm": false,
-        "clip_grad_val": 1.0,
+        "clip_grad_val": 10.0,
         "loss_spec": {
           "name": "SmoothL1Loss"
         },

--- a/slm_lab/spec/experimental/ddqn_per_mspacman.json
+++ b/slm_lab/spec/experimental/ddqn_per_mspacman.json
@@ -46,7 +46,7 @@
         },
         "optim_spec": {
           "name": "Adam",
-          "lr": 5.0e-5,
+          "lr": 2.5e-5,
         },
         "lr_scheduler_spec": null,
         "update_type": "replace",

--- a/slm_lab/spec/experimental/ddqn_per_mspacman.json
+++ b/slm_lab/spec/experimental/ddqn_per_mspacman.json
@@ -50,7 +50,7 @@
         },
         "lr_scheduler_spec": null,
         "update_type": "replace",
-        "update_frequency": 1000,
+        "update_frequency": 2000,
         "gpu": true
       }
     }],

--- a/slm_lab/spec/experimental/ddqn_per_mspacman.json
+++ b/slm_lab/spec/experimental/ddqn_per_mspacman.json
@@ -1,5 +1,5 @@
 {
-  "ddqn_per_mspacman": {
+  "ddqn_per_mspacman_2k": {
     "agent": [{
       "name": "DoubleDQN",
       "algorithm": {

--- a/slm_lab/spec/experimental/ddqn_per_mspacman.json
+++ b/slm_lab/spec/experimental/ddqn_per_mspacman.json
@@ -1,5 +1,5 @@
 {
-  "ddqn_per_mspacman_2k": {
+  "ddqn_per_mspacman": {
     "agent": [{
       "name": "DoubleDQN",
       "algorithm": {
@@ -50,7 +50,7 @@
         },
         "lr_scheduler_spec": null,
         "update_type": "replace",
-        "update_frequency": 2000,
+        "update_frequency": 1000,
         "gpu": true
       }
     }],

--- a/slm_lab/spec/experimental/ddqn_per_mspacman.json
+++ b/slm_lab/spec/experimental/ddqn_per_mspacman.json
@@ -1,5 +1,5 @@
 {
-  "ddqn_per_beamrider": {
+  "ddqn_per_mspacman": {
     "agent": [{
       "name": "DoubleDQN",
       "algorithm": {
@@ -27,7 +27,7 @@
         "batch_size": 32,
         "max_size": 200000,
         "stack_len": 4,
-        "use_cer": false,
+        "use_cer": false
       },
       "net": {
         "type": "ConvNet",
@@ -55,7 +55,7 @@
       }
     }],
     "env": [{
-      "name": "BeamRiderNoFrameskip-v4",
+      "name": "MsPacmanNoFrameskip-v4",
       "max_t": null,
       "max_tick": 10000000
     }],
@@ -68,10 +68,10 @@
       "eval_frequency": 10000,
       "max_tick_unit": "total_t",
       "max_session": 4,
-      "max_trial": 12,
+      "max_trial": 16,
       "search": "RandomSearch",
       "resources": {
-        "num_cpus": 12
+        "num_cpus": 16
       }
     }
   }

--- a/slm_lab/spec/experimental/ddqn_per_pong.json
+++ b/slm_lab/spec/experimental/ddqn_per_pong.json
@@ -1,5 +1,5 @@
 {
-  "ddqn_per_pong": {
+  "ddqn_per_pong_2k": {
     "agent": [{
       "name": "DoubleDQN",
       "algorithm": {
@@ -50,7 +50,7 @@
         },
         "lr_scheduler_spec": null,
         "update_type": "replace",
-        "update_frequency": 1000,
+        "update_frequency": 2000,
         "gpu": true
       }
     }],

--- a/slm_lab/spec/experimental/ddqn_per_pong.json
+++ b/slm_lab/spec/experimental/ddqn_per_pong.json
@@ -1,5 +1,5 @@
 {
-  "ddqn_per_pong_2k": {
+  "ddqn_per_pong": {
     "agent": [{
       "name": "DoubleDQN",
       "algorithm": {
@@ -50,7 +50,7 @@
         },
         "lr_scheduler_spec": null,
         "update_type": "replace",
-        "update_frequency": 2000,
+        "update_frequency": 1000,
         "gpu": true
       }
     }],

--- a/slm_lab/spec/experimental/ddqn_per_pong.json
+++ b/slm_lab/spec/experimental/ddqn_per_pong.json
@@ -1,5 +1,5 @@
 {
-  "ddqn_pong": {
+  "ddqn_per_pong": {
     "agent": [{
       "name": "DoubleDQN",
       "algorithm": {

--- a/slm_lab/spec/experimental/ddqn_per_pong.json
+++ b/slm_lab/spec/experimental/ddqn_per_pong.json
@@ -46,11 +46,11 @@
         },
         "optim_spec": {
           "name": "Adam",
-          "lr": 2.5e-5,
+          "lr": 5.0e-5,
         },
         "lr_scheduler_spec": null,
         "update_type": "replace",
-        "update_frequency": 3000,
+        "update_frequency": 1000,
         "gpu": true
       }
     }],

--- a/slm_lab/spec/experimental/ddqn_per_pong.json
+++ b/slm_lab/spec/experimental/ddqn_per_pong.json
@@ -50,7 +50,7 @@
         },
         "lr_scheduler_spec": null,
         "update_type": "replace",
-        "update_frequency": 1000,
+        "update_frequency": 3000,
         "gpu": true
       }
     }],

--- a/slm_lab/spec/experimental/ddqn_per_pong.json
+++ b/slm_lab/spec/experimental/ddqn_per_pong.json
@@ -45,16 +45,12 @@
           "name": "SmoothL1Loss"
         },
         "optim_spec": {
-          "name": "RMSprop",
-          "lr": 6.25e-5,
-          "alpha": 0.95,
-          "eps": 1e-1,
-          "momentum": 0.95
+          "name": "Adam",
+          "lr": 2.5e-5,
         },
         "lr_scheduler_spec": null,
         "update_type": "replace",
-        "update_frequency": 5000,
-        "update_frequency_short": 1000,
+        "update_frequency": 1000,
         "gpu": true
       }
     }],

--- a/slm_lab/spec/experimental/ddqn_per_pong.json
+++ b/slm_lab/spec/experimental/ddqn_per_pong.json
@@ -40,7 +40,7 @@
         "hid_layers_activation": "relu",
         "init_fn": null,
         "batch_norm": false,
-        "clip_grad_val": 1.0,
+        "clip_grad_val": 10.0,
         "loss_spec": {
           "name": "SmoothL1Loss"
         },

--- a/slm_lab/spec/experimental/ddqn_per_pong.json
+++ b/slm_lab/spec/experimental/ddqn_per_pong.json
@@ -54,6 +54,7 @@
         "lr_scheduler_spec": null,
         "update_type": "replace",
         "update_frequency": 5000,
+        "update_frequency_short": 1000,
         "gpu": true
       }
     }],

--- a/slm_lab/spec/experimental/ddqn_per_pong.json
+++ b/slm_lab/spec/experimental/ddqn_per_pong.json
@@ -46,7 +46,7 @@
         },
         "optim_spec": {
           "name": "Adam",
-          "lr": 5.0e-5,
+          "lr": 2.5e-5,
         },
         "lr_scheduler_spec": null,
         "update_type": "replace",

--- a/slm_lab/spec/experimental/ddqn_per_pong.json
+++ b/slm_lab/spec/experimental/ddqn_per_pong.json
@@ -1,0 +1,81 @@
+{
+  "ddqn_pong": {
+    "agent": [{
+      "name": "DoubleDQN",
+      "algorithm": {
+        "name": "DoubleDQN",
+        "action_pdtype": "Argmax",
+        "action_policy": "epsilon_greedy",
+        "explore_var_spec": {
+          "name": "linear_decay",
+          "start_val": 1.0,
+          "end_val": 0.01,
+          "start_step": 10000,
+          "end_step": 1000000
+        },
+        "gamma": 0.99,
+        "training_batch_epoch": 1,
+        "training_epoch": 1,
+        "training_frequency": 4,
+        "training_start_step": 10000,
+        "normalize_state": false
+      },
+      "memory": {
+        "name": "AtariPrioritizedReplay",
+        "alpha": 0.6,
+        "epsilon": 0.0001,
+        "batch_size": 32,
+        "max_size": 200000,
+        "stack_len": 4,
+        "use_cer": false
+      },
+      "net": {
+        "type": "ConvNet",
+        "conv_hid_layers": [
+          [32, 8, 4, 0, 1],
+          [64, 4, 2, 0, 1],
+          [64, 3, 1, 0, 1]
+        ],
+        "fc_hid_layers": [256],
+        "hid_layers_activation": "relu",
+        "init_fn": null,
+        "batch_norm": false,
+        "clip_grad_val": 1.0,
+        "loss_spec": {
+          "name": "SmoothL1Loss"
+        },
+        "optim_spec": {
+          "name": "RMSprop",
+          "lr": 6.25e-5,
+          "alpha": 0.95,
+          "eps": 1e-1,
+          "momentum": 0.95
+        },
+        "lr_scheduler_spec": null,
+        "update_type": "replace",
+        "update_frequency": 5000,
+        "gpu": true
+      }
+    }],
+    "env": [{
+      "name": "PongNoFrameskip-v4",
+      "max_t": null,
+      "max_tick": 10000000
+    }],
+    "body": {
+      "product": "outer",
+      "num": 1
+    },
+    "meta": {
+      "distributed": false,
+      "eval_frequency": 10000,
+      "max_tick_unit": "total_t",
+      "max_session": 4,
+      "max_trial": 16,
+      "search": "RandomSearch",
+      "resources": {
+        "num_cpus": 16
+      }
+    }
+  }
+}

--- a/slm_lab/spec/experimental/ddqn_per_qbert.json
+++ b/slm_lab/spec/experimental/ddqn_per_qbert.json
@@ -46,11 +46,11 @@
         },
         "optim_spec": {
           "name": "Adam",
-          "lr": 2.5e-5,
+          "lr": 5.0e-5,
         },
         "lr_scheduler_spec": null,
         "update_type": "replace",
-        "update_frequency": 3000,
+        "update_frequency": 1000,
         "gpu": true
       }
     }],

--- a/slm_lab/spec/experimental/ddqn_per_qbert.json
+++ b/slm_lab/spec/experimental/ddqn_per_qbert.json
@@ -1,5 +1,5 @@
 {
-  "ddqn_per_qbert_2k": {
+  "ddqn_per_qbert": {
     "agent": [{
       "name": "DoubleDQN",
       "algorithm": {
@@ -50,7 +50,7 @@
         },
         "lr_scheduler_spec": null,
         "update_type": "replace",
-        "update_frequency": 2000,
+        "update_frequency": 1000,
         "gpu": true
       }
     }],

--- a/slm_lab/spec/experimental/ddqn_per_qbert.json
+++ b/slm_lab/spec/experimental/ddqn_per_qbert.json
@@ -50,7 +50,7 @@
         },
         "lr_scheduler_spec": null,
         "update_type": "replace",
-        "update_frequency": 1000,
+        "update_frequency": 3000,
         "gpu": true
       }
     }],

--- a/slm_lab/spec/experimental/ddqn_per_qbert.json
+++ b/slm_lab/spec/experimental/ddqn_per_qbert.json
@@ -40,7 +40,7 @@
         "hid_layers_activation": "relu",
         "init_fn": null,
         "batch_norm": false,
-        "clip_grad_val": 1.0,
+        "clip_grad_val": 10.0,
         "loss_spec": {
           "name": "SmoothL1Loss"
         },

--- a/slm_lab/spec/experimental/ddqn_per_qbert.json
+++ b/slm_lab/spec/experimental/ddqn_per_qbert.json
@@ -1,5 +1,5 @@
 {
-  "ddqn_per_beamrider": {
+  "ddqn_per_qbert": {
     "agent": [{
       "name": "DoubleDQN",
       "algorithm": {
@@ -27,7 +27,7 @@
         "batch_size": 32,
         "max_size": 200000,
         "stack_len": 4,
-        "use_cer": false,
+        "use_cer": false
       },
       "net": {
         "type": "ConvNet",
@@ -55,7 +55,7 @@
       }
     }],
     "env": [{
-      "name": "BeamRiderNoFrameskip-v4",
+      "name": "QbertNoFrameskip-v4",
       "max_t": null,
       "max_tick": 10000000
     }],
@@ -68,10 +68,10 @@
       "eval_frequency": 10000,
       "max_tick_unit": "total_t",
       "max_session": 4,
-      "max_trial": 12,
+      "max_trial": 16,
       "search": "RandomSearch",
       "resources": {
-        "num_cpus": 12
+        "num_cpus": 16
       }
     }
   }

--- a/slm_lab/spec/experimental/ddqn_per_qbert.json
+++ b/slm_lab/spec/experimental/ddqn_per_qbert.json
@@ -46,7 +46,7 @@
         },
         "optim_spec": {
           "name": "Adam",
-          "lr": 5.0e-5,
+          "lr": 2.5e-5,
         },
         "lr_scheduler_spec": null,
         "update_type": "replace",

--- a/slm_lab/spec/experimental/ddqn_per_qbert.json
+++ b/slm_lab/spec/experimental/ddqn_per_qbert.json
@@ -1,5 +1,5 @@
 {
-  "ddqn_per_qbert": {
+  "ddqn_per_qbert_2k": {
     "agent": [{
       "name": "DoubleDQN",
       "algorithm": {

--- a/slm_lab/spec/experimental/ddqn_per_qbert.json
+++ b/slm_lab/spec/experimental/ddqn_per_qbert.json
@@ -50,7 +50,7 @@
         },
         "lr_scheduler_spec": null,
         "update_type": "replace",
-        "update_frequency": 1000,
+        "update_frequency": 2000,
         "gpu": true
       }
     }],

--- a/slm_lab/spec/experimental/ddqn_per_seaquest.json
+++ b/slm_lab/spec/experimental/ddqn_per_seaquest.json
@@ -1,5 +1,5 @@
 {
-  "ddqn_per_seaquest": {
+  "ddqn_per_seaquest_2k": {
     "agent": [{
       "name": "DoubleDQN",
       "algorithm": {

--- a/slm_lab/spec/experimental/ddqn_per_seaquest.json
+++ b/slm_lab/spec/experimental/ddqn_per_seaquest.json
@@ -46,11 +46,11 @@
         },
         "optim_spec": {
           "name": "Adam",
-          "lr": 2.5e-5,
+          "lr": 5.0e-5,
         },
         "lr_scheduler_spec": null,
         "update_type": "replace",
-        "update_frequency": 3000,
+        "update_frequency": 1000,
         "gpu": true
       }
     }],

--- a/slm_lab/spec/experimental/ddqn_per_seaquest.json
+++ b/slm_lab/spec/experimental/ddqn_per_seaquest.json
@@ -1,5 +1,5 @@
 {
-  "ddqn_per_seaquest_2k": {
+  "ddqn_per_seaquest": {
     "agent": [{
       "name": "DoubleDQN",
       "algorithm": {
@@ -50,7 +50,7 @@
         },
         "lr_scheduler_spec": null,
         "update_type": "replace",
-        "update_frequency": 2000,
+        "update_frequency": 1000,
         "gpu": true
       }
     }],

--- a/slm_lab/spec/experimental/ddqn_per_seaquest.json
+++ b/slm_lab/spec/experimental/ddqn_per_seaquest.json
@@ -50,7 +50,7 @@
         },
         "lr_scheduler_spec": null,
         "update_type": "replace",
-        "update_frequency": 1000,
+        "update_frequency": 3000,
         "gpu": true
       }
     }],

--- a/slm_lab/spec/experimental/ddqn_per_seaquest.json
+++ b/slm_lab/spec/experimental/ddqn_per_seaquest.json
@@ -40,7 +40,7 @@
         "hid_layers_activation": "relu",
         "init_fn": null,
         "batch_norm": false,
-        "clip_grad_val": 1.0,
+        "clip_grad_val": 10.0,
         "loss_spec": {
           "name": "SmoothL1Loss"
         },

--- a/slm_lab/spec/experimental/ddqn_per_seaquest.json
+++ b/slm_lab/spec/experimental/ddqn_per_seaquest.json
@@ -1,5 +1,5 @@
 {
-  "ddqn_per_beamrider": {
+  "ddqn_per_seaquest": {
     "agent": [{
       "name": "DoubleDQN",
       "algorithm": {
@@ -27,7 +27,7 @@
         "batch_size": 32,
         "max_size": 200000,
         "stack_len": 4,
-        "use_cer": false,
+        "use_cer": false
       },
       "net": {
         "type": "ConvNet",
@@ -55,7 +55,7 @@
       }
     }],
     "env": [{
-      "name": "BeamRiderNoFrameskip-v4",
+      "name": "SeaquestNoFrameskip-v4",
       "max_t": null,
       "max_tick": 10000000
     }],
@@ -68,10 +68,10 @@
       "eval_frequency": 10000,
       "max_tick_unit": "total_t",
       "max_session": 4,
-      "max_trial": 12,
+      "max_trial": 16,
       "search": "RandomSearch",
       "resources": {
-        "num_cpus": 12
+        "num_cpus": 16
       }
     }
   }

--- a/slm_lab/spec/experimental/ddqn_per_seaquest.json
+++ b/slm_lab/spec/experimental/ddqn_per_seaquest.json
@@ -46,7 +46,7 @@
         },
         "optim_spec": {
           "name": "Adam",
-          "lr": 5.0e-5,
+          "lr": 2.5e-5,
         },
         "lr_scheduler_spec": null,
         "update_type": "replace",

--- a/slm_lab/spec/experimental/ddqn_per_seaquest.json
+++ b/slm_lab/spec/experimental/ddqn_per_seaquest.json
@@ -50,7 +50,7 @@
         },
         "lr_scheduler_spec": null,
         "update_type": "replace",
-        "update_frequency": 1000,
+        "update_frequency": 2000,
         "gpu": true
       }
     }],

--- a/slm_lab/spec/experimental/ddqn_per_spaceinvaders.json
+++ b/slm_lab/spec/experimental/ddqn_per_spaceinvaders.json
@@ -1,5 +1,5 @@
 {
-  "ddqn_per_spaceinvaders_2k": {
+  "ddqn_per_spaceinvaders": {
     "agent": [{
       "name": "DoubleDQN",
       "algorithm": {
@@ -50,7 +50,7 @@
         },
         "lr_scheduler_spec": null,
         "update_type": "replace",
-        "update_frequency": 2000,
+        "update_frequency": 1000,
         "gpu": true
       }
     }],

--- a/slm_lab/spec/experimental/ddqn_per_spaceinvaders.json
+++ b/slm_lab/spec/experimental/ddqn_per_spaceinvaders.json
@@ -46,11 +46,11 @@
         },
         "optim_spec": {
           "name": "Adam",
-          "lr": 2.5e-5,
+          "lr": 5.0e-5,
         },
         "lr_scheduler_spec": null,
         "update_type": "replace",
-        "update_frequency": 3000,
+        "update_frequency": 1000,
         "gpu": true
       }
     }],

--- a/slm_lab/spec/experimental/ddqn_per_spaceinvaders.json
+++ b/slm_lab/spec/experimental/ddqn_per_spaceinvaders.json
@@ -50,7 +50,7 @@
         },
         "lr_scheduler_spec": null,
         "update_type": "replace",
-        "update_frequency": 1000,
+        "update_frequency": 3000,
         "gpu": true
       }
     }],

--- a/slm_lab/spec/experimental/ddqn_per_spaceinvaders.json
+++ b/slm_lab/spec/experimental/ddqn_per_spaceinvaders.json
@@ -40,7 +40,7 @@
         "hid_layers_activation": "relu",
         "init_fn": null,
         "batch_norm": false,
-        "clip_grad_val": 1.0,
+        "clip_grad_val": 10.0,
         "loss_spec": {
           "name": "SmoothL1Loss"
         },

--- a/slm_lab/spec/experimental/ddqn_per_spaceinvaders.json
+++ b/slm_lab/spec/experimental/ddqn_per_spaceinvaders.json
@@ -46,7 +46,7 @@
         },
         "optim_spec": {
           "name": "Adam",
-          "lr": 5.0e-5,
+          "lr": 2.5e-5,
         },
         "lr_scheduler_spec": null,
         "update_type": "replace",

--- a/slm_lab/spec/experimental/ddqn_per_spaceinvaders.json
+++ b/slm_lab/spec/experimental/ddqn_per_spaceinvaders.json
@@ -1,5 +1,5 @@
 {
-  "ddqn_per_beamrider": {
+  "ddqn_per_spaceinvaders": {
     "agent": [{
       "name": "DoubleDQN",
       "algorithm": {
@@ -27,7 +27,7 @@
         "batch_size": 32,
         "max_size": 200000,
         "stack_len": 4,
-        "use_cer": false,
+        "use_cer": false
       },
       "net": {
         "type": "ConvNet",
@@ -55,7 +55,7 @@
       }
     }],
     "env": [{
-      "name": "BeamRiderNoFrameskip-v4",
+      "name": "SpaceInvadersNoFrameskip-v4",
       "max_t": null,
       "max_tick": 10000000
     }],
@@ -68,10 +68,10 @@
       "eval_frequency": 10000,
       "max_tick_unit": "total_t",
       "max_session": 4,
-      "max_trial": 12,
+      "max_trial": 16,
       "search": "RandomSearch",
       "resources": {
-        "num_cpus": 12
+        "num_cpus": 16
       }
     }
   }

--- a/slm_lab/spec/experimental/ddqn_per_spaceinvaders.json
+++ b/slm_lab/spec/experimental/ddqn_per_spaceinvaders.json
@@ -50,7 +50,7 @@
         },
         "lr_scheduler_spec": null,
         "update_type": "replace",
-        "update_frequency": 1000,
+        "update_frequency": 2000,
         "gpu": true
       }
     }],

--- a/slm_lab/spec/experimental/ddqn_per_spaceinvaders.json
+++ b/slm_lab/spec/experimental/ddqn_per_spaceinvaders.json
@@ -1,5 +1,5 @@
 {
-  "ddqn_per_spaceinvaders": {
+  "ddqn_per_spaceinvaders_2k": {
     "agent": [{
       "name": "DoubleDQN",
       "algorithm": {

--- a/slm_lab/spec/experimental/ddqn_pong.json
+++ b/slm_lab/spec/experimental/ddqn_pong.json
@@ -51,7 +51,7 @@
         },
         "lr_scheduler_spec": null,
         "update_type": "replace",
-        "update_frequency": 5000,
+        "update_frequency": 1000,
         "gpu": true
       }
     }],

--- a/slm_lab/spec/experimental/ddqn_pong.json
+++ b/slm_lab/spec/experimental/ddqn_pong.json
@@ -49,7 +49,7 @@
         "lr_scheduler_spec": null,
         "update_type": "replace",
         "update_frequency": 1000,
-        "update_frequency_short": 1000,
+        "update_frequency_short": 1,
         "gpu": true
       }
     }],

--- a/slm_lab/spec/experimental/ddqn_pong.json
+++ b/slm_lab/spec/experimental/ddqn_pong.json
@@ -49,7 +49,6 @@
         "lr_scheduler_spec": null,
         "update_type": "replace",
         "update_frequency": 1000,
-        "update_frequency_short": 1,
         "gpu": true
       }
     }],

--- a/slm_lab/spec/experimental/ddqn_pong.json
+++ b/slm_lab/spec/experimental/ddqn_pong.json
@@ -1,5 +1,5 @@
 {
-  "ddqn_pong_2k": {
+  "ddqn_pong": {
     "agent": [{
       "name": "DoubleDQN",
       "algorithm": {
@@ -48,7 +48,7 @@
         },
         "lr_scheduler_spec": null,
         "update_type": "replace",
-        "update_frequency": 2000,
+        "update_frequency": 1000,
         "gpu": true
       }
     }],

--- a/slm_lab/spec/experimental/ddqn_pong.json
+++ b/slm_lab/spec/experimental/ddqn_pong.json
@@ -48,7 +48,7 @@
         },
         "lr_scheduler_spec": null,
         "update_type": "replace",
-        "update_frequency": 3000,
+        "update_frequency": 1000,
         "gpu": true
       }
     }],

--- a/slm_lab/spec/experimental/ddqn_pong.json
+++ b/slm_lab/spec/experimental/ddqn_pong.json
@@ -50,9 +50,8 @@
           "momentum": 0.95
         },
         "lr_scheduler_spec": null,
-        "update_type": "polyak",
-        "update_frequency": 10,
-        "polyak_coef": 0.992,
+        "update_type": "replace",
+        "update_frequency": 5000,
         "gpu": true
       }
     }],

--- a/slm_lab/spec/experimental/ddqn_pong.json
+++ b/slm_lab/spec/experimental/ddqn_pong.json
@@ -48,7 +48,7 @@
         },
         "lr_scheduler_spec": null,
         "update_type": "replace",
-        "update_frequency": 1000,
+        "update_frequency": 3000,
         "gpu": true
       }
     }],

--- a/slm_lab/spec/experimental/ddqn_pong.json
+++ b/slm_lab/spec/experimental/ddqn_pong.json
@@ -44,7 +44,7 @@
         },
         "optim_spec": {
           "name": "RMSprop",
-          "lr": 2.5e-4,
+          "lr": 7.5e-4,
           "alpha": 0.95,
           "eps": 1e-1,
           "momentum": 0.95

--- a/slm_lab/spec/experimental/ddqn_pong.json
+++ b/slm_lab/spec/experimental/ddqn_pong.json
@@ -1,5 +1,5 @@
 {
-  "ddqn_pong": {
+  "ddqn_pong_2k": {
     "agent": [{
       "name": "DoubleDQN",
       "algorithm": {
@@ -48,7 +48,7 @@
         },
         "lr_scheduler_spec": null,
         "update_type": "replace",
-        "update_frequency": 1000,
+        "update_frequency": 2000,
         "gpu": true
       }
     }],

--- a/slm_lab/spec/experimental/ddqn_pong.json
+++ b/slm_lab/spec/experimental/ddqn_pong.json
@@ -51,7 +51,8 @@
         },
         "lr_scheduler_spec": null,
         "update_type": "replace",
-        "update_frequency": 1000,
+        "update_frequency": 5000,
+        "update_frequency_short": 1000,
         "gpu": true
       }
     }],

--- a/slm_lab/spec/experimental/ddqn_pong.json
+++ b/slm_lab/spec/experimental/ddqn_pong.json
@@ -44,7 +44,7 @@
         },
         "optim_spec": {
           "name": "RMSprop",
-          "lr": 7.5e-4,
+          "lr": 2.5e-4,
           "alpha": 0.95,
           "eps": 1e-1,
           "momentum": 0.95
@@ -52,7 +52,7 @@
         "lr_scheduler_spec": null,
         "update_type": "replace",
         "update_frequency": 5000,
-        "update_frequency_short": 1000,
+        "update_frequency_short": 2500,
         "gpu": true
       }
     }],

--- a/slm_lab/spec/experimental/ddqn_pong.json
+++ b/slm_lab/spec/experimental/ddqn_pong.json
@@ -38,21 +38,18 @@
         "hid_layers_activation": "relu",
         "init_fn": null,
         "batch_norm": false,
-        "clip_grad_val": 1.0,
+        "clip_grad_val": 10.0,
         "loss_spec": {
           "name": "SmoothL1Loss"
         },
         "optim_spec": {
-          "name": "RMSprop",
-          "lr": 2.5e-4,
-          "alpha": 0.95,
-          "eps": 1e-1,
-          "momentum": 0.95
+          "name": "Adam",
+          "lr": 1e-4,
         },
         "lr_scheduler_spec": null,
         "update_type": "replace",
-        "update_frequency": 5000,
-        "update_frequency_short": 2500,
+        "update_frequency": 1000,
+        "update_frequency_short": 1000,
         "gpu": true
       }
     }],

--- a/slm_lab/spec/experimental/ddqn_qbert.json
+++ b/slm_lab/spec/experimental/ddqn_qbert.json
@@ -48,7 +48,7 @@
         },
         "lr_scheduler_spec": null,
         "update_type": "replace",
-        "update_frequency": 1000,
+        "update_frequency": 2000,
         "gpu": true
       }
     }],

--- a/slm_lab/spec/experimental/ddqn_qbert.json
+++ b/slm_lab/spec/experimental/ddqn_qbert.json
@@ -43,15 +43,12 @@
           "name": "SmoothL1Loss"
         },
         "optim_spec": {
-          "name": "RMSprop",
-          "lr": 2.5e-4,
-          "alpha": 0.95,
-          "eps": 1e-1,
-          "momentum": 0.95
+          "name": "Adam",
+          "lr": 1e-4,
         },
         "lr_scheduler_spec": null,
         "update_type": "replace",
-        "update_frequency": 5000,
+        "update_frequency": 1000,
         "gpu": true
       }
     }],

--- a/slm_lab/spec/experimental/ddqn_qbert.json
+++ b/slm_lab/spec/experimental/ddqn_qbert.json
@@ -1,5 +1,5 @@
 {
-  "ddqn_qbert": {
+  "ddqn_qbert_2k": {
     "agent": [{
       "name": "DoubleDQN",
       "algorithm": {

--- a/slm_lab/spec/experimental/ddqn_qbert.json
+++ b/slm_lab/spec/experimental/ddqn_qbert.json
@@ -1,5 +1,5 @@
 {
-  "ddqn_qbert_2k": {
+  "ddqn_qbert": {
     "agent": [{
       "name": "DoubleDQN",
       "algorithm": {
@@ -48,7 +48,7 @@
         },
         "lr_scheduler_spec": null,
         "update_type": "replace",
-        "update_frequency": 2000,
+        "update_frequency": 1000,
         "gpu": true
       }
     }],

--- a/slm_lab/spec/experimental/ddqn_qbert.json
+++ b/slm_lab/spec/experimental/ddqn_qbert.json
@@ -48,7 +48,7 @@
         },
         "lr_scheduler_spec": null,
         "update_type": "replace",
-        "update_frequency": 3000,
+        "update_frequency": 1000,
         "gpu": true
       }
     }],

--- a/slm_lab/spec/experimental/ddqn_qbert.json
+++ b/slm_lab/spec/experimental/ddqn_qbert.json
@@ -50,9 +50,8 @@
           "momentum": 0.95
         },
         "lr_scheduler_spec": null,
-        "update_type": "polyak",
-        "update_frequency": 10,
-        "polyak_coef": 0.992,
+        "update_type": "replace",
+        "update_frequency": 5000,
         "gpu": true
       }
     }],

--- a/slm_lab/spec/experimental/ddqn_qbert.json
+++ b/slm_lab/spec/experimental/ddqn_qbert.json
@@ -48,7 +48,7 @@
         },
         "lr_scheduler_spec": null,
         "update_type": "replace",
-        "update_frequency": 1000,
+        "update_frequency": 3000,
         "gpu": true
       }
     }],

--- a/slm_lab/spec/experimental/ddqn_qbert.json
+++ b/slm_lab/spec/experimental/ddqn_qbert.json
@@ -38,7 +38,7 @@
         "hid_layers_activation": "relu",
         "init_fn": null,
         "batch_norm": false,
-        "clip_grad_val": 1.0,
+        "clip_grad_val": 10.0,
         "loss_spec": {
           "name": "SmoothL1Loss"
         },

--- a/slm_lab/spec/experimental/ddqn_seaquest.json
+++ b/slm_lab/spec/experimental/ddqn_seaquest.json
@@ -48,7 +48,7 @@
         },
         "lr_scheduler_spec": null,
         "update_type": "replace",
-        "update_frequency": 1000,
+        "update_frequency": 2000,
         "gpu": true
       }
     }],

--- a/slm_lab/spec/experimental/ddqn_seaquest.json
+++ b/slm_lab/spec/experimental/ddqn_seaquest.json
@@ -43,15 +43,12 @@
           "name": "SmoothL1Loss"
         },
         "optim_spec": {
-          "name": "RMSprop",
-          "lr": 2.5e-4,
-          "alpha": 0.95,
-          "eps": 1e-1,
-          "momentum": 0.95
+          "name": "Adam",
+          "lr": 1e-4,
         },
         "lr_scheduler_spec": null,
-        "update_type": "reaplce",
-        "update_frequency": 5000,
+        "update_type": "replace",
+        "update_frequency": 1000,
         "gpu": true
       }
     }],

--- a/slm_lab/spec/experimental/ddqn_seaquest.json
+++ b/slm_lab/spec/experimental/ddqn_seaquest.json
@@ -48,7 +48,7 @@
         },
         "lr_scheduler_spec": null,
         "update_type": "replace",
-        "update_frequency": 3000,
+        "update_frequency": 1000,
         "gpu": true
       }
     }],

--- a/slm_lab/spec/experimental/ddqn_seaquest.json
+++ b/slm_lab/spec/experimental/ddqn_seaquest.json
@@ -1,5 +1,5 @@
 {
-  "ddqn_seaquest_2k": {
+  "ddqn_seaquest": {
     "agent": [{
       "name": "DoubleDQN",
       "algorithm": {
@@ -48,7 +48,7 @@
         },
         "lr_scheduler_spec": null,
         "update_type": "replace",
-        "update_frequency": 2000,
+        "update_frequency": 1000,
         "gpu": true
       }
     }],

--- a/slm_lab/spec/experimental/ddqn_seaquest.json
+++ b/slm_lab/spec/experimental/ddqn_seaquest.json
@@ -1,5 +1,5 @@
 {
-  "ddqn_seaquest": {
+  "ddqn_seaquest_2k": {
     "agent": [{
       "name": "DoubleDQN",
       "algorithm": {

--- a/slm_lab/spec/experimental/ddqn_seaquest.json
+++ b/slm_lab/spec/experimental/ddqn_seaquest.json
@@ -48,7 +48,7 @@
         },
         "lr_scheduler_spec": null,
         "update_type": "replace",
-        "update_frequency": 1000,
+        "update_frequency": 3000,
         "gpu": true
       }
     }],

--- a/slm_lab/spec/experimental/ddqn_seaquest.json
+++ b/slm_lab/spec/experimental/ddqn_seaquest.json
@@ -50,9 +50,8 @@
           "momentum": 0.95
         },
         "lr_scheduler_spec": null,
-        "update_type": "polyak",
-        "update_frequency": 10,
-        "polyak_coef": 0.992,
+        "update_type": "reaplce",
+        "update_frequency": 5000,
         "gpu": true
       }
     }],

--- a/slm_lab/spec/experimental/ddqn_seaquest.json
+++ b/slm_lab/spec/experimental/ddqn_seaquest.json
@@ -38,7 +38,7 @@
         "hid_layers_activation": "relu",
         "init_fn": null,
         "batch_norm": false,
-        "clip_grad_val": 1.0,
+        "clip_grad_val": 10.0,
         "loss_spec": {
           "name": "SmoothL1Loss"
         },

--- a/slm_lab/spec/experimental/ddqn_spaceinvaders.json
+++ b/slm_lab/spec/experimental/ddqn_spaceinvaders.json
@@ -48,7 +48,7 @@
         },
         "lr_scheduler_spec": null,
         "update_type": "replace",
-        "update_frequency": 1000,
+        "update_frequency": 2000,
         "gpu": true
       }
     }],

--- a/slm_lab/spec/experimental/ddqn_spaceinvaders.json
+++ b/slm_lab/spec/experimental/ddqn_spaceinvaders.json
@@ -1,5 +1,5 @@
 {
-  "ddqn_spaceinvaders_2k": {
+  "ddqn_spaceinvaders": {
     "agent": [{
       "name": "DoubleDQN",
       "algorithm": {
@@ -48,7 +48,7 @@
         },
         "lr_scheduler_spec": null,
         "update_type": "replace",
-        "update_frequency": 2000,
+        "update_frequency": 1000,
         "gpu": true
       }
     }],

--- a/slm_lab/spec/experimental/ddqn_spaceinvaders.json
+++ b/slm_lab/spec/experimental/ddqn_spaceinvaders.json
@@ -43,15 +43,12 @@
           "name": "SmoothL1Loss"
         },
         "optim_spec": {
-          "name": "RMSprop",
-          "lr": 2.5e-4,
-          "alpha": 0.95,
-          "eps": 1e-1,
-          "momentum": 0.95
+          "name": "Adam",
+          "lr": 1e-4,
         },
         "lr_scheduler_spec": null,
         "update_type": "replace",
-        "update_frequency": 5000,
+        "update_frequency": 1000,
         "gpu": true
       }
     }],

--- a/slm_lab/spec/experimental/ddqn_spaceinvaders.json
+++ b/slm_lab/spec/experimental/ddqn_spaceinvaders.json
@@ -48,7 +48,7 @@
         },
         "lr_scheduler_spec": null,
         "update_type": "replace",
-        "update_frequency": 3000,
+        "update_frequency": 1000,
         "gpu": true
       }
     }],

--- a/slm_lab/spec/experimental/ddqn_spaceinvaders.json
+++ b/slm_lab/spec/experimental/ddqn_spaceinvaders.json
@@ -50,9 +50,8 @@
           "momentum": 0.95
         },
         "lr_scheduler_spec": null,
-        "update_type": "polyak",
-        "update_frequency": 10,
-        "polyak_coef": 0.992,
+        "update_type": "replace",
+        "update_frequency": 5000,
         "gpu": true
       }
     }],

--- a/slm_lab/spec/experimental/ddqn_spaceinvaders.json
+++ b/slm_lab/spec/experimental/ddqn_spaceinvaders.json
@@ -48,7 +48,7 @@
         },
         "lr_scheduler_spec": null,
         "update_type": "replace",
-        "update_frequency": 1000,
+        "update_frequency": 3000,
         "gpu": true
       }
     }],

--- a/slm_lab/spec/experimental/ddqn_spaceinvaders.json
+++ b/slm_lab/spec/experimental/ddqn_spaceinvaders.json
@@ -38,7 +38,7 @@
         "hid_layers_activation": "relu",
         "init_fn": null,
         "batch_norm": false,
-        "clip_grad_val": 1.0,
+        "clip_grad_val": 10.0,
         "loss_spec": {
           "name": "SmoothL1Loss"
         },

--- a/slm_lab/spec/experimental/ddqn_spaceinvaders.json
+++ b/slm_lab/spec/experimental/ddqn_spaceinvaders.json
@@ -1,5 +1,5 @@
 {
-  "ddqn_spaceinvaders": {
+  "ddqn_spaceinvaders_2k": {
     "agent": [{
       "name": "DoubleDQN",
       "algorithm": {

--- a/slm_lab/spec/experimental/dqn_beamrider.json
+++ b/slm_lab/spec/experimental/dqn_beamrider.json
@@ -48,7 +48,7 @@
         },
         "lr_scheduler_spec": null,
         "update_type": "replace",
-        "update_frequency": 3000,
+        "update_frequency": 1000,
         "gpu": true
       }
     }],

--- a/slm_lab/spec/experimental/dqn_beamrider.json
+++ b/slm_lab/spec/experimental/dqn_beamrider.json
@@ -1,5 +1,5 @@
 {
-  "dqn_beamrider": {
+  "dqn_beamrider_2k": {
     "agent": [{
       "name": "DQN",
       "algorithm": {
@@ -48,7 +48,7 @@
         },
         "lr_scheduler_spec": null,
         "update_type": "replace",
-        "update_frequency": 1000,
+        "update_frequency": 2000,
         "gpu": true
       }
     }],

--- a/slm_lab/spec/experimental/dqn_beamrider.json
+++ b/slm_lab/spec/experimental/dqn_beamrider.json
@@ -48,7 +48,7 @@
         },
         "lr_scheduler_spec": null,
         "update_type": "replace",
-        "update_frequency": 1000,
+        "update_frequency": 3000,
         "gpu": true
       }
     }],

--- a/slm_lab/spec/experimental/dqn_beamrider.json
+++ b/slm_lab/spec/experimental/dqn_beamrider.json
@@ -1,5 +1,5 @@
 {
-  "dqn_per_beamrider": {
+  "dqn_beamrider": {
     "agent": [{
       "name": "DQN",
       "algorithm": {
@@ -21,9 +21,7 @@
         "normalize_state": false
       },
       "memory": {
-        "name": "AtariPrioritizedReplay",
-        "alpha": 0.6,
-        "epsilon": 0.0001,
+        "name": "AtariReplay",
         "batch_size": 32,
         "max_size": 200000,
         "stack_len": 4,
@@ -45,15 +43,12 @@
           "name": "SmoothL1Loss"
         },
         "optim_spec": {
-          "name": "RMSprop",
-          "lr": 6.25e-5,
-          "alpha": 0.95,
-          "eps": 1e-1,
-          "momentum": 0.95
+          "name": "Adam",
+          "lr": 1e-4,
         },
         "lr_scheduler_spec": null,
         "update_type": "replace",
-        "update_frequency": 5000,
+        "update_frequency": 1000,
         "gpu": true
       }
     }],

--- a/slm_lab/spec/experimental/dqn_beamrider.json
+++ b/slm_lab/spec/experimental/dqn_beamrider.json
@@ -38,7 +38,7 @@
         "hid_layers_activation": "relu",
         "init_fn": null,
         "batch_norm": false,
-        "clip_grad_val": 1.0,
+        "clip_grad_val": 10.0,
         "loss_spec": {
           "name": "SmoothL1Loss"
         },

--- a/slm_lab/spec/experimental/dqn_beamrider.json
+++ b/slm_lab/spec/experimental/dqn_beamrider.json
@@ -1,5 +1,5 @@
 {
-  "dqn_beamrider_2k": {
+  "dqn_beamrider": {
     "agent": [{
       "name": "DQN",
       "algorithm": {
@@ -48,7 +48,7 @@
         },
         "lr_scheduler_spec": null,
         "update_type": "replace",
-        "update_frequency": 2000,
+        "update_frequency": 1000,
         "gpu": true
       }
     }],

--- a/slm_lab/spec/experimental/dqn_breakout.json
+++ b/slm_lab/spec/experimental/dqn_breakout.json
@@ -1,5 +1,5 @@
 {
-  "dqn_per_breakout": {
+  "dqn_breakout": {
     "agent": [{
       "name": "DQN",
       "algorithm": {
@@ -21,9 +21,7 @@
         "normalize_state": false
       },
       "memory": {
-        "name": "AtariPrioritizedReplay",
-        "alpha": 0.6,
-        "epsilon": 0.0001,
+        "name": "AtariReplay",
         "batch_size": 32,
         "max_size": 200000,
         "stack_len": 4,
@@ -45,15 +43,12 @@
           "name": "SmoothL1Loss"
         },
         "optim_spec": {
-          "name": "RMSprop",
-          "lr": 6.25e-5,
-          "alpha": 0.95,
-          "eps": 1e-1,
-          "momentum": 0.95
+          "name": "Adam",
+          "lr": 1e-4,
         },
         "lr_scheduler_spec": null,
         "update_type": "replace",
-        "update_frequency": 5000,
+        "update_frequency": 1000,
         "gpu": true
       }
     }],

--- a/slm_lab/spec/experimental/dqn_breakout.json
+++ b/slm_lab/spec/experimental/dqn_breakout.json
@@ -48,7 +48,7 @@
         },
         "lr_scheduler_spec": null,
         "update_type": "replace",
-        "update_frequency": 3000,
+        "update_frequency": 1000,
         "gpu": true
       }
     }],

--- a/slm_lab/spec/experimental/dqn_breakout.json
+++ b/slm_lab/spec/experimental/dqn_breakout.json
@@ -48,7 +48,7 @@
         },
         "lr_scheduler_spec": null,
         "update_type": "replace",
-        "update_frequency": 1000,
+        "update_frequency": 3000,
         "gpu": true
       }
     }],

--- a/slm_lab/spec/experimental/dqn_breakout.json
+++ b/slm_lab/spec/experimental/dqn_breakout.json
@@ -1,5 +1,5 @@
 {
-  "dqn_breakout_2k": {
+  "dqn_breakout": {
     "agent": [{
       "name": "DQN",
       "algorithm": {
@@ -48,7 +48,7 @@
         },
         "lr_scheduler_spec": null,
         "update_type": "replace",
-        "update_frequency": 2000,
+        "update_frequency": 1000,
         "gpu": true
       }
     }],

--- a/slm_lab/spec/experimental/dqn_breakout.json
+++ b/slm_lab/spec/experimental/dqn_breakout.json
@@ -1,5 +1,5 @@
 {
-  "dqn_breakout": {
+  "dqn_breakout_2k": {
     "agent": [{
       "name": "DQN",
       "algorithm": {
@@ -48,7 +48,7 @@
         },
         "lr_scheduler_spec": null,
         "update_type": "replace",
-        "update_frequency": 1000,
+        "update_frequency": 2000,
         "gpu": true
       }
     }],

--- a/slm_lab/spec/experimental/dqn_breakout.json
+++ b/slm_lab/spec/experimental/dqn_breakout.json
@@ -38,7 +38,7 @@
         "hid_layers_activation": "relu",
         "init_fn": null,
         "batch_norm": false,
-        "clip_grad_val": 1.0,
+        "clip_grad_val": 10.0,
         "loss_spec": {
           "name": "SmoothL1Loss"
         },

--- a/slm_lab/spec/experimental/dqn_enduro.json
+++ b/slm_lab/spec/experimental/dqn_enduro.json
@@ -1,5 +1,5 @@
 {
-  "dqn_per_enduro": {
+  "dqn_enduro": {
     "agent": [{
       "name": "DQN",
       "algorithm": {
@@ -21,9 +21,7 @@
         "normalize_state": false
       },
       "memory": {
-        "name": "AtariPrioritizedReplay",
-        "alpha": 0.6,
-        "epsilon": 0.0001,
+        "name": "AtariReplay",
         "batch_size": 32,
         "max_size": 200000,
         "stack_len": 4,
@@ -45,15 +43,12 @@
           "name": "SmoothL1Loss"
         },
         "optim_spec": {
-          "name": "RMSprop",
-          "lr": 6.25e-5,
-          "alpha": 0.95,
-          "eps": 1e-1,
-          "momentum": 0.95
+          "name": "Adam",
+          "lr": 1e-4,
         },
         "lr_scheduler_spec": null,
         "update_type": "replace",
-        "update_frequency": 5000,
+        "update_frequency": 1000,
         "gpu": true
       }
     }],

--- a/slm_lab/spec/experimental/dqn_enduro.json
+++ b/slm_lab/spec/experimental/dqn_enduro.json
@@ -48,7 +48,7 @@
         },
         "lr_scheduler_spec": null,
         "update_type": "replace",
-        "update_frequency": 1000,
+        "update_frequency": 2000,
         "gpu": true
       }
     }],

--- a/slm_lab/spec/experimental/dqn_enduro.json
+++ b/slm_lab/spec/experimental/dqn_enduro.json
@@ -1,5 +1,5 @@
 {
-  "dqn_enduro_2k": {
+  "dqn_enduro": {
     "agent": [{
       "name": "DQN",
       "algorithm": {
@@ -48,7 +48,7 @@
         },
         "lr_scheduler_spec": null,
         "update_type": "replace",
-        "update_frequency": 2000,
+        "update_frequency": 1000,
         "gpu": true
       }
     }],

--- a/slm_lab/spec/experimental/dqn_enduro.json
+++ b/slm_lab/spec/experimental/dqn_enduro.json
@@ -48,7 +48,7 @@
         },
         "lr_scheduler_spec": null,
         "update_type": "replace",
-        "update_frequency": 3000,
+        "update_frequency": 1000,
         "gpu": true
       }
     }],

--- a/slm_lab/spec/experimental/dqn_enduro.json
+++ b/slm_lab/spec/experimental/dqn_enduro.json
@@ -48,7 +48,7 @@
         },
         "lr_scheduler_spec": null,
         "update_type": "replace",
-        "update_frequency": 1000,
+        "update_frequency": 3000,
         "gpu": true
       }
     }],

--- a/slm_lab/spec/experimental/dqn_enduro.json
+++ b/slm_lab/spec/experimental/dqn_enduro.json
@@ -1,5 +1,5 @@
 {
-  "dqn_enduro": {
+  "dqn_enduro_2k": {
     "agent": [{
       "name": "DQN",
       "algorithm": {

--- a/slm_lab/spec/experimental/dqn_enduro.json
+++ b/slm_lab/spec/experimental/dqn_enduro.json
@@ -38,7 +38,7 @@
         "hid_layers_activation": "relu",
         "init_fn": null,
         "batch_norm": false,
-        "clip_grad_val": 1.0,
+        "clip_grad_val": 10.0,
         "loss_spec": {
           "name": "SmoothL1Loss"
         },

--- a/slm_lab/spec/experimental/dqn_mspacman.json
+++ b/slm_lab/spec/experimental/dqn_mspacman.json
@@ -48,7 +48,7 @@
         },
         "lr_scheduler_spec": null,
         "update_type": "replace",
-        "update_frequency": 1000,
+        "update_frequency": 2000,
         "gpu": true
       }
     }],

--- a/slm_lab/spec/experimental/dqn_mspacman.json
+++ b/slm_lab/spec/experimental/dqn_mspacman.json
@@ -48,7 +48,7 @@
         },
         "lr_scheduler_spec": null,
         "update_type": "replace",
-        "update_frequency": 3000,
+        "update_frequency": 1000,
         "gpu": true
       }
     }],

--- a/slm_lab/spec/experimental/dqn_mspacman.json
+++ b/slm_lab/spec/experimental/dqn_mspacman.json
@@ -1,5 +1,5 @@
 {
-  "dqn_mspacman": {
+  "dqn_mspacman_2k": {
     "agent": [{
       "name": "DQN",
       "algorithm": {

--- a/slm_lab/spec/experimental/dqn_mspacman.json
+++ b/slm_lab/spec/experimental/dqn_mspacman.json
@@ -48,7 +48,7 @@
         },
         "lr_scheduler_spec": null,
         "update_type": "replace",
-        "update_frequency": 1000,
+        "update_frequency": 3000,
         "gpu": true
       }
     }],

--- a/slm_lab/spec/experimental/dqn_mspacman.json
+++ b/slm_lab/spec/experimental/dqn_mspacman.json
@@ -38,7 +38,7 @@
         "hid_layers_activation": "relu",
         "init_fn": null,
         "batch_norm": false,
-        "clip_grad_val": 1.0,
+        "clip_grad_val": 10.0,
         "loss_spec": {
           "name": "SmoothL1Loss"
         },

--- a/slm_lab/spec/experimental/dqn_mspacman.json
+++ b/slm_lab/spec/experimental/dqn_mspacman.json
@@ -1,5 +1,5 @@
 {
-  "dqn_mspacman_2k": {
+  "dqn_mspacman": {
     "agent": [{
       "name": "DQN",
       "algorithm": {
@@ -48,7 +48,7 @@
         },
         "lr_scheduler_spec": null,
         "update_type": "replace",
-        "update_frequency": 2000,
+        "update_frequency": 1000,
         "gpu": true
       }
     }],

--- a/slm_lab/spec/experimental/dqn_mspacman.json
+++ b/slm_lab/spec/experimental/dqn_mspacman.json
@@ -1,5 +1,5 @@
 {
-  "dqn_per_mspacman": {
+  "dqn_mspacman": {
     "agent": [{
       "name": "DQN",
       "algorithm": {
@@ -21,9 +21,7 @@
         "normalize_state": false
       },
       "memory": {
-        "name": "AtariPrioritizedReplay",
-        "alpha": 0.6,
-        "epsilon": 0.0001,
+        "name": "AtariReplay",
         "batch_size": 32,
         "max_size": 200000,
         "stack_len": 4,
@@ -45,15 +43,12 @@
           "name": "SmoothL1Loss"
         },
         "optim_spec": {
-          "name": "RMSprop",
-          "lr": 6.25e-5,
-          "alpha": 0.95,
-          "eps": 1e-1,
-          "momentum": 0.95
+          "name": "Adam",
+          "lr": 1e-4,
         },
         "lr_scheduler_spec": null,
         "update_type": "replace",
-        "update_frequency": 5000,
+        "update_frequency": 1000,
         "gpu": true
       }
     }],

--- a/slm_lab/spec/experimental/dqn_per_beamrider.json
+++ b/slm_lab/spec/experimental/dqn_per_beamrider.json
@@ -1,5 +1,5 @@
 {
-  "dqn_per_beamrider_2k": {
+  "dqn_per_beamrider": {
     "agent": [{
       "name": "DQN",
       "algorithm": {
@@ -50,7 +50,7 @@
         },
         "lr_scheduler_spec": null,
         "update_type": "replace",
-        "update_frequency": 2000,
+        "update_frequency": 1000,
         "gpu": true
       }
     }],

--- a/slm_lab/spec/experimental/dqn_per_beamrider.json
+++ b/slm_lab/spec/experimental/dqn_per_beamrider.json
@@ -46,11 +46,11 @@
         },
         "optim_spec": {
           "name": "Adam",
-          "lr": 2.5e-5,
+          "lr": 5.0e-5,
         },
         "lr_scheduler_spec": null,
         "update_type": "replace",
-        "update_frequency": 3000,
+        "update_frequency": 1000,
         "gpu": true
       }
     }],

--- a/slm_lab/spec/experimental/dqn_per_beamrider.json
+++ b/slm_lab/spec/experimental/dqn_per_beamrider.json
@@ -50,7 +50,7 @@
         },
         "lr_scheduler_spec": null,
         "update_type": "replace",
-        "update_frequency": 1000,
+        "update_frequency": 3000,
         "gpu": true
       }
     }],

--- a/slm_lab/spec/experimental/dqn_per_beamrider.json
+++ b/slm_lab/spec/experimental/dqn_per_beamrider.json
@@ -40,7 +40,7 @@
         "hid_layers_activation": "relu",
         "init_fn": null,
         "batch_norm": false,
-        "clip_grad_val": 1.0,
+        "clip_grad_val": 10.0,
         "loss_spec": {
           "name": "SmoothL1Loss"
         },

--- a/slm_lab/spec/experimental/dqn_per_beamrider.json
+++ b/slm_lab/spec/experimental/dqn_per_beamrider.json
@@ -46,7 +46,7 @@
         },
         "optim_spec": {
           "name": "Adam",
-          "lr": 5.0e-5,
+          "lr": 2.5e-5,
         },
         "lr_scheduler_spec": null,
         "update_type": "replace",

--- a/slm_lab/spec/experimental/dqn_per_beamrider.json
+++ b/slm_lab/spec/experimental/dqn_per_beamrider.json
@@ -1,5 +1,5 @@
 {
-  "dqn_per_beamrider": {
+  "dqn_per_beamrider_2k": {
     "agent": [{
       "name": "DQN",
       "algorithm": {
@@ -50,7 +50,7 @@
         },
         "lr_scheduler_spec": null,
         "update_type": "replace",
-        "update_frequency": 1000,
+        "update_frequency": 2000,
         "gpu": true
       }
     }],

--- a/slm_lab/spec/experimental/dqn_per_beamrider.json
+++ b/slm_lab/spec/experimental/dqn_per_beamrider.json
@@ -1,5 +1,5 @@
 {
-  "dqn_pong": {
+  "dqn_per_beamrider": {
     "agent": [{
       "name": "DQN",
       "algorithm": {
@@ -21,7 +21,9 @@
         "normalize_state": false
       },
       "memory": {
-        "name": "AtariReplay",
+        "name": "AtariPrioritizedReplay",
+        "alpha": 0.6,
+        "epsilon": 0.0001,
         "batch_size": 32,
         "max_size": 200000,
         "stack_len": 4,
@@ -44,7 +46,7 @@
         },
         "optim_spec": {
           "name": "Adam",
-          "lr": 1e-4,
+          "lr": 2.5e-5,
         },
         "lr_scheduler_spec": null,
         "update_type": "replace",
@@ -53,7 +55,7 @@
       }
     }],
     "env": [{
-      "name": "PongNoFrameskip-v4",
+      "name": "BeamRiderNoFrameskip-v4",
       "max_t": null,
       "max_tick": 10000000
     }],
@@ -66,10 +68,10 @@
       "eval_frequency": 10000,
       "max_tick_unit": "total_t",
       "max_session": 4,
-      "max_trial": 16,
+      "max_trial": 12,
       "search": "RandomSearch",
       "resources": {
-        "num_cpus": 16
+        "num_cpus": 12
       }
     }
   }

--- a/slm_lab/spec/experimental/dqn_per_breakout.json
+++ b/slm_lab/spec/experimental/dqn_per_breakout.json
@@ -46,11 +46,11 @@
         },
         "optim_spec": {
           "name": "Adam",
-          "lr": 2.5e-5,
+          "lr": 5.0e-5,
         },
         "lr_scheduler_spec": null,
         "update_type": "replace",
-        "update_frequency": 3000,
+        "update_frequency": 1000,
         "gpu": true
       }
     }],

--- a/slm_lab/spec/experimental/dqn_per_breakout.json
+++ b/slm_lab/spec/experimental/dqn_per_breakout.json
@@ -1,5 +1,5 @@
 {
-  "dqn_per_breakout_2k": {
+  "dqn_per_breakout": {
     "agent": [{
       "name": "DQN",
       "algorithm": {
@@ -50,7 +50,7 @@
         },
         "lr_scheduler_spec": null,
         "update_type": "replace",
-        "update_frequency": 2000,
+        "update_frequency": 1000,
         "gpu": true
       }
     }],

--- a/slm_lab/spec/experimental/dqn_per_breakout.json
+++ b/slm_lab/spec/experimental/dqn_per_breakout.json
@@ -50,7 +50,7 @@
         },
         "lr_scheduler_spec": null,
         "update_type": "replace",
-        "update_frequency": 1000,
+        "update_frequency": 3000,
         "gpu": true
       }
     }],

--- a/slm_lab/spec/experimental/dqn_per_breakout.json
+++ b/slm_lab/spec/experimental/dqn_per_breakout.json
@@ -40,7 +40,7 @@
         "hid_layers_activation": "relu",
         "init_fn": null,
         "batch_norm": false,
-        "clip_grad_val": 1.0,
+        "clip_grad_val": 10.0,
         "loss_spec": {
           "name": "SmoothL1Loss"
         },

--- a/slm_lab/spec/experimental/dqn_per_breakout.json
+++ b/slm_lab/spec/experimental/dqn_per_breakout.json
@@ -1,5 +1,5 @@
 {
-  "dqn_per_breakout": {
+  "dqn_per_breakout_2k": {
     "agent": [{
       "name": "DQN",
       "algorithm": {
@@ -50,7 +50,7 @@
         },
         "lr_scheduler_spec": null,
         "update_type": "replace",
-        "update_frequency": 1000,
+        "update_frequency": 2000,
         "gpu": true
       }
     }],

--- a/slm_lab/spec/experimental/dqn_per_breakout.json
+++ b/slm_lab/spec/experimental/dqn_per_breakout.json
@@ -46,7 +46,7 @@
         },
         "optim_spec": {
           "name": "Adam",
-          "lr": 5.0e-5,
+          "lr": 2.5e-5,
         },
         "lr_scheduler_spec": null,
         "update_type": "replace",

--- a/slm_lab/spec/experimental/dqn_per_breakout.json
+++ b/slm_lab/spec/experimental/dqn_per_breakout.json
@@ -1,5 +1,5 @@
 {
-  "dqn_pong": {
+  "dqn_per_breakout": {
     "agent": [{
       "name": "DQN",
       "algorithm": {
@@ -21,7 +21,9 @@
         "normalize_state": false
       },
       "memory": {
-        "name": "AtariReplay",
+        "name": "AtariPrioritizedReplay",
+        "alpha": 0.6,
+        "epsilon": 0.0001,
         "batch_size": 32,
         "max_size": 200000,
         "stack_len": 4,
@@ -44,7 +46,7 @@
         },
         "optim_spec": {
           "name": "Adam",
-          "lr": 1e-4,
+          "lr": 2.5e-5,
         },
         "lr_scheduler_spec": null,
         "update_type": "replace",
@@ -53,7 +55,7 @@
       }
     }],
     "env": [{
-      "name": "PongNoFrameskip-v4",
+      "name": "BreakoutNoFrameskip-v4",
       "max_t": null,
       "max_tick": 10000000
     }],

--- a/slm_lab/spec/experimental/dqn_per_enduro.json
+++ b/slm_lab/spec/experimental/dqn_per_enduro.json
@@ -1,5 +1,5 @@
 {
-  "dqn_per_enduro": {
+  "dqn_per_enduro_2k": {
     "agent": [{
       "name": "DQN",
       "algorithm": {

--- a/slm_lab/spec/experimental/dqn_per_enduro.json
+++ b/slm_lab/spec/experimental/dqn_per_enduro.json
@@ -1,5 +1,5 @@
 {
-  "dqn_pong": {
+  "dqn_per_enduro": {
     "agent": [{
       "name": "DQN",
       "algorithm": {
@@ -21,7 +21,9 @@
         "normalize_state": false
       },
       "memory": {
-        "name": "AtariReplay",
+        "name": "AtariPrioritizedReplay",
+        "alpha": 0.6,
+        "epsilon": 0.0001,
         "batch_size": 32,
         "max_size": 200000,
         "stack_len": 4,
@@ -44,7 +46,7 @@
         },
         "optim_spec": {
           "name": "Adam",
-          "lr": 1e-4,
+          "lr": 2.5e-5,
         },
         "lr_scheduler_spec": null,
         "update_type": "replace",
@@ -53,7 +55,7 @@
       }
     }],
     "env": [{
-      "name": "PongNoFrameskip-v4",
+      "name": "EnduroNoFrameskip-v4",
       "max_t": null,
       "max_tick": 10000000
     }],

--- a/slm_lab/spec/experimental/dqn_per_enduro.json
+++ b/slm_lab/spec/experimental/dqn_per_enduro.json
@@ -46,11 +46,11 @@
         },
         "optim_spec": {
           "name": "Adam",
-          "lr": 2.5e-5,
+          "lr": 5.0e-5,
         },
         "lr_scheduler_spec": null,
         "update_type": "replace",
-        "update_frequency": 3000,
+        "update_frequency": 1000,
         "gpu": true
       }
     }],

--- a/slm_lab/spec/experimental/dqn_per_enduro.json
+++ b/slm_lab/spec/experimental/dqn_per_enduro.json
@@ -50,7 +50,7 @@
         },
         "lr_scheduler_spec": null,
         "update_type": "replace",
-        "update_frequency": 1000,
+        "update_frequency": 3000,
         "gpu": true
       }
     }],

--- a/slm_lab/spec/experimental/dqn_per_enduro.json
+++ b/slm_lab/spec/experimental/dqn_per_enduro.json
@@ -40,7 +40,7 @@
         "hid_layers_activation": "relu",
         "init_fn": null,
         "batch_norm": false,
-        "clip_grad_val": 1.0,
+        "clip_grad_val": 10.0,
         "loss_spec": {
           "name": "SmoothL1Loss"
         },

--- a/slm_lab/spec/experimental/dqn_per_enduro.json
+++ b/slm_lab/spec/experimental/dqn_per_enduro.json
@@ -46,7 +46,7 @@
         },
         "optim_spec": {
           "name": "Adam",
-          "lr": 5.0e-5,
+          "lr": 2.5e-5,
         },
         "lr_scheduler_spec": null,
         "update_type": "replace",

--- a/slm_lab/spec/experimental/dqn_per_enduro.json
+++ b/slm_lab/spec/experimental/dqn_per_enduro.json
@@ -1,5 +1,5 @@
 {
-  "dqn_per_enduro_2k": {
+  "dqn_per_enduro": {
     "agent": [{
       "name": "DQN",
       "algorithm": {
@@ -50,7 +50,7 @@
         },
         "lr_scheduler_spec": null,
         "update_type": "replace",
-        "update_frequency": 2000,
+        "update_frequency": 1000,
         "gpu": true
       }
     }],

--- a/slm_lab/spec/experimental/dqn_per_enduro.json
+++ b/slm_lab/spec/experimental/dqn_per_enduro.json
@@ -50,7 +50,7 @@
         },
         "lr_scheduler_spec": null,
         "update_type": "replace",
-        "update_frequency": 1000,
+        "update_frequency": 2000,
         "gpu": true
       }
     }],

--- a/slm_lab/spec/experimental/dqn_per_mspacman.json
+++ b/slm_lab/spec/experimental/dqn_per_mspacman.json
@@ -46,11 +46,11 @@
         },
         "optim_spec": {
           "name": "Adam",
-          "lr": 2.5e-5,
+          "lr": 5.0e-5,
         },
         "lr_scheduler_spec": null,
         "update_type": "replace",
-        "update_frequency": 3000,
+        "update_frequency": 1000,
         "gpu": true
       }
     }],

--- a/slm_lab/spec/experimental/dqn_per_mspacman.json
+++ b/slm_lab/spec/experimental/dqn_per_mspacman.json
@@ -1,5 +1,5 @@
 {
-  "dqn_pong": {
+  "dqn_per_mspacman": {
     "agent": [{
       "name": "DQN",
       "algorithm": {
@@ -21,7 +21,9 @@
         "normalize_state": false
       },
       "memory": {
-        "name": "AtariReplay",
+        "name": "AtariPrioritizedReplay",
+        "alpha": 0.6,
+        "epsilon": 0.0001,
         "batch_size": 32,
         "max_size": 200000,
         "stack_len": 4,
@@ -44,7 +46,7 @@
         },
         "optim_spec": {
           "name": "Adam",
-          "lr": 1e-4,
+          "lr": 2.5e-5,
         },
         "lr_scheduler_spec": null,
         "update_type": "replace",
@@ -53,7 +55,7 @@
       }
     }],
     "env": [{
-      "name": "PongNoFrameskip-v4",
+      "name": "MsPacmanNoFrameskip-v4",
       "max_t": null,
       "max_tick": 10000000
     }],

--- a/slm_lab/spec/experimental/dqn_per_mspacman.json
+++ b/slm_lab/spec/experimental/dqn_per_mspacman.json
@@ -50,7 +50,7 @@
         },
         "lr_scheduler_spec": null,
         "update_type": "replace",
-        "update_frequency": 1000,
+        "update_frequency": 3000,
         "gpu": true
       }
     }],

--- a/slm_lab/spec/experimental/dqn_per_mspacman.json
+++ b/slm_lab/spec/experimental/dqn_per_mspacman.json
@@ -40,7 +40,7 @@
         "hid_layers_activation": "relu",
         "init_fn": null,
         "batch_norm": false,
-        "clip_grad_val": 1.0,
+        "clip_grad_val": 10.0,
         "loss_spec": {
           "name": "SmoothL1Loss"
         },

--- a/slm_lab/spec/experimental/dqn_per_mspacman.json
+++ b/slm_lab/spec/experimental/dqn_per_mspacman.json
@@ -46,7 +46,7 @@
         },
         "optim_spec": {
           "name": "Adam",
-          "lr": 5.0e-5,
+          "lr": 2.5e-5,
         },
         "lr_scheduler_spec": null,
         "update_type": "replace",

--- a/slm_lab/spec/experimental/dqn_per_mspacman.json
+++ b/slm_lab/spec/experimental/dqn_per_mspacman.json
@@ -50,7 +50,7 @@
         },
         "lr_scheduler_spec": null,
         "update_type": "replace",
-        "update_frequency": 1000,
+        "update_frequency": 2000,
         "gpu": true
       }
     }],

--- a/slm_lab/spec/experimental/dqn_per_mspacman.json
+++ b/slm_lab/spec/experimental/dqn_per_mspacman.json
@@ -1,5 +1,5 @@
 {
-  "dqn_per_mspacman": {
+  "dqn_per_mspacman_2k": {
     "agent": [{
       "name": "DQN",
       "algorithm": {

--- a/slm_lab/spec/experimental/dqn_per_mspacman.json
+++ b/slm_lab/spec/experimental/dqn_per_mspacman.json
@@ -1,5 +1,5 @@
 {
-  "dqn_per_mspacman_2k": {
+  "dqn_per_mspacman": {
     "agent": [{
       "name": "DQN",
       "algorithm": {
@@ -50,7 +50,7 @@
         },
         "lr_scheduler_spec": null,
         "update_type": "replace",
-        "update_frequency": 2000,
+        "update_frequency": 1000,
         "gpu": true
       }
     }],

--- a/slm_lab/spec/experimental/dqn_per_pong.json
+++ b/slm_lab/spec/experimental/dqn_per_pong.json
@@ -1,5 +1,5 @@
 {
-  "dqn_per_pong": {
+  "dqn_per_pong_2k": {
     "agent": [{
       "name": "DQN",
       "algorithm": {
@@ -50,7 +50,7 @@
         },
         "lr_scheduler_spec": null,
         "update_type": "replace",
-        "update_frequency": 1000,
+        "update_frequency": 2000,
         "gpu": true
       }
     }],

--- a/slm_lab/spec/experimental/dqn_per_pong.json
+++ b/slm_lab/spec/experimental/dqn_per_pong.json
@@ -1,5 +1,5 @@
 {
-  "dqn_pong": {
+  "dqn_per_pong": {
     "agent": [{
       "name": "DQN",
       "algorithm": {
@@ -21,7 +21,9 @@
         "normalize_state": false
       },
       "memory": {
-        "name": "AtariReplay",
+        "name": "AtariPrioritizedReplay",
+        "alpha": 0.6,
+        "epsilon": 0.0001,
         "batch_size": 32,
         "max_size": 200000,
         "stack_len": 4,
@@ -44,7 +46,7 @@
         },
         "optim_spec": {
           "name": "Adam",
-          "lr": 1e-4,
+          "lr": 2.5e-5,
         },
         "lr_scheduler_spec": null,
         "update_type": "replace",

--- a/slm_lab/spec/experimental/dqn_per_pong.json
+++ b/slm_lab/spec/experimental/dqn_per_pong.json
@@ -46,11 +46,11 @@
         },
         "optim_spec": {
           "name": "Adam",
-          "lr": 2.5e-5,
+          "lr": 5.0e-5,
         },
         "lr_scheduler_spec": null,
         "update_type": "replace",
-        "update_frequency": 3000,
+        "update_frequency": 1000,
         "gpu": true
       }
     }],

--- a/slm_lab/spec/experimental/dqn_per_pong.json
+++ b/slm_lab/spec/experimental/dqn_per_pong.json
@@ -50,7 +50,7 @@
         },
         "lr_scheduler_spec": null,
         "update_type": "replace",
-        "update_frequency": 1000,
+        "update_frequency": 3000,
         "gpu": true
       }
     }],

--- a/slm_lab/spec/experimental/dqn_per_pong.json
+++ b/slm_lab/spec/experimental/dqn_per_pong.json
@@ -40,7 +40,7 @@
         "hid_layers_activation": "relu",
         "init_fn": null,
         "batch_norm": false,
-        "clip_grad_val": 1.0,
+        "clip_grad_val": 10.0,
         "loss_spec": {
           "name": "SmoothL1Loss"
         },

--- a/slm_lab/spec/experimental/dqn_per_pong.json
+++ b/slm_lab/spec/experimental/dqn_per_pong.json
@@ -46,7 +46,7 @@
         },
         "optim_spec": {
           "name": "Adam",
-          "lr": 5.0e-5,
+          "lr": 2.5e-5,
         },
         "lr_scheduler_spec": null,
         "update_type": "replace",

--- a/slm_lab/spec/experimental/dqn_per_pong.json
+++ b/slm_lab/spec/experimental/dqn_per_pong.json
@@ -1,5 +1,5 @@
 {
-  "dqn_per_pong_2k": {
+  "dqn_per_pong": {
     "agent": [{
       "name": "DQN",
       "algorithm": {
@@ -50,7 +50,7 @@
         },
         "lr_scheduler_spec": null,
         "update_type": "replace",
-        "update_frequency": 2000,
+        "update_frequency": 1000,
         "gpu": true
       }
     }],

--- a/slm_lab/spec/experimental/dqn_per_qbert.json
+++ b/slm_lab/spec/experimental/dqn_per_qbert.json
@@ -1,5 +1,5 @@
 {
-  "dqn_pong": {
+  "dqn_per_qbert": {
     "agent": [{
       "name": "DQN",
       "algorithm": {
@@ -21,7 +21,9 @@
         "normalize_state": false
       },
       "memory": {
-        "name": "AtariReplay",
+        "name": "AtariPrioritizedReplay",
+        "alpha": 0.6,
+        "epsilon": 0.0001,
         "batch_size": 32,
         "max_size": 200000,
         "stack_len": 4,
@@ -44,7 +46,7 @@
         },
         "optim_spec": {
           "name": "Adam",
-          "lr": 1e-4,
+          "lr": 2.5e-5,
         },
         "lr_scheduler_spec": null,
         "update_type": "replace",
@@ -53,7 +55,7 @@
       }
     }],
     "env": [{
-      "name": "PongNoFrameskip-v4",
+      "name": "QbertNoFrameskip-v4",
       "max_t": null,
       "max_tick": 10000000
     }],

--- a/slm_lab/spec/experimental/dqn_per_qbert.json
+++ b/slm_lab/spec/experimental/dqn_per_qbert.json
@@ -46,11 +46,11 @@
         },
         "optim_spec": {
           "name": "Adam",
-          "lr": 2.5e-5,
+          "lr": 5.0e-5,
         },
         "lr_scheduler_spec": null,
         "update_type": "replace",
-        "update_frequency": 3000,
+        "update_frequency": 1000,
         "gpu": true
       }
     }],

--- a/slm_lab/spec/experimental/dqn_per_qbert.json
+++ b/slm_lab/spec/experimental/dqn_per_qbert.json
@@ -50,7 +50,7 @@
         },
         "lr_scheduler_spec": null,
         "update_type": "replace",
-        "update_frequency": 1000,
+        "update_frequency": 3000,
         "gpu": true
       }
     }],

--- a/slm_lab/spec/experimental/dqn_per_qbert.json
+++ b/slm_lab/spec/experimental/dqn_per_qbert.json
@@ -40,7 +40,7 @@
         "hid_layers_activation": "relu",
         "init_fn": null,
         "batch_norm": false,
-        "clip_grad_val": 1.0,
+        "clip_grad_val": 10.0,
         "loss_spec": {
           "name": "SmoothL1Loss"
         },

--- a/slm_lab/spec/experimental/dqn_per_qbert.json
+++ b/slm_lab/spec/experimental/dqn_per_qbert.json
@@ -46,7 +46,7 @@
         },
         "optim_spec": {
           "name": "Adam",
-          "lr": 5.0e-5,
+          "lr": 2.5e-5,
         },
         "lr_scheduler_spec": null,
         "update_type": "replace",

--- a/slm_lab/spec/experimental/dqn_per_qbert.json
+++ b/slm_lab/spec/experimental/dqn_per_qbert.json
@@ -50,7 +50,7 @@
         },
         "lr_scheduler_spec": null,
         "update_type": "replace",
-        "update_frequency": 1000,
+        "update_frequency": 2000,
         "gpu": true
       }
     }],

--- a/slm_lab/spec/experimental/dqn_per_qbert.json
+++ b/slm_lab/spec/experimental/dqn_per_qbert.json
@@ -1,5 +1,5 @@
 {
-  "dqn_per_qbert": {
+  "dqn_per_qbert_2k": {
     "agent": [{
       "name": "DQN",
       "algorithm": {

--- a/slm_lab/spec/experimental/dqn_per_qbert.json
+++ b/slm_lab/spec/experimental/dqn_per_qbert.json
@@ -1,5 +1,5 @@
 {
-  "dqn_per_qbert_2k": {
+  "dqn_per_qbert": {
     "agent": [{
       "name": "DQN",
       "algorithm": {
@@ -50,7 +50,7 @@
         },
         "lr_scheduler_spec": null,
         "update_type": "replace",
-        "update_frequency": 2000,
+        "update_frequency": 1000,
         "gpu": true
       }
     }],

--- a/slm_lab/spec/experimental/dqn_per_seaquest.json
+++ b/slm_lab/spec/experimental/dqn_per_seaquest.json
@@ -46,11 +46,11 @@
         },
         "optim_spec": {
           "name": "Adam",
-          "lr": 2.5e-5,
+          "lr": 5.0e-5,
         },
         "lr_scheduler_spec": null,
         "update_type": "replace",
-        "update_frequency": 3000,
+        "update_frequency": 1000,
         "gpu": true
       }
     }],

--- a/slm_lab/spec/experimental/dqn_per_seaquest.json
+++ b/slm_lab/spec/experimental/dqn_per_seaquest.json
@@ -50,7 +50,7 @@
         },
         "lr_scheduler_spec": null,
         "update_type": "replace",
-        "update_frequency": 1000,
+        "update_frequency": 3000,
         "gpu": true
       }
     }],

--- a/slm_lab/spec/experimental/dqn_per_seaquest.json
+++ b/slm_lab/spec/experimental/dqn_per_seaquest.json
@@ -40,7 +40,7 @@
         "hid_layers_activation": "relu",
         "init_fn": null,
         "batch_norm": false,
-        "clip_grad_val": 1.0,
+        "clip_grad_val": 10.0,
         "loss_spec": {
           "name": "SmoothL1Loss"
         },

--- a/slm_lab/spec/experimental/dqn_per_seaquest.json
+++ b/slm_lab/spec/experimental/dqn_per_seaquest.json
@@ -46,7 +46,7 @@
         },
         "optim_spec": {
           "name": "Adam",
-          "lr": 5.0e-5,
+          "lr": 2.5e-5,
         },
         "lr_scheduler_spec": null,
         "update_type": "replace",

--- a/slm_lab/spec/experimental/dqn_per_seaquest.json
+++ b/slm_lab/spec/experimental/dqn_per_seaquest.json
@@ -1,5 +1,5 @@
 {
-  "dqn_per_seaquest_2k": {
+  "dqn_per_seaquest": {
     "agent": [{
       "name": "DQN",
       "algorithm": {
@@ -50,7 +50,7 @@
         },
         "lr_scheduler_spec": null,
         "update_type": "replace",
-        "update_frequency": 2000,
+        "update_frequency": 1000,
         "gpu": true
       }
     }],

--- a/slm_lab/spec/experimental/dqn_per_seaquest.json
+++ b/slm_lab/spec/experimental/dqn_per_seaquest.json
@@ -50,7 +50,7 @@
         },
         "lr_scheduler_spec": null,
         "update_type": "replace",
-        "update_frequency": 1000,
+        "update_frequency": 2000,
         "gpu": true
       }
     }],

--- a/slm_lab/spec/experimental/dqn_per_seaquest.json
+++ b/slm_lab/spec/experimental/dqn_per_seaquest.json
@@ -1,5 +1,5 @@
 {
-  "dqn_pong": {
+  "dqn_per_seaquest": {
     "agent": [{
       "name": "DQN",
       "algorithm": {
@@ -21,7 +21,9 @@
         "normalize_state": false
       },
       "memory": {
-        "name": "AtariReplay",
+        "name": "AtariPrioritizedReplay",
+        "alpha": 0.6,
+        "epsilon": 0.0001,
         "batch_size": 32,
         "max_size": 200000,
         "stack_len": 4,
@@ -44,7 +46,7 @@
         },
         "optim_spec": {
           "name": "Adam",
-          "lr": 1e-4,
+          "lr": 2.5e-5,
         },
         "lr_scheduler_spec": null,
         "update_type": "replace",
@@ -53,7 +55,7 @@
       }
     }],
     "env": [{
-      "name": "PongNoFrameskip-v4",
+      "name": "SeaquestNoFrameskip-v4",
       "max_t": null,
       "max_tick": 10000000
     }],

--- a/slm_lab/spec/experimental/dqn_per_seaquest.json
+++ b/slm_lab/spec/experimental/dqn_per_seaquest.json
@@ -1,5 +1,5 @@
 {
-  "dqn_per_seaquest": {
+  "dqn_per_seaquest_2k": {
     "agent": [{
       "name": "DQN",
       "algorithm": {

--- a/slm_lab/spec/experimental/dqn_per_spaceinvaders.json
+++ b/slm_lab/spec/experimental/dqn_per_spaceinvaders.json
@@ -46,11 +46,11 @@
         },
         "optim_spec": {
           "name": "Adam",
-          "lr": 2.5e-5,
+          "lr": 5.0e-5,
         },
         "lr_scheduler_spec": null,
         "update_type": "replace",
-        "update_frequency": 3000,
+        "update_frequency": 1000,
         "gpu": true
       }
     }],

--- a/slm_lab/spec/experimental/dqn_per_spaceinvaders.json
+++ b/slm_lab/spec/experimental/dqn_per_spaceinvaders.json
@@ -50,7 +50,7 @@
         },
         "lr_scheduler_spec": null,
         "update_type": "replace",
-        "update_frequency": 1000,
+        "update_frequency": 3000,
         "gpu": true
       }
     }],

--- a/slm_lab/spec/experimental/dqn_per_spaceinvaders.json
+++ b/slm_lab/spec/experimental/dqn_per_spaceinvaders.json
@@ -40,7 +40,7 @@
         "hid_layers_activation": "relu",
         "init_fn": null,
         "batch_norm": false,
-        "clip_grad_val": 1.0,
+        "clip_grad_val": 10.0,
         "loss_spec": {
           "name": "SmoothL1Loss"
         },

--- a/slm_lab/spec/experimental/dqn_per_spaceinvaders.json
+++ b/slm_lab/spec/experimental/dqn_per_spaceinvaders.json
@@ -1,5 +1,5 @@
 {
-  "dqn_per_spaceinvaders": {
+  "dqn_per_spaceinvaders_2k": {
     "agent": [{
       "name": "DQN",
       "algorithm": {

--- a/slm_lab/spec/experimental/dqn_per_spaceinvaders.json
+++ b/slm_lab/spec/experimental/dqn_per_spaceinvaders.json
@@ -46,7 +46,7 @@
         },
         "optim_spec": {
           "name": "Adam",
-          "lr": 5.0e-5,
+          "lr": 2.5e-5,
         },
         "lr_scheduler_spec": null,
         "update_type": "replace",

--- a/slm_lab/spec/experimental/dqn_per_spaceinvaders.json
+++ b/slm_lab/spec/experimental/dqn_per_spaceinvaders.json
@@ -50,7 +50,7 @@
         },
         "lr_scheduler_spec": null,
         "update_type": "replace",
-        "update_frequency": 1000,
+        "update_frequency": 2000,
         "gpu": true
       }
     }],

--- a/slm_lab/spec/experimental/dqn_per_spaceinvaders.json
+++ b/slm_lab/spec/experimental/dqn_per_spaceinvaders.json
@@ -1,5 +1,5 @@
 {
-  "dqn_pong": {
+  "dqn_per_spaceinvaders": {
     "agent": [{
       "name": "DQN",
       "algorithm": {
@@ -21,7 +21,9 @@
         "normalize_state": false
       },
       "memory": {
-        "name": "AtariReplay",
+        "name": "AtariPrioritizedReplay",
+        "alpha": 0.6,
+        "epsilon": 0.0001,
         "batch_size": 32,
         "max_size": 200000,
         "stack_len": 4,
@@ -44,7 +46,7 @@
         },
         "optim_spec": {
           "name": "Adam",
-          "lr": 1e-4,
+          "lr": 2.5e-5,
         },
         "lr_scheduler_spec": null,
         "update_type": "replace",
@@ -53,7 +55,7 @@
       }
     }],
     "env": [{
-      "name": "PongNoFrameskip-v4",
+      "name": "SpaceInvadersNoFrameskip-v4",
       "max_t": null,
       "max_tick": 10000000
     }],

--- a/slm_lab/spec/experimental/dqn_per_spaceinvaders.json
+++ b/slm_lab/spec/experimental/dqn_per_spaceinvaders.json
@@ -1,5 +1,5 @@
 {
-  "dqn_per_spaceinvaders_2k": {
+  "dqn_per_spaceinvaders": {
     "agent": [{
       "name": "DQN",
       "algorithm": {
@@ -50,7 +50,7 @@
         },
         "lr_scheduler_spec": null,
         "update_type": "replace",
-        "update_frequency": 2000,
+        "update_frequency": 1000,
         "gpu": true
       }
     }],

--- a/slm_lab/spec/experimental/dqn_pong.json
+++ b/slm_lab/spec/experimental/dqn_pong.json
@@ -1,5 +1,5 @@
 {
-  "dqn_pong": {
+  "dqn_pong_2k": {
     "agent": [{
       "name": "DQN",
       "algorithm": {
@@ -48,7 +48,7 @@
         },
         "lr_scheduler_spec": null,
         "update_type": "replace",
-        "update_frequency": 1000,
+        "update_frequency": 2000,
         "gpu": true
       }
     }],

--- a/slm_lab/spec/experimental/dqn_pong.json
+++ b/slm_lab/spec/experimental/dqn_pong.json
@@ -1,5 +1,5 @@
 {
-  "dqn_pong_2k": {
+  "dqn_pong": {
     "agent": [{
       "name": "DQN",
       "algorithm": {
@@ -48,7 +48,7 @@
         },
         "lr_scheduler_spec": null,
         "update_type": "replace",
-        "update_frequency": 2000,
+        "update_frequency": 1000,
         "gpu": true
       }
     }],

--- a/slm_lab/spec/experimental/dqn_pong.json
+++ b/slm_lab/spec/experimental/dqn_pong.json
@@ -48,7 +48,7 @@
         },
         "lr_scheduler_spec": null,
         "update_type": "replace",
-        "update_frequency": 3000,
+        "update_frequency": 1000,
         "gpu": true
       }
     }],

--- a/slm_lab/spec/experimental/dqn_pong.json
+++ b/slm_lab/spec/experimental/dqn_pong.json
@@ -48,7 +48,7 @@
         },
         "lr_scheduler_spec": null,
         "update_type": "replace",
-        "update_frequency": 1000,
+        "update_frequency": 3000,
         "gpu": true
       }
     }],

--- a/slm_lab/spec/experimental/dqn_pong.json
+++ b/slm_lab/spec/experimental/dqn_pong.json
@@ -38,7 +38,7 @@
         "hid_layers_activation": "relu",
         "init_fn": null,
         "batch_norm": false,
-        "clip_grad_val": 1.0,
+        "clip_grad_val": 10.0,
         "loss_spec": {
           "name": "SmoothL1Loss"
         },

--- a/slm_lab/spec/experimental/dqn_qbert.json
+++ b/slm_lab/spec/experimental/dqn_qbert.json
@@ -48,7 +48,7 @@
         },
         "lr_scheduler_spec": null,
         "update_type": "replace",
-        "update_frequency": 1000,
+        "update_frequency": 2000,
         "gpu": true
       }
     }],

--- a/slm_lab/spec/experimental/dqn_qbert.json
+++ b/slm_lab/spec/experimental/dqn_qbert.json
@@ -1,5 +1,5 @@
 {
-  "dqn_qbert_2k": {
+  "dqn_qbert": {
     "agent": [{
       "name": "DQN",
       "algorithm": {
@@ -48,7 +48,7 @@
         },
         "lr_scheduler_spec": null,
         "update_type": "replace",
-        "update_frequency": 2000,
+        "update_frequency": 1000,
         "gpu": true
       }
     }],

--- a/slm_lab/spec/experimental/dqn_qbert.json
+++ b/slm_lab/spec/experimental/dqn_qbert.json
@@ -48,7 +48,7 @@
         },
         "lr_scheduler_spec": null,
         "update_type": "replace",
-        "update_frequency": 3000,
+        "update_frequency": 1000,
         "gpu": true
       }
     }],

--- a/slm_lab/spec/experimental/dqn_qbert.json
+++ b/slm_lab/spec/experimental/dqn_qbert.json
@@ -1,5 +1,5 @@
 {
-  "dqn_per_qbert": {
+  "dqn_qbert": {
     "agent": [{
       "name": "DQN",
       "algorithm": {
@@ -21,9 +21,7 @@
         "normalize_state": false
       },
       "memory": {
-        "name": "AtariPrioritizedReplay",
-        "alpha": 0.6,
-        "epsilon": 0.0001,
+        "name": "AtariReplay",
         "batch_size": 32,
         "max_size": 200000,
         "stack_len": 4,
@@ -45,15 +43,12 @@
           "name": "SmoothL1Loss"
         },
         "optim_spec": {
-          "name": "RMSprop",
-          "lr": 6.25e-5,
-          "alpha": 0.95,
-          "eps": 1e-1,
-          "momentum": 0.95
+          "name": "Adam",
+          "lr": 1e-4,
         },
         "lr_scheduler_spec": null,
         "update_type": "replace",
-        "update_frequency": 5000,
+        "update_frequency": 1000,
         "gpu": true
       }
     }],

--- a/slm_lab/spec/experimental/dqn_qbert.json
+++ b/slm_lab/spec/experimental/dqn_qbert.json
@@ -48,7 +48,7 @@
         },
         "lr_scheduler_spec": null,
         "update_type": "replace",
-        "update_frequency": 1000,
+        "update_frequency": 3000,
         "gpu": true
       }
     }],

--- a/slm_lab/spec/experimental/dqn_qbert.json
+++ b/slm_lab/spec/experimental/dqn_qbert.json
@@ -38,7 +38,7 @@
         "hid_layers_activation": "relu",
         "init_fn": null,
         "batch_norm": false,
-        "clip_grad_val": 1.0,
+        "clip_grad_val": 10.0,
         "loss_spec": {
           "name": "SmoothL1Loss"
         },

--- a/slm_lab/spec/experimental/dqn_qbert.json
+++ b/slm_lab/spec/experimental/dqn_qbert.json
@@ -1,5 +1,5 @@
 {
-  "dqn_qbert": {
+  "dqn_qbert_2k": {
     "agent": [{
       "name": "DQN",
       "algorithm": {

--- a/slm_lab/spec/experimental/dqn_seaquest.json
+++ b/slm_lab/spec/experimental/dqn_seaquest.json
@@ -48,7 +48,7 @@
         },
         "lr_scheduler_spec": null,
         "update_type": "replace",
-        "update_frequency": 1000,
+        "update_frequency": 2000,
         "gpu": true
       }
     }],

--- a/slm_lab/spec/experimental/dqn_seaquest.json
+++ b/slm_lab/spec/experimental/dqn_seaquest.json
@@ -48,7 +48,7 @@
         },
         "lr_scheduler_spec": null,
         "update_type": "replace",
-        "update_frequency": 3000,
+        "update_frequency": 1000,
         "gpu": true
       }
     }],

--- a/slm_lab/spec/experimental/dqn_seaquest.json
+++ b/slm_lab/spec/experimental/dqn_seaquest.json
@@ -48,7 +48,7 @@
         },
         "lr_scheduler_spec": null,
         "update_type": "replace",
-        "update_frequency": 1000,
+        "update_frequency": 3000,
         "gpu": true
       }
     }],

--- a/slm_lab/spec/experimental/dqn_seaquest.json
+++ b/slm_lab/spec/experimental/dqn_seaquest.json
@@ -1,5 +1,5 @@
 {
-  "dqn_seaquest_2k": {
+  "dqn_seaquest": {
     "agent": [{
       "name": "DQN",
       "algorithm": {
@@ -48,7 +48,7 @@
         },
         "lr_scheduler_spec": null,
         "update_type": "replace",
-        "update_frequency": 2000,
+        "update_frequency": 1000,
         "gpu": true
       }
     }],

--- a/slm_lab/spec/experimental/dqn_seaquest.json
+++ b/slm_lab/spec/experimental/dqn_seaquest.json
@@ -38,7 +38,7 @@
         "hid_layers_activation": "relu",
         "init_fn": null,
         "batch_norm": false,
-        "clip_grad_val": 1.0,
+        "clip_grad_val": 10.0,
         "loss_spec": {
           "name": "SmoothL1Loss"
         },

--- a/slm_lab/spec/experimental/dqn_seaquest.json
+++ b/slm_lab/spec/experimental/dqn_seaquest.json
@@ -1,5 +1,5 @@
 {
-  "dqn_per_seaquest": {
+  "dqn_seaquest": {
     "agent": [{
       "name": "DQN",
       "algorithm": {
@@ -21,9 +21,7 @@
         "normalize_state": false
       },
       "memory": {
-        "name": "AtariPrioritizedReplay",
-        "alpha": 0.6,
-        "epsilon": 0.0001,
+        "name": "AtariReplay",
         "batch_size": 32,
         "max_size": 200000,
         "stack_len": 4,
@@ -45,15 +43,12 @@
           "name": "SmoothL1Loss"
         },
         "optim_spec": {
-          "name": "RMSprop",
-          "lr": 6.25e-5,
-          "alpha": 0.95,
-          "eps": 1e-1,
-          "momentum": 0.95
+          "name": "Adam",
+          "lr": 1e-4,
         },
         "lr_scheduler_spec": null,
         "update_type": "replace",
-        "update_frequency": 5000,
+        "update_frequency": 1000,
         "gpu": true
       }
     }],

--- a/slm_lab/spec/experimental/dqn_seaquest.json
+++ b/slm_lab/spec/experimental/dqn_seaquest.json
@@ -1,5 +1,5 @@
 {
-  "dqn_seaquest": {
+  "dqn_seaquest_2k": {
     "agent": [{
       "name": "DQN",
       "algorithm": {

--- a/slm_lab/spec/experimental/dqn_spaceinvaders.json
+++ b/slm_lab/spec/experimental/dqn_spaceinvaders.json
@@ -48,7 +48,7 @@
         },
         "lr_scheduler_spec": null,
         "update_type": "replace",
-        "update_frequency": 1000,
+        "update_frequency": 2000,
         "gpu": true
       }
     }],

--- a/slm_lab/spec/experimental/dqn_spaceinvaders.json
+++ b/slm_lab/spec/experimental/dqn_spaceinvaders.json
@@ -1,5 +1,5 @@
 {
-  "dqn_spaceinvaders": {
+  "dqn_spaceinvaders_2k": {
     "agent": [{
       "name": "DQN",
       "algorithm": {

--- a/slm_lab/spec/experimental/dqn_spaceinvaders.json
+++ b/slm_lab/spec/experimental/dqn_spaceinvaders.json
@@ -1,5 +1,5 @@
 {
-  "dqn_per_spaceinvaders": {
+  "dqn_spaceinvaders": {
     "agent": [{
       "name": "DQN",
       "algorithm": {
@@ -21,9 +21,7 @@
         "normalize_state": false
       },
       "memory": {
-        "name": "AtariPrioritizedReplay",
-        "alpha": 0.6,
-        "epsilon": 0.0001,
+        "name": "AtariReplay",
         "batch_size": 32,
         "max_size": 200000,
         "stack_len": 4,
@@ -45,15 +43,12 @@
           "name": "SmoothL1Loss"
         },
         "optim_spec": {
-          "name": "RMSprop",
-          "lr": 6.25e-5,
-          "alpha": 0.95,
-          "eps": 1e-1,
-          "momentum": 0.95
+          "name": "Adam",
+          "lr": 1e-4,
         },
         "lr_scheduler_spec": null,
         "update_type": "replace",
-        "update_frequency": 5000,
+        "update_frequency": 1000,
         "gpu": true
       }
     }],

--- a/slm_lab/spec/experimental/dqn_spaceinvaders.json
+++ b/slm_lab/spec/experimental/dqn_spaceinvaders.json
@@ -48,7 +48,7 @@
         },
         "lr_scheduler_spec": null,
         "update_type": "replace",
-        "update_frequency": 3000,
+        "update_frequency": 1000,
         "gpu": true
       }
     }],

--- a/slm_lab/spec/experimental/dqn_spaceinvaders.json
+++ b/slm_lab/spec/experimental/dqn_spaceinvaders.json
@@ -48,7 +48,7 @@
         },
         "lr_scheduler_spec": null,
         "update_type": "replace",
-        "update_frequency": 1000,
+        "update_frequency": 3000,
         "gpu": true
       }
     }],

--- a/slm_lab/spec/experimental/dqn_spaceinvaders.json
+++ b/slm_lab/spec/experimental/dqn_spaceinvaders.json
@@ -1,5 +1,5 @@
 {
-  "dqn_spaceinvaders_2k": {
+  "dqn_spaceinvaders": {
     "agent": [{
       "name": "DQN",
       "algorithm": {
@@ -48,7 +48,7 @@
         },
         "lr_scheduler_spec": null,
         "update_type": "replace",
-        "update_frequency": 2000,
+        "update_frequency": 1000,
         "gpu": true
       }
     }],

--- a/slm_lab/spec/experimental/dqn_spaceinvaders.json
+++ b/slm_lab/spec/experimental/dqn_spaceinvaders.json
@@ -38,7 +38,7 @@
         "hid_layers_activation": "relu",
         "init_fn": null,
         "batch_norm": false,
-        "clip_grad_val": 1.0,
+        "clip_grad_val": 10.0,
         "loss_spec": {
           "name": "SmoothL1Loss"
         },

--- a/slm_lab/spec/experimental/ppo_beamrider.json
+++ b/slm_lab/spec/experimental/ppo_beamrider.json
@@ -33,6 +33,7 @@
       },
       "net": {
         "type": "ConvNet",
+        "shared": true,
         "conv_hid_layers": [
           [32, 8, 4, 0, 1],
           [64, 4, 2, 0, 1],

--- a/slm_lab/spec/experimental/ppo_breakout.json
+++ b/slm_lab/spec/experimental/ppo_breakout.json
@@ -33,6 +33,7 @@
       },
       "net": {
         "type": "ConvNet",
+        "shared": true,
         "conv_hid_layers": [
           [32, 8, 4, 0, 1],
           [64, 4, 2, 0, 1],

--- a/slm_lab/spec/experimental/ppo_enduro.json
+++ b/slm_lab/spec/experimental/ppo_enduro.json
@@ -33,6 +33,7 @@
       },
       "net": {
         "type": "ConvNet",
+        "shared": true,
         "conv_hid_layers": [
           [32, 8, 4, 0, 1],
           [64, 4, 2, 0, 1],

--- a/slm_lab/spec/experimental/ppo_mspacman.json
+++ b/slm_lab/spec/experimental/ppo_mspacman.json
@@ -33,6 +33,7 @@
       },
       "net": {
         "type": "ConvNet",
+        "shared": true,
         "conv_hid_layers": [
           [32, 8, 4, 0, 1],
           [64, 4, 2, 0, 1],

--- a/slm_lab/spec/experimental/ppo_pong.json
+++ b/slm_lab/spec/experimental/ppo_pong.json
@@ -33,6 +33,7 @@
       },
       "net": {
         "type": "ConvNet",
+        "shared": true,
         "conv_hid_layers": [
           [32, 8, 4, 0, 1],
           [64, 4, 2, 0, 1],

--- a/slm_lab/spec/experimental/ppo_qbert.json
+++ b/slm_lab/spec/experimental/ppo_qbert.json
@@ -33,6 +33,7 @@
       },
       "net": {
         "type": "ConvNet",
+        "shared": true,
         "conv_hid_layers": [
           [32, 8, 4, 0, 1],
           [64, 4, 2, 0, 1],

--- a/slm_lab/spec/experimental/ppo_seaquest.json
+++ b/slm_lab/spec/experimental/ppo_seaquest.json
@@ -33,6 +33,7 @@
       },
       "net": {
         "type": "ConvNet",
+        "shared": true,
         "conv_hid_layers": [
           [32, 8, 4, 0, 1],
           [64, 4, 2, 0, 1],

--- a/slm_lab/spec/experimental/ppo_spaceinvaders.json
+++ b/slm_lab/spec/experimental/ppo_spaceinvaders.json
@@ -33,6 +33,7 @@
       },
       "net": {
         "type": "ConvNet",
+        "shared": true,
         "conv_hid_layers": [
           [32, 8, 4, 0, 1],
           [64, 4, 2, 0, 1],


### PR DESCRIPTION
## DDQN refactor and specs
- remove unnecessary network switching logic
- add `ddqn`, `dqn_per` and `ddqn_per` Atari specs
