### PR TITLE
Update control loop update and eval for vec env

### DIFF
--- a/slm_lab/agent/__init__.py
+++ b/slm_lab/agent/__init__.py
@@ -79,7 +79,7 @@ class Agent:
         explore_var = self.algorithm.update()
         logger.debug(f'Agent {self.a} loss: {loss}, explore_var {explore_var}')
         if util.epi_done(done):
-            self.body.epi_update()
+            self.body.train_ckpt()
         return loss, explore_var
 
     @lab_api
@@ -149,7 +149,7 @@ class Agent:
         logger.debug(f'Agent {self.a} loss: {loss_a}, explore_var_a {explore_var_a}')
         for eb, body in util.ndenumerate_nonan(self.body_a):
             if body.env.done:
-                body.epi_update()
+                body.train_ckpt()
         return loss_a, explore_var_a
 
 

--- a/slm_lab/agent/__init__.py
+++ b/slm_lab/agent/__init__.py
@@ -78,7 +78,7 @@ class Agent:
             self.body.loss = loss
         explore_var = self.algorithm.update()
         logger.debug(f'Agent {self.a} loss: {loss}, explore_var {explore_var}')
-        if done:
+        if util.epi_done(done):
             self.body.epi_update()
         return loss, explore_var
 

--- a/slm_lab/agent/__init__.py
+++ b/slm_lab/agent/__init__.py
@@ -78,8 +78,6 @@ class Agent:
             self.body.loss = loss
         explore_var = self.algorithm.update()
         logger.debug(f'Agent {self.a} loss: {loss}, explore_var {explore_var}')
-        if util.epi_done(done):
-            self.body.train_ckpt()
         return loss, explore_var
 
     @lab_api
@@ -147,6 +145,7 @@ class Agent:
         explore_var_a = self.algorithm.space_update()
         explore_var_a = util.guard_data_a(self, explore_var_a, 'explore_var')
         logger.debug(f'Agent {self.a} loss: {loss_a}, explore_var_a {explore_var_a}')
+        # TODO below scheduled for update to be consistent with non-space mode
         for eb, body in util.ndenumerate_nonan(self.body_a):
             if body.env.done:
                 body.train_ckpt()

--- a/slm_lab/agent/memory/onpolicy.py
+++ b/slm_lab/agent/memory/onpolicy.py
@@ -74,7 +74,7 @@ class OnPolicyReplay(Memory):
         for idx, k in enumerate(self.data_keys):
             self.cur_epi_data[k].append(self.most_recent[idx])
         # If episode ended, add to memory and clear cur_epi_data
-        if done:
+        if util.epi_done(done):
             for k in self.data_keys:
                 getattr(self, k).append(self.cur_epi_data[k])
             self.cur_epi_data = {k: [] for k in self.data_keys}

--- a/slm_lab/env/base.py
+++ b/slm_lab/env/base.py
@@ -37,7 +37,6 @@ class Clock:
         self.max_tick = max_tick
         self.max_tick_unit = max_tick_unit
         self.clock_speed = int(clock_speed)
-        self.ticks = 0  # multiple ticks make a timestep; used for clock speed
         self.t = 0
         self.total_t = 0
         self.epi = 0
@@ -53,21 +52,13 @@ class Clock:
 
     def tick(self, unit='t'):
         if unit == 't':  # timestep
-            if self.to_step():
-                self.t += 1
-                self.total_t += 1
-            else:
-                pass
-            self.ticks += 1
+            self.t += self.clock_speed
+            self.total_t += self.clock_speed
         elif unit == 'epi':  # episode, reset timestep
             self.epi += 1
             self.t = 0
         else:
             raise KeyError
-
-    def to_step(self):
-        '''Step signal from clock_speed. Step only if the base unit of time in this clock has moved. Used to control if env of different clock_speed should step()'''
-        return self.ticks % self.clock_speed == 0
 
 
 class BaseEnv(ABC):
@@ -93,12 +84,11 @@ class BaseEnv(ABC):
 
     def __init__(self, spec, e=None, env_space=None):
         self.e = e or 0  # for compatibility with env_space
-        self.clock_speed = 1
         self.done = False
         self.env_spec = spec['env'][self.e]
         # set default
         util.set_attr(self, dict(
-            log_frequency=None, # default to log at epi done
+            log_frequency=None,  # default to log at epi done
             num_envs=None,
             reward_scale=1.0,
         ))
@@ -119,6 +109,7 @@ class BaseEnv(ABC):
             logger.info(f'Override max_tick for eval mode to {NUM_EVAL_EPI} epi')
             self.max_tick = NUM_EVAL_EPI - 1
             self.max_tick_unit = 'epi'
