### PR TITLE
Update env reset interface

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,8 +6,6 @@
   "scripts": {
     "start": "python run_lab.py",
     "debug": "LOG_LEVEL=DEBUG python run_lab.py",
-    "debug2": "LOG_LEVEL=DEBUG2 python run_lab.py",
-    "debug3": "LOG_LEVEL=DEBUG3 python run_lab.py",
     "retro_analyze": "python -c 'import sys; from slm_lab.experiment import retro_analysis; retro_analysis.retro_analyze(sys.argv[1])'",
     "retro_eval": "python -c 'import sys; from slm_lab.experiment import retro_analysis; retro_analysis.retro_eval(sys.argv[1])'",
     "reset": "rm -rf data/* .cache __pycache__ */__pycache__ *egg-info .pytest* htmlcov .coverage* *.xml",

--- a/slm_lab/agent/__init__.py
+++ b/slm_lab/agent/__init__.py
@@ -71,6 +71,7 @@ class Agent:
     def update(self, state, action, reward, next_state, done):
         '''Update per timestep after env transitions, e.g. memory, algorithm, update agent params, train net'''
         self.body.action_pd_update()
+        self.body.update(state, action, reward, next_state, done)
         self.body.memory.update(state, action, reward, next_state, done)
         loss = self.algorithm.train()
         if not np.isnan(loss):  # set for log_summary()
@@ -136,6 +137,7 @@ class Agent:
         '''Update per timestep after env transitions, e.g. memory, algorithm, update agent params, train net'''
         for eb, body in util.ndenumerate_nonan(self.body_a):
             body.action_pd_update()
+            body.update(state_a[eb], action_a[eb], reward_a[eb], next_state_a[eb], done_a[eb])
             body.memory.update(state_a[eb], action_a[eb], reward_a[eb], next_state_a[eb], done_a[eb])
         loss_a = self.algorithm.space_train()
         loss_a = util.guard_data_a(self, loss_a, 'loss')

--- a/slm_lab/agent/__init__.py
+++ b/slm_lab/agent/__init__.py
@@ -183,7 +183,6 @@ class AgentSpace:
 
     @lab_api
     def reset(self, state_space):
-        logger.debug3('AgentSpace.reset')
         _action_v, _loss_v, _explore_var_v = self.aeb_space.init_data_v(AGENT_DATA_NAMES)
         for agent in self.agents:
             state_a = state_space.get(a=agent.a)

--- a/slm_lab/agent/__init__.py
+++ b/slm_lab/agent/__init__.py
@@ -188,7 +188,7 @@ class AgentSpace:
             state_a = state_space.get(a=agent.a)
             agent.space_reset(state_a)
         _action_space, _loss_space, _explore_var_space = self.aeb_space.add(AGENT_DATA_NAMES, (_action_v, _loss_v, _explore_var_v))
-        logger.debug3(f'action_space: {_action_space}')
+        logger.debug(f'action_space: {_action_space}')
         return _action_space
 
     @lab_api
@@ -201,7 +201,7 @@ class AgentSpace:
             action_a = agent.space_act(state_a)
             action_v[a, 0:len(action_a)] = action_a
         action_space, = self.aeb_space.add(data_names, (action_v,))
-        logger.debug3(f'\naction_space: {action_space}')
+        logger.debug(f'\naction_space: {action_space}')
         return action_space
 
     @lab_api
@@ -219,7 +219,7 @@ class AgentSpace:
             loss_v[a, 0:len(loss_a)] = loss_a
             explore_var_v[a, 0:len(explore_var_a)] = explore_var_a
         loss_space, explore_var_space = self.aeb_space.add(data_names, (loss_v, explore_var_v))
-        logger.debug3(f'\nloss_space: {loss_space}\nexplore_var_space: {explore_var_space}')
+        logger.debug(f'\nloss_space: {loss_space}\nexplore_var_space: {explore_var_space}')
         return loss_space, explore_var_space
 
     @lab_api

--- a/slm_lab/agent/algorithm/actor_critic.py
+++ b/slm_lab/agent/algorithm/actor_critic.py
@@ -227,7 +227,7 @@ class ActorCritic(Reinforce):
             # reset
             self.to_train = 0
             self.body.flush()
-            logger.debug(f'Trained {self.name} at epi: {clock.epi}, total_t: {clock.total_t}, t: {clock.t}, total_reward so far: {self.body.memory.total_reward}, loss: {loss:g}')
+            logger.debug(f'Trained {self.name} at epi: {clock.epi}, total_t: {clock.total_t}, t: {clock.t}, total_reward so far: {self.body.total_reward}, loss: {loss:g}')
             return loss.item()
         else:
             return np.nan

--- a/slm_lab/agent/algorithm/dqn.py
+++ b/slm_lab/agent/algorithm/dqn.py
@@ -148,7 +148,7 @@ class VanillaDQN(SARSA):
             # reset
             self.to_train = 0
             self.body.flush()
-            logger.debug(f'Trained {self.name} at epi: {clock.epi}, total_t: {clock.total_t}, t: {clock.t}, total_reward so far: {self.body.memory.total_reward}, loss: {loss:g}')
+            logger.debug(f'Trained {self.name} at epi: {clock.epi}, total_t: {clock.total_t}, t: {clock.t}, total_reward so far: {self.body.total_reward}, loss: {loss:g}')
             return loss.item()
         else:
             return np.nan

--- a/slm_lab/agent/algorithm/hydra_dqn.py
+++ b/slm_lab/agent/algorithm/hydra_dqn.py
@@ -117,7 +117,7 @@ class HydraDQN(DQN):
             self.to_train = 0
             for body in self.agent.nanflat_body_a:
                 body.flush()
-            logger.debug(f'Trained {self.name} at epi: {clock.epi}, total_t: {clock.total_t}, t: {clock.t}, total_reward so far: {self.body.memory.total_reward}, loss: {loss:g}')
+            logger.debug(f'Trained {self.name} at epi: {clock.epi}, total_t: {clock.total_t}, t: {clock.t}, total_reward so far: {self.body.total_reward}, loss: {loss:g}')
             return loss.item()
         else:
             return np.nan

--- a/slm_lab/agent/algorithm/ppo.py
+++ b/slm_lab/agent/algorithm/ppo.py
@@ -172,7 +172,7 @@ class PPO(ActorCritic):
             # reset
             self.to_train = 0
             self.body.flush()
-            logger.debug(f'Trained {self.name} at epi: {clock.epi}, total_t: {clock.total_t}, t: {clock.t}, total_reward so far: {self.body.memory.total_reward}, loss: {loss:g}')
+            logger.debug(f'Trained {self.name} at epi: {clock.epi}, total_t: {clock.total_t}, t: {clock.t}, total_reward so far: {self.body.total_reward}, loss: {loss:g}')
             return loss.item()
         else:
             return np.nan
@@ -192,7 +192,7 @@ class PPO(ActorCritic):
             # reset
             self.to_train = 0
             self.body.flush()
-            logger.debug(f'Trained {self.name} at epi: {clock.epi}, total_t: {clock.total_t}, t: {clock.t}, total_reward so far: {self.body.memory.total_reward}, loss: {loss:g}')
+            logger.debug(f'Trained {self.name} at epi: {clock.epi}, total_t: {clock.total_t}, t: {clock.t}, total_reward so far: {self.body.total_reward}, loss: {loss:g}')
             return loss.item()
         else:
             return np.nan

--- a/slm_lab/agent/algorithm/reinforce.py
+++ b/slm_lab/agent/algorithm/reinforce.py
@@ -138,7 +138,7 @@ class Reinforce(Algorithm):
             # reset
             self.to_train = 0
             self.body.flush()
-            logger.debug(f'Trained {self.name} at epi: {clock.epi}, total_t: {clock.total_t}, t: {clock.t}, total_reward so far: {self.body.memory.total_reward}, loss: {loss:g}')
+            logger.debug(f'Trained {self.name} at epi: {clock.epi}, total_t: {clock.total_t}, t: {clock.t}, total_reward so far: {self.body.total_reward}, loss: {loss:g}')
             return loss.item()
         else:
             return np.nan

--- a/slm_lab/agent/algorithm/sarsa.py
+++ b/slm_lab/agent/algorithm/sarsa.py
@@ -150,7 +150,7 @@ class SARSA(Algorithm):
             # reset
             self.to_train = 0
             self.body.flush()
-            logger.debug(f'Trained {self.name} at epi: {clock.epi}, total_t: {clock.total_t}, t: {clock.t}, total_reward so far: {self.body.memory.total_reward}, loss: {loss:g}')
+            logger.debug(f'Trained {self.name} at epi: {clock.epi}, total_t: {clock.total_t}, t: {clock.t}, total_reward so far: {self.body.total_reward}, loss: {loss:g}')
             return loss.item()
         else:
             return np.nan

--- a/slm_lab/agent/algorithm/sil.py
+++ b/slm_lab/agent/algorithm/sil.py
@@ -151,7 +151,7 @@ class SIL(ActorCritic):
                     total_sil_loss += sil_loss
             sil_loss = total_sil_loss / self.training_epoch
             loss = super_loss + sil_loss
-            logger.debug(f'Trained {self.name} at epi: {clock.epi}, total_t: {clock.total_t}, t: {clock.t}, total_reward so far: {self.body.memory.total_reward}, loss: {loss:g}')
+            logger.debug(f'Trained {self.name} at epi: {clock.epi}, total_t: {clock.total_t}, t: {clock.t}, total_reward so far: {self.body.total_reward}, loss: {loss:g}')
             return loss.item()
         else:
             return np.nan
@@ -175,7 +175,7 @@ class SIL(ActorCritic):
                     total_sil_loss += sil_policy_loss + sil_val_loss
             sil_loss = total_sil_loss / self.training_epoch
             loss = super_loss + sil_loss
-            logger.debug(f'Trained {self.name} at epi: {clock.epi}, total_t: {clock.total_t}, t: {clock.t}, total_reward so far: {self.body.memory.total_reward}, loss: {loss:g}')
+            logger.debug(f'Trained {self.name} at epi: {clock.epi}, total_t: {clock.total_t}, t: {clock.t}, total_reward so far: {self.body.total_reward}, loss: {loss:g}')
             return loss.item()
         else:
             return np.nan

--- a/slm_lab/agent/memory/base.py
+++ b/slm_lab/agent/memory/base.py
@@ -24,8 +24,6 @@ class Memory(ABC):
 
         # declare what data keys to store
         self.data_keys = ['states', 'actions', 'rewards', 'next_states', 'dones', 'priorities']
-        # method to log size warning only once to prevent spamming log
-        self.warn_size_once = ps.once(lambda msg: logger.warn(msg))
         # for API consistency, reset to some max_len in your specific memory class
         self.state_buffer = deque(maxlen=0)
 

--- a/slm_lab/agent/memory/base.py
+++ b/slm_lab/agent/memory/base.py
@@ -41,15 +41,9 @@ class Memory(ABC):
         for _ in range(self.state_buffer.maxlen):
             self.state_buffer.append(np.zeros(self.body.state_dim))
 
-    def base_update(self, state, action, reward, next_state, done):
-        '''Method to do base memory update, like stats'''
-        if np.isnan(reward):  # the start of episode
-            self.epi_reset(next_state)
-
     @abstractmethod
     def update(self, state, action, reward, next_state, done):
         '''Implement memory update given the full info from the latest timestep. NOTE: guard for np.nan reward and done when individual env resets.'''
-        self.base_update(state, action, reward, next_state, done)
         raise NotImplementedError
 
     @abstractmethod

--- a/slm_lab/agent/memory/base.py
+++ b/slm_lab/agent/memory/base.py
@@ -28,8 +28,6 @@ class Memory(ABC):
         self.warn_size_once = ps.once(lambda msg: logger.warn(msg))
         # for API consistency, reset to some max_len in your specific memory class
         self.state_buffer = deque(maxlen=0)
-        # total_reward and its history over episodes
-        self.total_reward = 0
 
     @abstractmethod
     def reset(self):
@@ -39,7 +37,6 @@ class Memory(ABC):
     def epi_reset(self, state):
         '''Method to reset at new episode'''
         self.body.epi_reset()
-        self.total_reward = 0
         self.state_buffer.clear()
         for _ in range(self.state_buffer.maxlen):
             self.state_buffer.append(np.zeros(self.body.state_dim))
@@ -48,10 +45,6 @@ class Memory(ABC):
         '''Method to do base memory update, like stats'''
         if np.isnan(reward):  # the start of episode
             self.epi_reset(next_state)
-            return
-
-        self.total_reward += reward
-        return
 
     @abstractmethod
     def update(self, state, action, reward, next_state, done):

--- a/slm_lab/agent/memory/onpolicy.py
+++ b/slm_lab/agent/memory/onpolicy.py
@@ -42,7 +42,7 @@ class OnPolicyReplay(Memory):
         self.state_buffer = deque(maxlen=0)  # for API consistency
         # Don't want total experiences reset when memory is
         self.is_episodic = True
-        self.true_size = 0  # to number of experiences stored
+        self.size = 0  # to number of experiences stored
         self.seen_size = 0  # the number of experiences seen, including those stored and discarded
         # declare what data keys to store
         self.data_keys = ['states', 'actions', 'rewards', 'next_states', 'dones']
@@ -55,7 +55,7 @@ class OnPolicyReplay(Memory):
             setattr(self, k, [])
         self.cur_epi_data = {k: [] for k in self.data_keys}
         self.most_recent = [None] * len(self.data_keys)
-        self.true_size = 0  # Size of the current memory
+        self.size = 0  # Size of the current memory
         self.state_buffer.clear()
         for _ in range(self.state_buffer.maxlen):
             self.state_buffer.append(np.zeros(self.body.state_dim))
@@ -82,9 +82,9 @@ class OnPolicyReplay(Memory):
             if len(self.states) == self.body.agent.algorithm.training_frequency:
                 self.body.agent.algorithm.to_train = 1
         # Track memory size and num experiences
-        self.true_size += 1
-        if self.true_size > 1000:
-            self.warn_size_once('Large memory size: {}'.format(self.true_size))
+        self.size += 1
+        if self.size > 1000:
+            self.warn_size_once('Large memory size: {}'.format(self.size))
         self.seen_size += 1
 
     def get_most_recent_experience(self):
@@ -205,9 +205,9 @@ class OnPolicyBatchReplay(OnPolicyReplay):
         for idx, k in enumerate(self.data_keys):
             getattr(self, k).append(self.most_recent[idx])
         # Track memory size and num experiences
-        self.true_size += 1
-        if self.true_size > 1000:
-            self.warn_size_once('Large memory size: {}'.format(self.true_size))
+        self.size += 1
+        if self.size > 1000:
+            self.warn_size_once('Large memory size: {}'.format(self.size))
         self.seen_size += 1
         # Decide if agent is to train
         if len(self.states) == self.body.agent.algorithm.training_frequency:

--- a/slm_lab/agent/memory/onpolicy.py
+++ b/slm_lab/agent/memory/onpolicy.py
@@ -63,8 +63,9 @@ class OnPolicyReplay(Memory):
     @lab_api
     def update(self, state, action, reward, next_state, done):
         '''Interface method to update memory'''
-        self.base_update(state, action, reward, next_state, done)
-        if not np.isnan(reward):  # not the start of episode
+        if np.isnan(reward):  # start of episode
+            self.epi_reset(next_state)
+        else:
             self.add_experience(state, action, reward, next_state, done)
 
     def add_experience(self, state, action, reward, next_state, done):
@@ -327,11 +328,12 @@ class OnPolicyConcatReplay(OnPolicyReplay):
     @lab_api
     def update(self, state, action, reward, next_state, done):
         '''Interface method to update memory'''
-        self.base_update(state, action, reward, next_state, done)
-        # prevent conflict with preprocess in epi_reset
-        state = self.preprocess_state(state, append=False)
-        next_state = self.preprocess_state(next_state, append=False)
-        if not np.isnan(reward):  # not the start of episode
+        if np.isnan(reward):  # start of episode
+            self.epi_reset(next_state)
+        else:
+            # prevent conflict with preprocess in epi_reset
+            state = self.preprocess_state(state, append=False)
+            next_state = self.preprocess_state(next_state, append=False)
             self.add_experience(state, action, reward, next_state, done)
 
 

--- a/slm_lab/agent/memory/onpolicy.py
+++ b/slm_lab/agent/memory/onpolicy.py
@@ -42,8 +42,8 @@ class OnPolicyReplay(Memory):
         self.state_buffer = deque(maxlen=0)  # for API consistency
         # Don't want total experiences reset when memory is
         self.is_episodic = True
-        self.size = 0  # to number of experiences stored
-        self.seen_size = 0  # the number of experiences seen, including those stored and discarded
+        self.size = 0  # total experiences stored
+        self.seen_size = 0  # total experiences seen cumulatively
         # declare what data keys to store
         self.data_keys = ['states', 'actions', 'rewards', 'next_states', 'dones']
         self.reset()
@@ -55,7 +55,7 @@ class OnPolicyReplay(Memory):
             setattr(self, k, [])
         self.cur_epi_data = {k: [] for k in self.data_keys}
         self.most_recent = [None] * len(self.data_keys)
-        self.size = 0  # Size of the current memory
+        self.size = 0
         self.state_buffer.clear()
         for _ in range(self.state_buffer.maxlen):
             self.state_buffer.append(np.zeros(self.body.state_dim))
@@ -84,8 +84,6 @@ class OnPolicyReplay(Memory):
                 self.body.agent.algorithm.to_train = 1
         # Track memory size and num experiences
         self.size += 1
-        if self.size > 1000:
-            self.warn_size_once('Large memory size: {}'.format(self.size))
         self.seen_size += 1
 
     def get_most_recent_experience(self):
@@ -207,8 +205,6 @@ class OnPolicyBatchReplay(OnPolicyReplay):
             getattr(self, k).append(self.most_recent[idx])
         # Track memory size and num experiences
         self.size += 1
-        if self.size > 1000:
-            self.warn_size_once('Large memory size: {}'.format(self.size))
         self.seen_size += 1
         # Decide if agent is to train
         if len(self.states) == self.body.agent.algorithm.training_frequency:

--- a/slm_lab/agent/memory/replay.py
+++ b/slm_lab/agent/memory/replay.py
@@ -48,7 +48,7 @@ class Replay(Memory):
         self.state_buffer = deque(maxlen=0)  # for API consistency
         self.is_episodic = False
         self.batch_idxs = None
-        self.true_size = 0  # to number of experiences stored
+        self.size = 0  # to number of experiences stored
         self.seen_size = 0  # the number of experiences seen, including those stored and discarded
         self.head = -1  # index of most recent experience
         # declare what data keys to store
@@ -71,7 +71,7 @@ class Replay(Memory):
                 setattr(self, k, np.zeros(self.actions_shape, dtype=self.body.action_space.dtype))
             else:
                 setattr(self, k, np.zeros(self.scalar_shape, dtype=np.float16))
-        self.true_size = 0
+        self.size = 0
         self.head = -1
         self.state_buffer.clear()
         for _ in range(self.state_buffer.maxlen):
@@ -101,8 +101,8 @@ class Replay(Memory):
         self.latest_next_state = next_state
         self.dones[self.head] = done
         # Actually occupied size of memory
-        if self.true_size < self.max_size:
-            self.true_size += 1
+        if self.size < self.max_size:
+            self.size += 1
         self.seen_size += 1
 
     @lab_api
@@ -132,7 +132,7 @@ class Replay(Memory):
         # idxs for next state is state idxs + 1
         ns_batch_idxs = batch_idxs + 1
         # find the locations to be replaced with latest_next_state
-        latest_ns_locs = np.argwhere(ns_batch_idxs == self.true_size).flatten()
+        latest_ns_locs = np.argwhere(ns_batch_idxs == self.size).flatten()
         to_replace = latest_ns_locs.size != 0
         # set to 0, a safe sentinel for ns_batch_idxs due to the +1 above
         # then sample safely from self.states, and replace at locs with latest_next_state
@@ -145,7 +145,7 @@ class Replay(Memory):
 
     def sample_idxs(self, batch_size):
         '''Batch indices a sampled random uniformly'''
-        batch_idxs = np.random.randint(self.true_size, size=batch_size)
+        batch_idxs = np.random.randint(self.size, size=batch_size)
         if self.use_cer:  # add the latest sample
             batch_idxs[-1] = self.head
         return batch_idxs

--- a/slm_lab/agent/memory/replay.py
+++ b/slm_lab/agent/memory/replay.py
@@ -48,8 +48,8 @@ class Replay(Memory):
         self.state_buffer = deque(maxlen=0)  # for API consistency
         self.is_episodic = False
         self.batch_idxs = None
-        self.size = 0  # to number of experiences stored
-        self.seen_size = 0  # the number of experiences seen, including those stored and discarded
+        self.size = 0  # total experiences stored
+        self.seen_size = 0  # total experiences seen cumulatively
         self.head = -1  # index of most recent experience
         # declare what data keys to store
         self.data_keys = ['states', 'actions', 'rewards', 'next_states', 'dones']

--- a/slm_lab/agent/memory/replay.py
+++ b/slm_lab/agent/memory/replay.py
@@ -84,11 +84,12 @@ class Replay(Memory):
     @lab_api
     def update(self, state, action, reward, next_state, done):
         '''Interface method to update memory'''
-        self.base_update(state, action, reward, next_state, done)
-        # prevent conflict with preprocess in epi_reset
-        state = self.preprocess_state(state, append=False)
-        next_state = self.preprocess_state(next_state, append=False)
-        if not np.isnan(reward):  # not the start of episode
+        if np.isnan(reward):  # start of episode
+            self.epi_reset(next_state)
+        else:
+            # prevent conflict with preprocess in epi_reset
+            state = self.preprocess_state(state, append=False)
+            next_state = self.preprocess_state(next_state, append=False)
             self.add_experience(state, action, reward, next_state, done)
 
     def add_experience(self, state, action, reward, next_state, done):

--- a/slm_lab/env/__init__.py
+++ b/slm_lab/env/__init__.py
@@ -52,14 +52,13 @@ class EnvSpace:
     @lab_api
     def reset(self):
         logger.debug3('EnvSpace.reset')
-        state_v, _reward_v, done_v = self.aeb_space.init_data_v(ENV_DATA_NAMES)
+        state_v, = self.aeb_space.init_data_v(['state'])
         for env in self.envs:
-            _reward_e, state_e, done_e = env.space_reset()
+            state_e = env.space_reset()
             state_v[env.e, 0:len(state_e)] = state_e
-            done_v[env.e, 0:len(done_e)] = done_e
-        state_space, _reward_space, done_space = self.aeb_space.add(ENV_DATA_NAMES, (state_v, _reward_v, done_v))
+        state_space = self.aeb_space.add('state', state_v)
         logger.debug3(f'\nstate_space: {state_space}')
-        return _reward_space, state_space, done_space
+        return state_space
 
     @lab_api
     def step(self, action_space):

--- a/slm_lab/env/__init__.py
+++ b/slm_lab/env/__init__.py
@@ -51,13 +51,13 @@ class EnvSpace:
 
     @lab_api
     def reset(self):
-        logger.debug3('EnvSpace.reset')
+        logger.debug('EnvSpace.reset')
         state_v, = self.aeb_space.init_data_v(['state'])
         for env in self.envs:
             state_e = env.space_reset()
             state_v[env.e, 0:len(state_e)] = state_e
         state_space = self.aeb_space.add('state', state_v)
-        logger.debug3(f'\nstate_space: {state_space}')
+        logger.debug(f'\nstate_space: {state_space}')
         return state_space
 
     @lab_api
@@ -73,7 +73,7 @@ class EnvSpace:
             done_v[e, 0:len(done_e)] = done_e
             info_v.append(info_e)
         state_space, reward_space, done_space = self.aeb_space.add(ENV_DATA_NAMES, (state_v, reward_v, done_v))
-        logger.debug3(f'\nstate_space: {state_space}\nreward_space: {reward_space}\ndone_space: {done_space}')
+        logger.debug(f'\nstate_space: {state_space}\nreward_space: {reward_space}\ndone_space: {done_space}')
         return state_space, reward_space, done_space, info_v
 
     @lab_api

--- a/slm_lab/env/base.py
+++ b/slm_lab/env/base.py
@@ -187,7 +187,7 @@ class BaseEnv(ABC):
 
     @lab_api
     def space_reset(self):
-        '''Space (multi-env) reset method, return _reward_e, state_e, done_e'''
+        '''Space (multi-env) reset method, return state_e'''
         raise NotImplementedError
 
     @lab_api

--- a/slm_lab/env/base.py
+++ b/slm_lab/env/base.py
@@ -156,7 +156,7 @@ class BaseEnv(ABC):
     @abstractmethod
     @lab_api
     def reset(self):
-        '''Reset method, return _reward, state, done'''
+        '''Reset method, return state'''
         raise NotImplementedError
 
     @abstractmethod

--- a/slm_lab/env/openai.py
+++ b/slm_lab/env/openai.py
@@ -85,21 +85,22 @@ class OpenAIEnv(BaseEnv):
 
     @lab_api
     def space_reset(self):
-        state_e, _reward_e, done_e = self.env_space.aeb_space.init_data_s(ENV_DATA_NAMES, e=self.e)
+        self.done = False
+        state_e, = self.env_space.aeb_space.init_data_s(['state'], e=self.e)
         for ab, body in util.ndenumerate_nonan(self.body_e):
             state = self.u_env.reset()
             state_e[ab] = state
-            done_e[ab] = self.done = False
         if util.to_render():
             self.u_env.render()
-        logger.debug(f'Env {self.e} reset reward_e: {_reward_e}, state_e: {state_e}, done_e: {done_e}')
-        return _reward_e, state_e, done_e
+        logger.debug(f'Env {self.e} reset state_e: {state_e}')
+        return state_e
 
     @lab_api
     def space_step(self, action_e):
         action = action_e[(0, 0)]  # single body
         if self.done:  # space envs run continually without a central reset signal
-            _reward_e, state_e, done_e = self.space_reset()
+            state_e = self.space_reset()
+            _reward_e, done_e = self.env_space.aeb_space.init_data_s(['reward', 'done'], e=self.e)
             return state_e, _reward_e, done_e, None
         if not self.is_discrete:
             action = np.array([action])

--- a/slm_lab/env/openai.py
+++ b/slm_lab/env/openai.py
@@ -49,13 +49,12 @@ class OpenAIEnv(BaseEnv):
 
     @lab_api
     def reset(self):
-        _reward = np.nan
+        self.done = False
         state = self.u_env.reset()
-        self.done = done = False
         if util.to_render():
             self.u_env.render()
-        logger.debug(f'Env {self.e} reset reward: {_reward}, state: {state}, done: {done}')
-        return _reward, state, done
+        logger.debug(f'Env {self.e} reset state: {state}')
+        return state
 
     @lab_api
     def step(self, action):

--- a/slm_lab/env/unity.py
+++ b/slm_lab/env/unity.py
@@ -163,24 +163,24 @@ class UnityEnv(BaseEnv):
 
     @lab_api
     def space_reset(self):
-        self._check_u_brain_to_agent()
         self.done = False
+        self._check_u_brain_to_agent()
         env_info_dict = self.u_env.reset(train_mode=(util.get_lab_mode() != 'dev'), config=self.env_spec.get('unity'))
-        state_e, _reward_e, done_e = self.env_space.aeb_space.init_data_s(ENV_DATA_NAMES, e=self.e)
+        state_e, = self.env_space.aeb_space.init_data_s(['state'], e=self.e)
         for (a, b), body in util.ndenumerate_nonan(self.body_e):
             env_info_a = self._get_env_info(env_info_dict, a)
             self._check_u_agent_to_body(env_info_a, a)
             state = env_info_a.states[b]
             state_e[(a, b)] = state
-            done_e[(a, b)] = self.done
-        logger.debug(f'Env {self.e} reset reward_e: {_reward_e}, state_e: {state_e}, done_e: {done_e}')
+        logger.debug(f'Env {self.e} reset state_e: {state_e}')
         return _reward_e, state_e, done_e
 
     @lab_api
     def space_step(self, action_e):
         # TODO implement clock_speed: step only if self.clock.to_step()
         if self.done:
-            _reward_e, state_e, done_e = self.space_reset()
+            state_e = self.space_reset()
+            _reward_e, done_e = self.env_space.aeb_space.init_data_s(['reward', 'done'], e=self.e)
             return state_e, _reward_e, done_e, None
         action_e = util.nanflatten(action_e)
         env_info_dict = self.u_env.step(action_e)

--- a/slm_lab/env/unity.py
+++ b/slm_lab/env/unity.py
@@ -173,7 +173,7 @@ class UnityEnv(BaseEnv):
             state = env_info_a.states[b]
             state_e[(a, b)] = state
         logger.debug(f'Env {self.e} reset state_e: {state_e}')
-        return _reward_e, state_e, done_e
+        return state_e
 
     @lab_api
     def space_step(self, action_e):

--- a/slm_lab/env/unity.py
+++ b/slm_lab/env/unity.py
@@ -127,14 +127,13 @@ class UnityEnv(BaseEnv):
 
     @lab_api
     def reset(self):
-        _reward = np.nan
+        self.done = False
         env_info_dict = self.u_env.reset(train_mode=(util.get_lab_mode() != 'dev'), config=self.env_spec.get('unity'))
         a, b = 0, 0  # default singleton aeb
         env_info_a = self._get_env_info(env_info_dict, a)
         state = env_info_a.states[b]
-        self.done = done = False
-        logger.debug(f'Env {self.e} reset reward: {_reward}, state: {state}, done: {done}')
-        return _reward, state, done
+        logger.debug(f'Env {self.e} reset state: {state}')
+        return state
 
     @lab_api
     def step(self, action):

--- a/slm_lab/experiment/control.py
+++ b/slm_lab/experiment/control.py
@@ -154,7 +154,7 @@ class SpaceSession(Session):
         Will terminate when all envs done are done.
         '''
         all_done = self.aeb_space.tick('epi')
-        reward_space, state_space, done_space = self.env_space.reset()
+        state_space = self.env_space.reset()
         self.agent_space.reset(state_space)
         while not all_done:
             self.try_ckpt(self.agent_space, self.env_space)

--- a/slm_lab/experiment/control.py
+++ b/slm_lab/experiment/control.py
@@ -69,7 +69,8 @@ class Session:
             self.eval_env.clock.tick('epi')
             logger.info(f'Running eval episode for trial {self.info_space.get("trial")} session {self.index}')
             total_reward = 0
-            reward, state, done = self.eval_env.reset()
+            state = self.eval_env.reset()
+            done = False
             while not done:
                 self.eval_env.clock.tick('t')
                 action = self.agent.act(state)
@@ -85,7 +86,8 @@ class Session:
     def run_episode(self):
         self.env.clock.tick('epi')
         logger.info(f'Running trial {self.info_space.get("trial")} session {self.index} episode {self.env.clock.epi}')
-        reward, state, done = self.env.reset()
+        state = self.env.reset()
+        done = False
         self.agent.reset(state)
         while not done:
             self.try_ckpt(self.agent, self.env)

--- a/slm_lab/experiment/monitor.py
+++ b/slm_lab/experiment/monitor.py
@@ -155,8 +155,8 @@ class Body:
         '''Interface update method for body at agent.update()'''
         self.total_reward = math_util.nan_add(self.total_reward, reward)
 
-    def calc_df_row(self, env, total_reward):
-        '''Calculate a row for updating train_df or eval_df, given a total_reward.'''
+    def calc_df_row(self, env):
+        '''Calculate a row for updating train_df or eval_df.'''
         total_t = self.env.clock.get('total_t')
         wall_t = env.clock.get_elapsed_wall_t()
         fps = 0 if wall_t == 0 else total_t / wall_t
@@ -168,7 +168,7 @@ class Body:
             't': env.clock.get('t'),
             'wall_t': wall_t,
             'fps': fps,
-            'reward': total_reward,
+            'reward': self.total_reward,
             'loss': self.loss,
             'lr': self.get_mean_lr(),
             'explore_var': self.explore_var,
@@ -193,13 +193,14 @@ class Body:
     def epi_update(self):
         '''Update to append data at the end of an episode (when env.done is true)'''
         assert self.env.done
-        row = self.calc_df_row(self.env, self.total_reward)
+        row = self.calc_df_row(self.env)
         # append efficiently to df
         self.train_df.loc[len(self.train_df)] = row
 
     def eval_update(self, eval_env, total_reward):
         '''Update to append data at eval checkpoint'''
-        row = self.calc_df_row(eval_env, total_reward)
+        row = self.calc_df_row(eval_env)
+        row['total_reward'] = total_reward
         # append efficiently to df
         self.eval_df.loc[len(self.eval_df)] = row
         # update current reward_ma

--- a/slm_lab/experiment/monitor.py
+++ b/slm_lab/experiment/monitor.py
@@ -201,11 +201,12 @@ class Body:
         # update current reward_ma
         self.total_reward_ma = self.train_df[-analysis.MA_WINDOW:]['reward'].mean()
         self.train_df.iloc[-1]['reward_ma'] = self.total_reward_ma
+        self.total_reward = np.nan  # reset
 
     def eval_update(self, eval_env, total_reward):
         '''Update to append data at eval checkpoint'''
         row = self.calc_df_row(eval_env)
-        row['total_reward'] = total_reward
+        row['reward'] = total_reward
         # append efficiently to df
         self.eval_df.loc[len(self.eval_df)] = row
         # update current reward_ma

--- a/slm_lab/lib/decorator.py
+++ b/slm_lab/lib/decorator.py
@@ -38,6 +38,6 @@ def timeit(fn):
         start = time.time()
         output = fn(*args, **kwargs)
         end = time.time()
-        logger.debug3(f'Timed: {fn.__name__} {round((end - start) * 1000, 4)}ms')
+        logger.debug(f'Timed: {fn.__name__} {round((end - start) * 1000, 4)}ms')
         return output
     return time_fn

--- a/slm_lab/lib/logger.py
+++ b/slm_lab/lib/logger.py
@@ -14,11 +14,6 @@ class FixedList(list):
         pass
 
 
-# extra debugging level deeper than the default debug
-NEW_LVLS = {'DEBUG2': 9, 'DEBUG3': 8}
-for name, val in NEW_LVLS.items():
-    logging.addLevelName(val, name)
-    setattr(logging, name, val)
 LOG_FORMAT = '[%(asctime)s PID:%(process)d %(levelname)s %(filename)s %(funcName)s] %(message)s'
 color_formatter = colorlog.ColoredFormatter('%(log_color)s[%(asctime)s PID:%(process)d %(levelname)s %(filename)s %(funcName)s]%(reset)s %(message)s')
 sh = logging.StreamHandler(sys.stdout)
@@ -67,14 +62,6 @@ def debug(msg, *args, **kwargs):
     return lab_logger.debug(msg, *args, **kwargs)
 
 
-def debug2(msg, *args, **kwargs):
-    return lab_logger.log(NEW_LVLS['DEBUG2'], msg, *args, **kwargs)
-
-
-def debug3(msg, *args, **kwargs):
-    return lab_logger.log(NEW_LVLS['DEBUG3'], msg, *args, **kwargs)
-
-
 def error(msg, *args, **kwargs):
     return lab_logger.error(msg, *args, **kwargs)
 
@@ -93,17 +80,7 @@ def warn(msg, *args, **kwargs):
 
 def get_logger(__name__):
     '''Create a child logger specific to a module'''
-    module_logger = logging.getLogger(__name__)
-
-    def debug2(msg, *args, **kwargs):
-        return module_logger.log(NEW_LVLS['DEBUG2'], msg, *args, **kwargs)
-
-    def debug3(msg, *args, **kwargs):
-        return module_logger.log(NEW_LVLS['DEBUG3'], msg, *args, **kwargs)
-
-    setattr(module_logger, 'debug2', debug2)
-    setattr(module_logger, 'debug3', debug3)
-    return module_logger
+    return logging.getLogger(__name__)
 
 
 def toggle_debug(modules, level='DEBUG'):

--- a/test/agent/memory/test_onpolicy_memory.py
+++ b/test/agent/memory/test_onpolicy_memory.py
@@ -5,7 +5,7 @@ import pytest
 
 
 def memory_init_util(memory):
-    assert memory.true_size == 0
+    assert memory.size == 0
     assert memory.seen_size == 0
     return True
 
@@ -16,7 +16,7 @@ def memory_reset_util(memory, experiences):
         e = experiences[i]
         memory.add_experience(*e)
     memory.reset()
-    assert memory.true_size == 0
+    assert memory.size == 0
     assert np.sum(memory.states) == 0
     assert np.sum(memory.actions) == 0
     assert np.sum(memory.rewards) == 0
@@ -45,7 +45,7 @@ class TestOnPolicyBatchMemory:
         experiences = test_on_policy_batch_memory[2]
         exp = experiences[0]
         memory.add_experience(*exp)
-        assert memory.true_size == 1
+        assert memory.size == 1
         assert len(memory.states) == 1
         # Handle states and actions with multiple dimensions
         assert np.array_equal(memory.states[-1], exp[0])
@@ -114,7 +114,7 @@ class TestOnPolicyMemory:
         experiences = test_on_policy_episodic_memory[2]
         exp = experiences[0]
         memory.add_experience(*exp)
-        assert memory.true_size == 1
+        assert memory.size == 1
         assert len(memory.states) == 0
         # Handle states and actions with multiple dimensions
         assert np.array_equal(memory.cur_epi_data['states'][-1], exp[0])

--- a/test/agent/memory/test_per_memory.py
+++ b/test/agent/memory/test_per_memory.py
@@ -16,7 +16,7 @@ class TestPERMemory:
 
     def test_prioritized_replay_memory_init(self, test_prioritized_replay_memory):
         memory = test_prioritized_replay_memory[0]
-        assert memory.true_size == 0
+        assert memory.size == 0
         assert memory.states.shape == (memory.max_size, memory.body.state_dim)
         assert memory.actions.shape == (memory.max_size,)
         assert memory.rewards.shape == (memory.max_size,)
@@ -34,7 +34,7 @@ class TestPERMemory:
         experiences = test_prioritized_replay_memory[2]
         exp = experiences[0]
         memory.add_experience(*exp)
-        assert memory.true_size == 1
+        assert memory.size == 1
         assert memory.head == 0
         # Handle states and actions with multiple dimensions
         assert np.array_equal(memory.states[memory.head], exp[0])
@@ -52,7 +52,7 @@ class TestPERMemory:
         for e in experiences:
             memory.add_experience(*e)
             num_added += 1
-            assert memory.true_size == min(memory.max_size, num_added)
+            assert memory.size == min(memory.max_size, num_added)
             assert memory.head == (num_added - 1) % memory.max_size
             write = (num_added - 1) % memory.max_size + 1
             if write == memory.max_size:
@@ -99,7 +99,7 @@ class TestPERMemory:
             memory.add_experience(*e)
         memory.reset()
         assert memory.head == -1
-        assert memory.true_size == 0
+        assert memory.size == 0
         assert np.sum(memory.states) == 0
         assert np.sum(memory.actions) == 0
         assert np.sum(memory.rewards) == 0

--- a/test/agent/memory/test_replay_memory.py
+++ b/test/agent/memory/test_replay_memory.py
@@ -16,7 +16,7 @@ class TestMemory:
 
     def test_memory_init(self, test_memory):
         memory = test_memory[0]
-        assert memory.true_size == 0
+        assert memory.size == 0
         assert memory.states.shape == (memory.max_size, memory.body.state_dim)
         assert memory.actions.shape == (memory.max_size,)
         assert memory.rewards.shape == (memory.max_size,)
@@ -29,7 +29,7 @@ class TestMemory:
         experiences = test_memory[2]
         exp = experiences[0]
         memory.add_experience(*exp)
-        assert memory.true_size == 1
+        assert memory.size == 1
         assert memory.head == 0
         # Handle states and actions with multiple dimensions
         assert np.array_equal(memory.states[memory.head], exp[0])
@@ -46,7 +46,7 @@ class TestMemory:
         for e in experiences:
             memory.add_experience(*e)
             num_added += 1
-            assert memory.true_size == min(memory.max_size, num_added)
+            assert memory.size == min(memory.max_size, num_added)
             assert memory.head == (num_added - 1) % memory.max_size
 
     def test_sample(self, test_memory):
@@ -85,7 +85,7 @@ class TestMemory:
 
     def test_sample_next_states(self, test_memory):
         memory = test_memory[0]
-        idxs = np.array(range(memory.true_size))
+        idxs = np.array(range(memory.size))
         next_states = memory._sample_next_states(idxs)
         assert np.array_equal(next_states[len(next_states) - 1], memory.latest_next_state)
 
@@ -99,7 +99,7 @@ class TestMemory:
             memory.add_experience(*e)
         memory.reset()
         assert memory.head == -1
-        assert memory.true_size == 0
+        assert memory.size == 0
         assert np.sum(memory.states) == 0
         assert np.sum(memory.actions) == 0
         assert np.sum(memory.rewards) == 0

--- a/test/lib/test_math_util.py
+++ b/test/lib/test_math_util.py
@@ -4,6 +4,26 @@ import pytest
 import torch
 
 
+@pytest.mark.parametrize('vec,res', [
+    ([1, 1, 1], [False, False, False]),
+    ([1, 1, 2], [False, False, True]),
+    ([[1, 1], [1, 1], [1, 2]], [False, False, True]),
+])
+def test_is_outlier(vec, res):
+    assert np.array_equal(math_util.is_outlier(vec), res)
+
+
+def test_nan_add():
+    r0 = np.nan
+    r1 = np.array([1.0, 1.0])
+    r2 = np.array([np.nan, 2.0])
+    r3 = np.array([3.0, 3.0])
+
+    assert np.array_equal(math_util.nan_add(r0, r1), r1)
+    assert np.array_equal(math_util.nan_add(r1, r2), np.array([0.0, 3.0]))
+    assert np.array_equal(math_util.nan_add(r2, r3), np.array([3.0, 5.0]))
+
+
 def test_calc_gaes():
     rewards = torch.tensor([1., 0., 1., 1., 0., 1., 1., 1.])
     dones = torch.tensor([0., 0., 1., 1., 0., 0., 0., 0.])
@@ -15,15 +35,6 @@ def test_calc_gaes():
     res = torch.tensor([0.84070045, 0.89495, -0.1, -0.1, 3.616724, 2.7939649, 1.9191545, 0.989])
     # use allclose instead of equal to account for atol
     assert torch.allclose(gaes, res)
-
-
-@pytest.mark.parametrize('vec,res', [
-    ([1, 1, 1], [False, False, False]),
-    ([1, 1, 2], [False, False, True]),
-    ([[1, 1], [1, 1], [1, 2]], [False, False, True]),
-])
-def test_is_outlier(vec, res):
-    assert np.array_equal(math_util.is_outlier(vec), res)
 
 
 @pytest.mark.parametrize('start_val, end_val, start_step, end_step, step, correct', [


### PR DESCRIPTION
## Update env reset interface
- update env.reset interface to be consistent with gym return: state. all logic perserved
- methods involved:
  - `env.reset`
  - `env.space_reset`
  - `env.space_step`
  - `env_space.reset`
- purge `memory.base_update` for simplicity and update `memory.update` to remain equivalent

## Memory/Misc
- move `total_reward` from memory into body, improve calculation and logging
- remove onpolicy memory `warn_size_once` to simplify code since sample already checks for flushing
- rename `memory.true_size` to `memory.size`
- add `reward_ma` to `body.df`
- purge `debug2, debug3` logger methods
