### PR TITLE
Change a,r,s' interface to s,a,r,s'

### DIFF
--- a/slm_lab/agent/memory/base.py
+++ b/slm_lab/agent/memory/base.py
@@ -24,8 +24,6 @@ class Memory(ABC):
 
         # declare what data keys to store
         self.data_keys = ['states', 'actions', 'rewards', 'next_states', 'dones', 'priorities']
-        # the basic variables for every memory
-        self.last_state = None
         # method to log size warning only once to prevent spamming log
         self.warn_size_once = ps.once(lambda msg: logger.warn(msg))
         # for API consistency, reset to some max_len in your specific memory class
@@ -40,27 +38,25 @@ class Memory(ABC):
 
     def epi_reset(self, state):
         '''Method to reset at new episode'''
-        self.last_state = state
         self.body.epi_reset()
         self.total_reward = 0
         self.state_buffer.clear()
         for _ in range(self.state_buffer.maxlen):
             self.state_buffer.append(np.zeros(self.body.state_dim))
 
-    def base_update(self, action, reward, state, done):
+    def base_update(self, state, action, reward, next_state, done):
         '''Method to do base memory update, like stats'''
-        from slm_lab.experiment import analysis
         if np.isnan(reward):  # the start of episode
-            self.epi_reset(state)
+            self.epi_reset(next_state)
             return
 
         self.total_reward += reward
         return
 
     @abstractmethod
-    def update(self, action, reward, state, done):
-        '''Implement memory update given the full info from the latest timestep. Hint: use self.last_state to construct SARS. NOTE: guard for np.nan reward and done when individual env resets.'''
-        self.base_update(action, reward, state, done)
+    def update(self, state, action, reward, next_state, done):
+        '''Implement memory update given the full info from the latest timestep. NOTE: guard for np.nan reward and done when individual env resets.'''
+        self.base_update(state, action, reward, next_state, done)
         raise NotImplementedError
 
     @abstractmethod

--- a/slm_lab/agent/memory/onpolicy.py
+++ b/slm_lab/agent/memory/onpolicy.py
@@ -61,12 +61,11 @@ class OnPolicyReplay(Memory):
             self.state_buffer.append(np.zeros(self.body.state_dim))
 
     @lab_api
-    def update(self, action, reward, state, done):
+    def update(self, state, action, reward, next_state, done):
         '''Interface method to update memory'''
-        self.base_update(action, reward, state, done)
+        self.base_update(state, action, reward, next_state, done)
         if not np.isnan(reward):  # not the start of episode
-            self.add_experience(self.last_state, action, reward, state, done)
-        self.last_state = state
+            self.add_experience(state, action, reward, next_state, done)
 
     def add_experience(self, state, action, reward, next_state, done):
         '''Interface helper method for update() to add experience to memory'''
@@ -326,13 +325,14 @@ class OnPolicyConcatReplay(OnPolicyReplay):
         return np.concatenate(self.state_buffer)
 
     @lab_api
-    def update(self, action, reward, state, done):
+    def update(self, state, action, reward, next_state, done):
         '''Interface method to update memory'''
-        self.base_update(action, reward, state, done)
-        state = self.preprocess_state(state, append=False)  # prevent conflict with preprocess in epi_reset
+        self.base_update(state, action, reward, next_state, done)
+        # prevent conflict with preprocess in epi_reset
+        state = self.preprocess_state(state, append=False)
+        next_state = self.preprocess_state(next_state, append=False)
         if not np.isnan(reward):  # not the start of episode
-            self.add_experience(self.last_state, action, reward, state, done)
-        self.last_state = state
+            self.add_experience(state, action, reward, next_state, done)
 
 
 class OnPolicyAtariReplay(OnPolicyReplay):

--- a/slm_lab/agent/memory/replay.py
+++ b/slm_lab/agent/memory/replay.py
@@ -82,13 +82,14 @@ class Replay(Memory):
         super(Replay, self).epi_reset(self.preprocess_state(state, append=False))
 
     @lab_api
-    def update(self, action, reward, state, done):
+    def update(self, state, action, reward, next_state, done):
         '''Interface method to update memory'''
-        self.base_update(action, reward, state, done)
-        state = self.preprocess_state(state, append=False)  # prevent conflict with preprocess in epi_reset
+        self.base_update(state, action, reward, next_state, done)
+        # prevent conflict with preprocess in epi_reset
+        state = self.preprocess_state(state, append=False)
+        next_state = self.preprocess_state(next_state, append=False)
         if not np.isnan(reward):  # not the start of episode
-            self.add_experience(self.last_state, action, reward, state, done)
-        self.last_state = state
+            self.add_experience(state, action, reward, next_state, done)
 
     def add_experience(self, state, action, reward, next_state, done):
         '''Implementation for update() to add experience to memory, expanding the memory size if necessary'''
@@ -199,7 +200,7 @@ class SILReplay(Replay):
         self.reset()
 
     @lab_api
-    def update(self, action, reward, state, done):
+    def update(self, state, action, reward, next_state, done):
         '''Interface method to update memory'''
         raise AssertionError('Do not call SIL memory in main API control loop')
 

--- a/slm_lab/experiment/control.py
+++ b/slm_lab/experiment/control.py
@@ -90,8 +90,9 @@ class Session:
             self.try_ckpt(self.agent, self.env)
             self.env.clock.tick('t')
             action = self.agent.act(state)
-            reward, state, done = self.env.step(action)
-            self.agent.update(action, reward, state, done)
+            reward, next_state, done = self.env.step(action)
+            self.agent.update(state, action, reward, next_state, done)
+            state = next_state
         self.try_ckpt(self.agent, self.env)  # final timestep ckpt
         self.agent.body.log_summary(body_df_kind='train')
 
@@ -156,8 +157,9 @@ class SpaceSession(Session):
             self.try_ckpt(self.agent_space, self.env_space)
             all_done = self.aeb_space.tick()
             action_space = self.agent_space.act(state_space)
-            reward_space, state_space, done_space = self.env_space.step(action_space)
-            self.agent_space.update(action_space, reward_space, state_space, done_space)
+            reward_space, next_state_space, done_space = self.env_space.step(action_space)
+            self.agent_space.update(state_space, action_space, reward_space, next_state_space, done_space)
+            state_space = next_state_space
         self.try_ckpt(self.agent_space, self.env_space)
         retro_analysis.try_wait_parallel_eval(self)
 


### PR DESCRIPTION
## Change interface to s,a,r,s'
- change all the interface from `action, reward, state` to `state, action, reward, next_state` and propagate in all methods
- this is a safe interface change without affecting logic. all changes are traceable and complete. Procedure: add new argument, rename old `state` to `next_state`.
- this means the internal variable `self.last_state` of memory is no longer needed
- changes done in:
  - control loop for singleton and space, which affects
  - `agent.update`, which affects
  - `memory.update`, which affects
  - `memory.base_update` and `memory.add_experience`