+        self.clock_speed = 1 * (self.num_envs or 1)  # tick with a multiple of num_envs to properly count frames
         self.clock = Clock(self.max_tick, self.max_tick_unit, self.clock_speed)
 
     def _set_attr_from_u_env(self, u_env):

--- a/slm_lab/env/base.py
+++ b/slm_lab/env/base.py
@@ -98,10 +98,12 @@ class BaseEnv(ABC):
         self.env_spec = spec['env'][self.e]
         # set default
         util.set_attr(self, dict(
+            log_frequency=None, # default to log at epi done
             num_envs=None,
             reward_scale=1.0,
         ))
         util.set_attr(self, spec['meta'], [
+            'log_frequency',
             'eval_frequency',
             'max_tick_unit',
         ])

--- a/slm_lab/env/base.py
+++ b/slm_lab/env/base.py
@@ -77,6 +77,7 @@ class BaseEnv(ABC):
     e.g. env_spec
     "env": [{
       "name": "CartPole-v0",
+      "num_envs": null,
       "max_t": null,
       "max_tick": 150,
     }],
@@ -84,6 +85,7 @@ class BaseEnv(ABC):
     # or using total_t
     "env": [{
       "name": "CartPole-v0",
+      "num_envs": null,
       "max_t": null,
       "max_tick": 10000,
     }],
@@ -94,7 +96,9 @@ class BaseEnv(ABC):
         self.clock_speed = 1
         self.done = False
         self.env_spec = spec['env'][self.e]
