### PR TITLE
Generalize env wrapper

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -28,7 +28,6 @@ dependencies:
   - pydash=4.2.1=py_0
   - pytest-cov=2.5.1=py36_0
   - pytest-timeout=1.2.1=py_0
-  - pytest-xdist=1.26.1=py36_0
   - pytest=3.6.0=py36_0
   - python=3.6.4=0
   - pyyaml=3.12=py36_1

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup
 from setuptools.command.test import test as TestCommand
 
 test_args = [
-    '-n 4',
+    '-n 2',
     '--verbose',
     '--capture=sys',
     '--log-level=INFO',

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,6 @@ from setuptools import setup
 from setuptools.command.test import test as TestCommand
 
 test_args = [
-    '-n 2',
     '--verbose',
     '--capture=sys',
     '--log-level=INFO',

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup
 from setuptools.command.test import test as TestCommand
 
 test_args = [
-    '-n 2',
+    '-n 4',
     '--verbose',
     '--capture=sys',
     '--log-level=INFO',

--- a/slm_lab/agent/algorithm/base.py
+++ b/slm_lab/agent/algorithm/base.py
@@ -49,8 +49,8 @@ class Algorithm(ABC):
         '''
         assert hasattr(self, 'net_names')
         if util.in_eval_lab_modes():
-            logger.info(f'Loaded algorithm models for lab_mode: {util.get_lab_mode()}')
             self.load()
+            logger.info(f'Loaded algorithm models for lab_mode: {util.get_lab_mode()}')
         else:
             logger.info(f'Initialized algorithm models for lab_mode: {util.get_lab_mode()}')
 

--- a/slm_lab/env/unity.py
+++ b/slm_lab/env/unity.py
@@ -62,7 +62,8 @@ class UnityEnv(BaseEnv):
         super(UnityEnv, self).__init__(spec, e, env_space)
         util.set_attr(self, self.env_spec, ['unity'])
         worker_id = int(f'{os.getpid()}{self.e+int(ps.unique_id())}'[-4:])
-        self.u_env = UnityEnvironment(file_name=get_env_path(self.name), worker_id=worker_id)
+        seed = ps.get(spec, 'meta.random_seed')
+        self.u_env = UnityEnvironment(file_name=get_env_path(self.name), worker_id=worker_id, seed=seed)
         self.patch_gym_spaces(self.u_env)
         self._set_attr_from_u_env(self.u_env)
         assert self.max_t is not None

--- a/slm_lab/env/unity.py
+++ b/slm_lab/env/unity.py
@@ -63,7 +63,8 @@ class UnityEnv(BaseEnv):
         util.set_attr(self, self.env_spec, ['unity'])
         worker_id = int(f'{os.getpid()}{self.e+int(ps.unique_id())}'[-4:])
         seed = ps.get(spec, 'meta.random_seed')
-        self.u_env = UnityEnvironment(file_name=get_env_path(self.name), worker_id=worker_id, seed=seed)
+        # TODO update Unity ml-agents to use seed=seed below
+        self.u_env = UnityEnvironment(file_name=get_env_path(self.name), worker_id=worker_id)
         self.patch_gym_spaces(self.u_env)
         self._set_attr_from_u_env(self.u_env)
         assert self.max_t is not None

--- a/slm_lab/experiment/control.py
+++ b/slm_lab/experiment/control.py
@@ -28,15 +28,15 @@ class Session:
         self.info_space = info_space
         self.index = self.info_space.get('session')
         util.set_random_seed(self.info_space.get('trial'), self.index, self.spec)
+        util.set_cuda_id(self.spec, self.info_space)
         util.set_logger(self.spec, self.info_space, logger, 'session')
-        self.data = None
         analysis.save_spec(spec, info_space, unit='session')
+        self.data = None
 
         # init singleton agent and env
         self.env = make_env(self.spec)
         with util.ctx_lab_mode('eval'):  # env for eval
             self.eval_env = make_env(self.spec)
-        util.try_set_cuda_id(self.spec, self.info_space)
         body = Body(self.env, self.spec['agent'])
         self.agent = Agent(self.spec, self.info_space, body=body, global_nets=global_nets)
 
@@ -122,14 +122,14 @@ class SpaceSession(Session):
         self.info_space = info_space
         self.index = self.info_space.get('session')
         util.set_random_seed(self.info_space.get('trial'), self.index, self.spec)
+        util.set_cuda_id(self.spec, self.info_space)
         util.set_logger(self.spec, self.info_space, logger, 'session')
-        self.data = None
         analysis.save_spec(spec, info_space, unit='session')
+        self.data = None
 
         self.aeb_space = AEBSpace(self.spec, self.info_space)
         self.env_space = EnvSpace(self.spec, self.aeb_space)
         self.aeb_space.init_body_space()
-        util.try_set_cuda_id(self.spec, self.info_space)
         self.agent_space = AgentSpace(self.spec, self.aeb_space, global_nets)
 
         logger.info(util.self_desc(self))
@@ -204,9 +204,9 @@ class Trial:
         self.index = self.info_space.get('trial')
         info_space.set('session', None)  # Session starts anew for new trial
         util.set_logger(self.spec, self.info_space, logger, 'trial')
+        analysis.save_spec(spec, info_space, unit='trial')
         self.session_data_dict = {}
         self.data = None
-        analysis.save_spec(spec, info_space, unit='trial')
 
         self.is_singleton = spec_util.is_singleton(spec)  # singleton mode as opposed to multi-agent-env space
         self.SessionClass = Session if self.is_singleton else SpaceSession
@@ -299,9 +299,9 @@ class Experiment:
         self.info_space = info_space
         self.index = self.info_space.get('experiment')
         util.set_logger(self.spec, self.info_space, logger, 'trial')
+        analysis.save_spec(spec, info_space, unit='experiment')
         self.trial_data_dict = {}
         self.data = None
-        analysis.save_spec(spec, info_space, unit='experiment')
         SearchClass = getattr(search, spec['meta'].get('search'))
         self.search = SearchClass(self)
         logger.info(f'Initialized experiment {self.index}')

--- a/slm_lab/experiment/control.py
+++ b/slm_lab/experiment/control.py
@@ -27,15 +27,15 @@ class Session:
         self.spec = spec
         self.info_space = info_space
         self.index = self.info_space.get('session')
+        util.set_random_seed(self.info_space.get('trial'), self.index, self.spec)
         util.set_logger(self.spec, self.info_space, logger, 'session')
         self.data = None
+        analysis.save_spec(spec, info_space, unit='session')
 
         # init singleton agent and env
         self.env = make_env(self.spec)
-        util.set_random_seed(self.info_space.get_random_seed(), self.env)
         with util.ctx_lab_mode('eval'):  # env for eval
             self.eval_env = make_env(self.spec)
-            util.set_random_seed(self.info_space.get_random_seed(), self.eval_env)
         util.try_set_cuda_id(self.spec, self.info_space)
         body = Body(self.env, self.spec['agent'])
         self.agent = Agent(self.spec, self.info_space, body=body, global_nets=global_nets)
@@ -121,13 +121,14 @@ class SpaceSession(Session):
         self.spec = spec
         self.info_space = info_space
         self.index = self.info_space.get('session')
+        util.set_random_seed(self.info_space.get('trial'), self.index, self.spec)
         util.set_logger(self.spec, self.info_space, logger, 'session')
         self.data = None
+        analysis.save_spec(spec, info_space, unit='session')
 
         self.aeb_space = AEBSpace(self.spec, self.info_space)
         self.env_space = EnvSpace(self.spec, self.aeb_space)
         self.aeb_space.init_body_space()
-        util.set_random_seed(self.info_space.get_random_seed(), self.env_space)
         util.try_set_cuda_id(self.spec, self.info_space)
         self.agent_space = AgentSpace(self.spec, self.aeb_space, global_nets)
 
@@ -205,8 +206,8 @@ class Trial:
         util.set_logger(self.spec, self.info_space, logger, 'trial')
         self.session_data_dict = {}
         self.data = None
-
         analysis.save_spec(spec, info_space, unit='trial')
+
         self.is_singleton = spec_util.is_singleton(spec)  # singleton mode as opposed to multi-agent-env space
         self.SessionClass = Session if self.is_singleton else SpaceSession
         self.mp_runner = init_run_session if self.is_singleton else init_run_space_session

--- a/slm_lab/experiment/control.py
+++ b/slm_lab/experiment/control.py
@@ -32,10 +32,10 @@ class Session:
 
         # init singleton agent and env
         self.env = make_env(self.spec)
-        util.set_rand_seed(self.info_space.get_random_seed(), self.env)
+        util.set_random_seed(self.info_space.get_random_seed(), self.env)
         with util.ctx_lab_mode('eval'):  # env for eval
             self.eval_env = make_env(self.spec)
-            util.set_rand_seed(self.info_space.get_random_seed(), self.eval_env)
+            util.set_random_seed(self.info_space.get_random_seed(), self.eval_env)
         util.try_set_cuda_id(self.spec, self.info_space)
         body = Body(self.env, self.spec['agent'])
         self.agent = Agent(self.spec, self.info_space, body=body, global_nets=global_nets)
@@ -127,7 +127,7 @@ class SpaceSession(Session):
         self.aeb_space = AEBSpace(self.spec, self.info_space)
         self.env_space = EnvSpace(self.spec, self.aeb_space)
         self.aeb_space.init_body_space()
-        util.set_rand_seed(self.info_space.get_random_seed(), self.env_space)
+        util.set_random_seed(self.info_space.get_random_seed(), self.env_space)
         util.try_set_cuda_id(self.spec, self.info_space)
         self.agent_space = AgentSpace(self.spec, self.aeb_space, global_nets)
 

--- a/slm_lab/experiment/monitor.py
+++ b/slm_lab/experiment/monitor.py
@@ -488,7 +488,3 @@ class InfoSpace:
     def set(self, axis, val):
         self.coor[axis] = val
         return self.coor[axis]
-
-    def get_random_seed(self):
-        '''Standard method to get random seed for a session'''
-        return int(1e5 * (self.get('trial') or 0) + 1e3 * (self.get('session') or 0) + time.time())

--- a/slm_lab/lib/util.py
+++ b/slm_lab/lib/util.py
@@ -564,23 +564,20 @@ def set_attr(obj, attr_dict, keys=None):
     return obj
 
 
-def set_random_seed(random_seed, env_space):
-    '''Set all the module random seeds'''
-    torch.cuda.manual_seed_all(random_seed)
-    torch.manual_seed(random_seed)
-    np.random.seed(random_seed)
-    envs = env_space.envs if hasattr(env_space, 'envs') else [env_space]
-    for env in envs:
-        try:
-            env.u_env.seed(random_seed)
-        except Exception as e:
-            pass
-
-
 def set_logger(spec, info_space, logger, unit=None):
     '''Set the logger for a lab unit give its spec and info_space'''
     os.environ['PREPATH'] = get_prepath(spec, info_space, unit=unit)
     reload(logger)  # to set session-specific logger
+
+
+def set_random_seed(trial, session, spec):
+    '''Generate and set random seed for relevant modules, and record it in spec.meta.random_seed'''
+    random_seed = int(1e5 * (trial or 0) + 1e3 * (session or 0) + time.time())
+    torch.cuda.manual_seed_all(random_seed)
+    torch.manual_seed(random_seed)
+    np.random.seed(random_seed)
+    spec['meta']['random_seed'] = random_seed
+    return random_seed
 
 
 def _sizeof(obj, seen=None):

--- a/slm_lab/lib/util.py
+++ b/slm_lab/lib/util.py
@@ -564,7 +564,7 @@ def set_attr(obj, attr_dict, keys=None):
     return obj
 
 
-def set_rand_seed(random_seed, env_space):
+def set_random_seed(random_seed, env_space):
     '''Set all the module random seeds'''
     torch.cuda.manual_seed_all(random_seed)
     torch.manual_seed(random_seed)

--- a/slm_lab/lib/util.py
+++ b/slm_lab/lib/util.py
@@ -651,7 +651,7 @@ def to_torch_batch(batch, device, is_episodic):
     return batch
 
 
-def try_set_cuda_id(spec, info_space):
+def set_cuda_id(spec, info_space):
     '''Use trial and session id to hash and modulo cuda device count for a cuda_id to maximize device usage. Sets the net_spec for the base Net class to pick up.'''
     # Don't trigger any cuda call if not using GPU. Otherwise will break multiprocessing on machines with CUDA.
     # see issues https://github.com/pytorch/pytorch/issues/334 https://github.com/pytorch/pytorch/issues/3491 https://github.com/pytorch/pytorch/issues/9996

--- a/slm_lab/lib/util.py
+++ b/slm_lab/lib/util.py
@@ -12,6 +12,7 @@ import pydash as ps
 import regex as re
 import subprocess
 import sys
+import time
 import torch
 import torch.multiprocessing as mp
 import ujson


### PR DESCRIPTION
## Feature / Fix
- generalize env wrapper and `make_gym_env` method
- introduce proper method `util.set_random_seed` with better arg design. passes env random seed via `spec.meta.random_seed`. Introduce session spec saved file for reproducibility with random seed
- standardize `set_cuda_id` method too
