### PR TITLE
Add out layer activation to net module

### DIFF
--- a/slm_lab/agent/net/mlp.py
+++ b/slm_lab/agent/net/mlp.py
@@ -285,6 +285,8 @@ class HydraMLPNet(Net, nn.Module):
 
     def build_model_tails(self, out_dim, out_layer_activation):
         '''Build each model_tail. These are stored as Sequential models in model_tails'''
+        if not ps.is_list(out_layer_activation):
+            out_layer_activation = [out_layer_activation] * len(out_dim)
         model_tails = nn.ModuleList()
         if ps.is_empty(self.tail_hid_layers):
             for out_d, out_activ in zip(out_dim, out_layer_activation):

--- a/slm_lab/agent/net/mlp.py
+++ b/slm_lab/agent/net/mlp.py
@@ -20,6 +20,7 @@ class MLPNet(Net, nn.Module):
         "shared": true,
         "hid_layers": [32],
         "hid_layers_activation": "relu",
+        "out_layer_activation": null,
         "init_fn": "xavier_uniform_",
         "clip_grad_val": 1.0,
         "loss_spec": {
@@ -46,6 +47,7 @@ class MLPNet(Net, nn.Module):
         net_spec:
         hid_layers: list containing dimensions of the hidden layers
         hid_layers_activation: activation function for the hidden layers
+        out_layer_activation: activation function for the output layer, same shape as out_dim
         init_fn: weight initialization function
         clip_grad_val: clip gradient norm if value is not None
         loss_spec: measure of error between model predictions and correct outputs
@@ -60,6 +62,7 @@ class MLPNet(Net, nn.Module):
         super(MLPNet, self).__init__(net_spec, in_dim, out_dim)
         # set default
         util.set_attr(self, dict(
+            out_layer_activation=None,
             init_fn=None,
             clip_grad_val=None,
             loss_spec={'name': 'MSELoss'},
@@ -74,6 +77,7 @@ class MLPNet(Net, nn.Module):
             'shared',
             'hid_layers',
             'hid_layers_activation',
+            'out_layer_activation',
             'init_fn',
             'clip_grad_val',
             'loss_spec',
@@ -90,9 +94,16 @@ class MLPNet(Net, nn.Module):
         # add last layer with no activation
         # tails. avoid list for single-tail for compute speed
         if ps.is_integer(self.out_dim):
-            self.model_tail = nn.Linear(dims[-1], self.out_dim)
+            self.model_tail = net_util.build_fc_model([dims[-1], self.out_dim], self.out_layer_activation)
         else:
-            self.model_tails = nn.ModuleList([nn.Linear(dims[-1], out_d) for out_d in self.out_dim])
+            if not ps.is_list(self.out_layer_activation):
+                self.out_layer_activation = [self.out_layer_activation] * len(out_dim)
+            assert len(self.out_layer_activation) == len(self.out_dim)
+            tails = []
+            for out_d, out_activ in zip(self.out_dim, self.out_layer_activation):
+                tail = net_util.build_fc_model([dims[-1], out_d], out_activ)
+                tails.append(tail)
+            self.model_tails = nn.ModuleList(tails)
 
         net_util.init_layers(self, self.init_fn)
         for module in self.modules():
@@ -160,6 +171,7 @@ class HydraMLPNet(Net, nn.Module):
             [] # tail, no hidden layers
         ],
         "hid_layers_activation": "relu",
+        "out_layer_activation": null,
         "init_fn": "xavier_uniform_",
         "clip_grad_val": 1.0,
         "loss_spec": {
@@ -209,6 +221,7 @@ class HydraMLPNet(Net, nn.Module):
         super(HydraMLPNet, self).__init__(net_spec, in_dim, out_dim)
         # set default
         util.set_attr(self, dict(
+            out_layer_activation=None,
             init_fn=None,
             clip_grad_val=None,
             loss_spec={'name': 'MSELoss'},
@@ -222,6 +235,7 @@ class HydraMLPNet(Net, nn.Module):
         util.set_attr(self, self.net_spec, [
             'hid_layers',
             'hid_layers_activation',
+            'out_layer_activation',
             'init_fn',
             'clip_grad_val',
             'loss_spec',
@@ -247,7 +261,7 @@ class HydraMLPNet(Net, nn.Module):
         heads_out_dim = np.sum([head_hid_layers[-1] for head_hid_layers in self.head_hid_layers])
         dims = [heads_out_dim] + self.body_hid_layers
         self.model_body = net_util.build_fc_model(dims, self.hid_layers_activation)
-        self.model_tails = self.build_model_tails(out_dim)
+        self.model_tails = self.build_model_tails(self.out_dim, self.out_layer_activation)
 
         net_util.init_layers(self, self.init_fn)
         for module in self.modules():
@@ -269,18 +283,20 @@ class HydraMLPNet(Net, nn.Module):
             model_heads.append(model_head)
         return model_heads
 
-    def build_model_tails(self, out_dim):
+    def build_model_tails(self, out_dim, out_layer_activation):
         '''Build each model_tail. These are stored as Sequential models in model_tails'''
         model_tails = nn.ModuleList()
         if ps.is_empty(self.tail_hid_layers):
-            for out_d in out_dim:
-                model_tails.append(nn.Linear(self.body_hid_layers[-1], out_d))
+            for out_d, out_activ in zip(out_dim, out_layer_activation):
+                tail = net_util.build_fc_model([self.body_hid_layers[-1], out_d], out_activ)
+                model_tails.append(tail)
         else:
             assert len(self.tail_hid_layers) == len(out_dim), 'Hydra tail hid_params inconsistent with number out dims'
-            for out_d, hid_layers in zip(out_dim, self.tail_hid_layers):
+            for out_d, out_activ, hid_layers in zip(out_dim, out_layer_activation, self.tail_hid_layers):
                 dims = hid_layers
                 model_tail = net_util.build_fc_model(dims, self.hid_layers_activation)
-                model_tail.add_module(str(len(model_tail)), nn.Linear(dims[-1], out_d))
+                tail_out = net_util.build_fc_model([dims[-1], out_d], out_activ)
+                model_tail.add_module(str(len(model_tail)), tail_out)
                 model_tails.append(model_tail)
         return model_tails
 

--- a/slm_lab/env/wrapper.py
+++ b/slm_lab/env/wrapper.py
@@ -151,7 +151,7 @@ class TransformImage(gym.ObservationWrapper):
     def observation(self, frame):
         frame = util.transform_image(frame, method='openai')
         frame = np.transpose(frame)  # reverses all axes
-        frame = np.expand_dims(frame, -1)
+        frame = np.expand_dims(frame, 0)
         return frame
 
 

--- a/slm_lab/env/wrapper.py
+++ b/slm_lab/env/wrapper.py
@@ -4,7 +4,6 @@
 from collections import deque
 from gym import spaces
 from slm_lab.lib import util
-import cv2
 import gym
 import numpy as np
 
@@ -21,7 +20,7 @@ class NoopResetEnv(gym.Wrapper):
         assert env.unwrapped.get_action_meanings()[0] == 'NOOP'
 
     def reset(self, **kwargs):
-        ''' Do no-op action for a number of steps in [1, noop_max].'''
+        '''Do no-op action for a number of steps in [1, noop_max].'''
         self.env.reset(**kwargs)
         if self.override_num_noops is not None:
             noops = self.override_num_noops
@@ -151,8 +150,8 @@ class TransformImage(gym.ObservationWrapper):
 
     def observation(self, frame):
         frame = util.transform_image(frame, method='openai')
+        frame = np.transpose(frame)  # reverses all axes
         frame = np.expand_dims(frame, -1)
-        frame = np.swapaxes(frame, 2, 0)
         return frame
 
 

--- a/slm_lab/lib/util.py
+++ b/slm_lab/lib/util.py
@@ -781,17 +781,19 @@ def transform_image(im, method='openai'):
         raise ValueError('method must be one of: nature, openai')
 
 
-def debug_image(im):
+def debug_image(im, is_chw=True):
     '''
     Renders an image for debugging; pauses process until key press
-    Handles tensor/numpy and different conventions among libraries
+    Handles tensor/numpy and conventions among libraries
     '''
     if torch.is_tensor(im):  # if PyTorch tensor, get numpy
         im = im.cpu().numpy()
-    if np.argmin(im.shape) == 0:  # if channel-first, transpose all axes
+    if is_chw:  # pytorch c,h,w convention
         im = np.transpose(im)
-    # typecast and accommodate from RGB (numpy) to BGR (cv2)
-    im = cv2.cvtColor(im.astype(np.uint8), cv2.COLOR_BGR2RGB)
+    im = im.astype(np.uint8)  # typecast guard
+    if im.shape[0] == 3:  # RGB image
+        # accommodate from RGB (numpy) to BGR (cv2)
+        im = cv2.cvtColor(im, cv2.COLOR_BGR2RGB)
     cv2.imshow('debug image', im)
     cv2.waitKey(0)
 

--- a/slm_lab/lib/util.py
+++ b/slm_lab/lib/util.py
@@ -782,8 +782,17 @@ def transform_image(im, method='openai'):
 
 
 def debug_image(im):
-    '''Use this method to render image the agent sees; waits for a key press before continuing'''
-    cv2.imshow('image', im)
+    '''
+    Renders an image for debugging; pauses process until key press
+    Handles tensor/numpy and different conventions among libraries
+    '''
+    if torch.is_tensor(im):  # if PyTorch tensor, get numpy
+        im = im.cpu().numpy()
+    if np.argmin(im.shape) == 0:  # if channel-first, transpose all axes
+        im = np.transpose(im)
+    # typecast and accommodate from RGB (numpy) to BGR (cv2)
+    im = cv2.cvtColor(im.astype(np.uint8), cv2.COLOR_BGR2RGB)
+    cv2.imshow('debug image', im)
     cv2.waitKey(0)
 
 


### PR DESCRIPTION
## Add out layer activation to net module
- add out layer activation option to net modules: MLP. Conv, recurrent
- use net spec `out_layer_activation` to specify; defaults to null
- if specified, `out_layer_activation` needs to be the same shape as out_dim, e.g. `tanh` for single scalar out_dim, or [tanh, None, ...] for a list out_dim

## Misc
- improve `util.debug_image`, and wrapper image preprocessing using transpose