+        # set default
         util.set_attr(self, dict(
+            num_envs=None,
             reward_scale=1.0,
         ))
         util.set_attr(self, spec['meta'], [
@@ -103,6 +107,7 @@ class BaseEnv(ABC):
         ])
         util.set_attr(self, self.env_spec, [
             'name',
+            'num_envs',
             'max_t',
             'max_tick',
             'reward_scale',

--- a/slm_lab/env/openai.py
+++ b/slm_lab/env/openai.py
@@ -33,7 +33,10 @@ class OpenAIEnv(BaseEnv):
             pass
         seed = ps.get(spec, 'meta.random_seed')
         stack_len = ps.get(spec, 'agent.0.memory.stack_len')
-        num_envs = ps.get(spec, f'env.{self.e}.num_envs')
+        if util.get_lab_mode() == 'eval':
+            num_envs = None
+        else:
+            num_envs = ps.get(spec, f'env.{self.e}.num_envs')
         if num_envs is None:
             self.u_env = make_gym_env(self.name, seed, stack_len)
         else:  # make vector environment

--- a/slm_lab/env/openai.py
+++ b/slm_lab/env/openai.py
@@ -64,7 +64,8 @@ class OpenAIEnv(BaseEnv):
         reward *= self.reward_scale
         if util.to_render():
             self.u_env.render()
-        done = done or self.clock.t > self.max_t
+        if self.clock.t > self.max_t:
+            done = True
         self.done = done
         logger.debug(f'Env {self.e} step state: {state}, reward: {reward}, done: {done}')
         return state, reward, done, info
@@ -108,7 +109,9 @@ class OpenAIEnv(BaseEnv):
         reward *= self.reward_scale
         if util.to_render():
             self.u_env.render()
-        self.done = done = done or self.clock.t > self.max_t
+        if self.clock.t > self.max_t:
+            done = True
+        self.done = done
         state_e, reward_e, done_e = self.env_space.aeb_space.init_data_s(ENV_DATA_NAMES, e=self.e)
         for ab, body in util.ndenumerate_nonan(self.body_e):
             state_e[ab] = state

--- a/slm_lab/env/openai.py
+++ b/slm_lab/env/openai.py
@@ -34,13 +34,11 @@ class OpenAIEnv(BaseEnv):
         seed = ps.get(spec, 'meta.random_seed')
         stack_len = ps.get(spec, 'agent.0.memory.stack_len')
         if util.get_lab_mode() == 'eval':
-            num_envs = None
-        else:
-            num_envs = ps.get(spec, f'env.{self.e}.num_envs')
-        if num_envs is None:
+            self.num_envs = None
+        if self.num_envs is None:
             self.u_env = make_gym_env(self.name, seed, stack_len)
         else:  # make vector environment
-            self.u_env = make_gym_venv(self.name, seed, stack_len, num_envs)
+            self.u_env = make_gym_venv(self.name, seed, stack_len, self.num_envs)
         self._set_attr_from_u_env(self.u_env)
         self.max_t = self.max_t or self.u_env.spec.max_episode_steps
         assert self.max_t is not None

--- a/slm_lab/env/unity.py
+++ b/slm_lab/env/unity.py
@@ -143,7 +143,9 @@ class UnityEnv(BaseEnv):
         state = env_info_a.states[b]
         reward = env_info_a.rewards[b] * self.reward_scale
         done = env_info_a.local_done[b]
-        self.done = done = done or self.clock.t > self.max_t
+        if self.clock.t > self.max_t:
+            done = True
+        self.done = done
         logger.debug(f'Env {self.e} step state: {state}, reward: {reward}, done: {done}')
         return state, reward, done, env_info_a
 

--- a/slm_lab/experiment/analysis.py
+++ b/slm_lab/experiment/analysis.py
@@ -226,7 +226,7 @@ def get_session_data(session, body_df_kind='eval', tmp_space_session_sub=False):
     session_data = {}
     for aeb, body in util.ndenumerate_nonan(session.aeb_space.body_space.data):
         aeb_df = body.eval_df if body_df_kind == 'eval' else body.train_df
-        # TODO tmp substitution since SpaceSession does not have run_eval_episode yet
+        # TODO tmp substitution since SpaceSession does not have run_eval yet
         if tmp_space_session_sub:
             aeb_df = body.train_df
         session_data[aeb] = aeb_df.copy()

--- a/slm_lab/experiment/control.py
+++ b/slm_lab/experiment/control.py
@@ -79,8 +79,7 @@ class Session:
                 total_reward += reward
         # exit eval context, restore variables simply by updating
         self.agent.algorithm.update()
-        # update body.eval_df
-        self.agent.body.eval_update(self.eval_env, total_reward)
+        self.agent.body.eval_ckpt(self.eval_env, total_reward)
         self.agent.body.log_summary('eval')
 
     def run_rl(self):
@@ -91,7 +90,7 @@ class Session:
         self.agent.reset(state)
         done = False
         while True:
-            if util.epi_done(done): # before starting another episode
+            if util.epi_done(done):  # before starting another episode
                 self.try_ckpt(self.agent, self.env)
                 self.agent.body.log_summary('train')
                 if clock.get() < clock.max_tick:  # reset and continue

--- a/slm_lab/experiment/control.py
+++ b/slm_lab/experiment/control.py
@@ -91,7 +91,7 @@ class Session:
         self.agent.reset(state)
         done = False
         while True:
-            if done:  # before starting another episode
+            if util.epi_done(done): # before starting another episode
                 self.try_ckpt(self.agent, self.env)
                 self.agent.body.log_summary('train')
                 if clock.get() < clock.max_tick:  # reset and continue

--- a/slm_lab/experiment/control.py
+++ b/slm_lab/experiment/control.py
@@ -66,7 +66,7 @@ class Session:
             agent.body.log_summary('train')
 
         if self.to_ckpt(env, 'eval'):
-            total_reward = self.run_eval_episode()
+            total_reward = self.run_eval()
             agent.body.eval_ckpt(self.eval_env, total_reward)
             agent.body.log_summary('eval')
             if analysis.new_best(agent):
@@ -74,7 +74,7 @@ class Session:
             if env.clock.get() > 0:  # nothing to analyze at start
                 analysis.analyze_session(self, eager_analyze_trial=True)
 
-    def run_eval_episode(self):
+    def run_eval(self):
         logger.info(f'Running eval episode for trial {self.info_space.get("trial")} session {self.index}')
         with util.ctx_lab_mode('eval'):  # enter eval context
             self.agent.algorithm.update()  # set explore_var etc. to end_val under ctx

--- a/slm_lab/experiment/control.py
+++ b/slm_lab/experiment/control.py
@@ -94,6 +94,7 @@ class Session:
         while True:
             if util.epi_done(done):  # before starting another episode
                 self.try_ckpt(self.agent, self.env)
+                self.agent.body.log_summary('train')
                 if clock.get() < clock.max_tick:  # reset and continue
                     clock.tick('epi')
                     state = self.env.reset()

--- a/slm_lab/experiment/control.py
+++ b/slm_lab/experiment/control.py
@@ -53,11 +53,7 @@ class Session:
         if env.max_tick_unit == 'epi':  # extra condition for epi
             to_ckpt = to_ckpt and env.done
 
-        if to_ckpt:
-            if self.spec['meta'].get('parallel_eval'):
-                retro_analysis.run_parallel_eval(self, agent, env)
-            else:
-                self.run_eval_episode()
+            self.run_eval_episode()
             if analysis.new_best(agent):
                 agent.save(ckpt='best')
             if tick > 0:  # nothing to analyze at start
@@ -118,7 +114,6 @@ class Session:
 
     def run(self):
         self.run_rl()
-        retro_analysis.try_wait_parallel_eval(self)
         self.data = analysis.analyze_session(self)  # session fitness
         self.close()
         return self.data
@@ -170,7 +165,6 @@ class SpaceSession(Session):
             self.agent_space.update(state_space, action_space, reward_space, next_state_space, done_space)
             state_space = next_state_space
         self.try_ckpt(self.agent_space, self.env_space)
-        retro_analysis.try_wait_parallel_eval(self)
 
     def close(self):
         '''

--- a/slm_lab/experiment/control.py
+++ b/slm_lab/experiment/control.py
@@ -44,19 +44,20 @@ class Session:
         logger.info(util.self_desc(self))
         logger.info(f'Initialized session {self.index}')
 
-    def to_ckpt(self, env):
-        '''Determine whether to run checkpointing'''
+    def to_ckpt(self, env, mode='ckpt'):
+        '''Determine whether to run ckpt/eval'''
         to_ckpt = False
         tick = env.clock.get()
+        frequency = env.ckpt_frequency if mode == 'ckpt' else env.eval_frequency
         if not util.in_eval_lab_modes() and tick <= env.max_tick:
-            to_ckpt = (tick % env.eval_frequency == 0) or tick == env.max_tick
+            to_ckpt = (tick % frequency == 0) or tick == env.max_tick
         if env.max_tick_unit == 'epi':  # extra condition for epi
             to_ckpt = to_ckpt and env.done
         return to_ckpt
 
     def try_ckpt(self, agent, env):
         '''Try to checkpoint agent at the start, save_freq, and the end'''
-        if self.to_ckpt(env):
+        if self.to_ckpt(env, 'ckpt'):
             agent.body.train_ckpt()
             agent.body.log_summary('train')
             self.run_eval_episode()

--- a/slm_lab/experiment/monitor.py
+++ b/slm_lab/experiment/monitor.py
@@ -122,7 +122,7 @@ class Body:
         self.train_df = pd.DataFrame(columns=[
             'epi', 'total_t', 't', 'wall_t', 'fps', 'reward', 'reward_ma', 'loss', 'lr',
             'explore_var', 'entropy_coef', 'entropy', 'log_prob', 'grad_norm'])
-        # track eval data within run_eval_episode. the same as train_df except for reward
+        # track eval data within run_eval. the same as train_df except for reward
         self.eval_df = self.train_df.copy()
 
         if aeb_space is None:  # singleton mode

--- a/slm_lab/experiment/monitor.py
+++ b/slm_lab/experiment/monitor.py
@@ -192,9 +192,8 @@ class Body:
         if hasattr(self, 'aeb_space'):
             self.space_fix_stats()
 
-    def epi_update(self):
-        '''Update to append data at the end of an episode (when env.done is true)'''
-        assert self.env.done
+    def train_ckpt(self):
+        '''Checkpoint to update body.train_df data'''
         row = self.calc_df_row(self.env)
         # append efficiently to df
         self.train_df.loc[len(self.train_df)] = row
@@ -203,8 +202,8 @@ class Body:
         self.train_df.iloc[-1]['reward_ma'] = self.total_reward_ma
         self.total_reward = np.nan  # reset
 
-    def eval_update(self, eval_env, total_reward):
-        '''Update to append data at eval checkpoint'''
+    def eval_ckpt(self, eval_env, total_reward):
+        '''Checkpoint to update body.eval_df data'''
         row = self.calc_df_row(eval_env)
         row['reward'] = total_reward
         # append efficiently to df

--- a/slm_lab/lib/util.py
+++ b/slm_lab/lib/util.py
@@ -117,6 +117,14 @@ def downcast_float32(df):
     return df
 
 
+def epi_done(done):
+    '''
+    General method to check if episode is done for both single and vectorized env
+    Only return True for singleton done since vectorized env does not have a natural episode boundary
+    '''
+    return np.isscalar(done) and done
+
+
 def find_ckpt(prepath):
     '''Find the ckpt-lorem-ipsum in a string and return lorem-ipsum'''
     if 'ckpt' in prepath:


### PR DESCRIPTION
## control loop and eval
- add `util.epi_done` to guard singleton and vec done
- update eval to auto use singleton env
- remove parallel eval in control
- generalize `try_ckpt`, split logic to log and eval, add new `log_frequency` spec var
- rename run_eval_episode to run_eval for brevity
- redesign and correct clock_speed definition; ticks more for num_envs
