### PR TITLE
make net, train() and eval() proper

### DIFF
--- a/slm_lab/agent/algorithm/base.py
+++ b/slm_lab/agent/algorithm/base.py
@@ -55,7 +55,7 @@ class Algorithm(ABC):
             logger.info(f'Initialized algorithm models for lab_mode: {util.get_lab_mode()}')
 
     @lab_api
-    def calc_pdparam(self, x, evaluate=True, net=None):
+    def calc_pdparam(self, x, net=None):
         '''
         To get the pdparam for action policy sampling, do a forward pass of the appropriate net, and pick the correct outputs.
         The pdparam will be the logits for discrete prob. dist., or the mean and std for continuous prob. dist.

--- a/slm_lab/agent/algorithm/dqn.py
+++ b/slm_lab/agent/algorithm/dqn.py
@@ -92,9 +92,9 @@ class VanillaDQN(SARSA):
 
     def calc_q_loss(self, batch):
         '''Compute the Q value loss using predicted and target Q values from the appropriate networks'''
-        q_preds = self.net.wrap_eval(batch['states'])
+        q_preds = self.net(batch['states'])
         act_q_preds = q_preds.gather(-1, batch['actions'].long().unsqueeze(-1)).squeeze(-1)
-        next_q_preds = self.net.wrap_eval(batch['next_states'])
+        next_q_preds = self.net(batch['next_states'])
         # Bellman equation: compute max_q_targets using reward and max estimated Q values (0 if no next_state)
         max_next_q_preds, _ = next_q_preds.max(dim=-1, keepdim=True)
         max_q_targets = batch['rewards'] + self.gamma * (1 - batch['dones']) * max_next_q_preds
@@ -196,12 +196,12 @@ class DQNBase(VanillaDQN):
 
     def calc_q_loss(self, batch):
         '''Compute the Q value loss using predicted and target Q values from the appropriate networks'''
-        q_preds = self.net.wrap_eval(batch['states'])
+        q_preds = self.net(batch['states'])
         act_q_preds = q_preds.gather(-1, batch['actions'].long().unsqueeze(-1)).squeeze(-1)
         # Use online_net to select actions in next state
-        online_next_q_preds = self.online_net.wrap_eval(batch['next_states'])
+        online_next_q_preds = self.online_net(batch['next_states'])
         # Use eval_net to calculate next_q_preds for actions chosen by online_net
-        next_q_preds = self.eval_net.wrap_eval(batch['next_states'])
+        next_q_preds = self.eval_net(batch['next_states'])
         max_next_q_preds = next_q_preds.gather(-1, online_next_q_preds.argmax(dim=-1, keepdim=True)).squeeze(-1)
         max_q_targets = batch['rewards'] + self.gamma * (1 - batch['dones']) * max_next_q_preds
         max_q_targets = max_q_targets.detach()

--- a/slm_lab/agent/algorithm/hydra_dqn.py
+++ b/slm_lab/agent/algorithm/hydra_dqn.py
@@ -32,11 +32,11 @@ class HydraDQN(DQN):
         self.eval_net = self.target_net
 
     @lab_api
-    def calc_pdparam(self, xs, evaluate=True, net=None):
+    def calc_pdparam(self, xs, net=None):
         '''
         Calculate pdparams for multi-action by chunking the network logits output
         '''
-        pdparam = SARSA.calc_pdparam(self, xs, evaluate=evaluate, net=net)
+        pdparam = SARSA.calc_pdparam(self, xs, net=net)
         return pdparam
 
     @lab_api
@@ -50,7 +50,7 @@ class HydraDQN(DQN):
                 state = policy_util.update_online_stats_and_normalize_state(body, state)
             states.append(state)
         xs = [torch.from_numpy(state).float() for state in states]
-        pdparam = self.calc_pdparam(xs, evaluate=False)
+        pdparam = self.calc_pdparam(xs)
         # use multi-policy. note arg change
         action_a, action_pd_a = self.action_policy(states, self, self.agent.nanflat_body_a, pdparam)
         for idx, body in enumerate(self.agent.nanflat_body_a):
@@ -72,12 +72,12 @@ class HydraDQN(DQN):
 
     def calc_q_loss(self, batch):
         '''Compute the Q value loss for Hydra network by apply the singleton logic on generalized aggregate.'''
-        q_preds = torch.stack(self.net.wrap_eval(batch['states']))
+        q_preds = torch.stack(self.net(batch['states']))
         act_q_preds = q_preds.gather(-1, torch.stack(batch['actions']).long().unsqueeze(-1)).squeeze(-1)
         # Use online_net to select actions in next state
-        online_next_q_preds = torch.stack(self.online_net.wrap_eval(batch['next_states']))
+        online_next_q_preds = torch.stack(self.online_net(batch['next_states']))
         # Use eval_net to calculate next_q_preds for actions chosen by online_net
-        next_q_preds = torch.stack(self.eval_net.wrap_eval(batch['next_states']))
+        next_q_preds = torch.stack(self.eval_net(batch['next_states']))
         max_next_q_preds = online_next_q_preds.gather(-1, next_q_preds.argmax(dim=-1, keepdim=True)).squeeze(-1)
         max_q_targets = torch.stack(batch['rewards']) + self.gamma * (1 - torch.stack(batch['dones'])) * max_next_q_preds
         q_loss = self.net.loss_fn(act_q_preds, max_q_targets)

--- a/slm_lab/agent/algorithm/policy_util.py
+++ b/slm_lab/agent/algorithm/policy_util.py
@@ -58,7 +58,7 @@ def init_action_pd(state, algorithm, body, append=True):
 
     state = try_preprocess(state, algorithm, body, append=append)
     state = state.to(algorithm.net.device)
-    pdparam = algorithm.calc_pdparam(state, evaluate=False)
+    pdparam = algorithm.calc_pdparam(state)
     return ActionPD, pdparam, body
 
 
@@ -142,7 +142,7 @@ def multi_default(states, algorithm, body_list, pdparam):
     Note, for efficiency, do a single forward pass to calculate pdparam, then call this policy like:
     @example
 
-    pdparam = self.calc_pdparam(state, evaluate=False)
+    pdparam = self.calc_pdparam(state)
     action_a, action_pd_a = self.action_policy(pdparam, self, body_list)
     '''
     pdparam = pdparam.squeeze(dim=0)

--- a/slm_lab/agent/algorithm/reinforce.py
+++ b/slm_lab/agent/algorithm/reinforce.py
@@ -91,16 +91,12 @@ class Reinforce(Algorithm):
         self.post_init_nets()
 
     @lab_api
-    def calc_pdparam(self, x, evaluate=True, net=None):
+    def calc_pdparam(self, x, net=None):
         '''
         The pdparam will be the logits for discrete prob. dist., or the mean and std for continuous prob. dist.
         '''
         net = self.net if net is None else net
-        if evaluate:
-            pdparam = net.wrap_eval(x)
-        else:
-            net.train()
-            pdparam = net(x)
+        pdparam = net(x)
         logger.debug(f'pdparam: {pdparam}')
         return pdparam
 

--- a/slm_lab/agent/algorithm/sil.py
+++ b/slm_lab/agent/algorithm/sil.py
@@ -121,7 +121,7 @@ class SIL(ActorCritic):
         This is called on a randomly-sample batch from experience replay
         '''
         returns = batch['rets']
-        v_preds = self.calc_v(batch['states'], evaluate=False)
+        v_preds = self.calc_v(batch['states'])
         clipped_advs = torch.clamp(returns - v_preds, min=0.0)
         log_probs = policy_util.calc_log_probs(self, self.net, self.body, batch)
 

--- a/slm_lab/agent/net/conv.py
+++ b/slm_lab/agent/net/conv.py
@@ -143,6 +143,7 @@ class ConvNet(Net, nn.Module):
         self.optim = net_util.get_optim(self, self.optim_spec)
         self.lr_scheduler = net_util.get_lr_scheduler(self, self.lr_scheduler_spec)
         self.to(self.device)
+        self.train()
 
     def __str__(self):
         return super(ConvNet, self).__str__() + f'\noptim: {self.optim}'
@@ -198,7 +199,6 @@ class ConvNet(Net, nn.Module):
         if hasattr(self, 'model_tails') and x is not None:
             raise ValueError('Loss computation from x,y not supported for multitails')
         self.lr_scheduler.step(epoch=ps.get(lr_clock, 'total_t'))
-        self.train()
         self.optim.zero_grad()
         if loss is None:
             out = self(x)
@@ -210,13 +210,6 @@ class ConvNet(Net, nn.Module):
         self.optim.step()
         logger.debug(f'Net training_step loss: {loss}')
         return loss
-
-    def wrap_eval(self, x):
-        '''
-        Completes one feedforward step, ensuring net is set to evaluation model returns: network output given input x
-        '''
-        self.eval()
-        return self(x)
 
 
 class DuelingConvNet(ConvNet):
@@ -325,6 +318,7 @@ class DuelingConvNet(ConvNet):
         self.optim = net_util.get_optim(self, self.optim_spec)
         self.lr_scheduler = net_util.get_lr_scheduler(self, self.lr_scheduler_spec)
         self.to(self.device)
+        self.train()
 
     def forward(self, x):
         '''The feedforward step'''

--- a/slm_lab/agent/net/mlp.py
+++ b/slm_lab/agent/net/mlp.py
@@ -134,7 +134,6 @@ class MLPNet(Net, nn.Module):
         if hasattr(self, 'model_tails') and x is not None:
             raise ValueError('Loss computation from x,y not supported for multitails')
         self.lr_scheduler.step(epoch=ps.get(lr_clock, 'total_t'))
-        self.train()
         self.optim.zero_grad()
         if loss is None:
             out = self(x)
@@ -146,14 +145,6 @@ class MLPNet(Net, nn.Module):
         self.optim.step()
         logger.debug(f'Net training_step loss: {loss}')
         return loss
-
-    def wrap_eval(self, x):
-        '''
-        Completes one feedforward step, ensuring net is set to evaluation model
-        returns: network output given input x
-        '''
-        self.eval()
-        return self(x)
 
 
 class HydraMLPNet(Net, nn.Module):
@@ -318,7 +309,6 @@ class HydraMLPNet(Net, nn.Module):
         Takes a single training step: one forward and one backwards pass. Both x and y are lists of the same length, one x and y per environment
         '''
         self.lr_scheduler.step(epoch=ps.get(lr_clock, 'total_t'))
-        self.train()
         self.optim.zero_grad()
         if loss is None:
             outs = self(xs)
@@ -334,14 +324,6 @@ class HydraMLPNet(Net, nn.Module):
         self.optim.step()
         logger.debug(f'Net training_step loss: {loss}')
         return loss
-
-    def wrap_eval(self, x):
-        '''
-        Completes one feedforward step, ensuring net is set to evaluation model
-        returns: network output given input x
-        '''
-        self.eval()
-        return self(x)
 
 
 class DuelingMLPNet(MLPNet):

--- a/slm_lab/agent/net/recurrent.py
+++ b/slm_lab/agent/net/recurrent.py
@@ -144,6 +144,7 @@ class RecurrentNet(Net, nn.Module):
         self.optim = net_util.get_optim(self, self.optim_spec)
         self.lr_scheduler = net_util.get_lr_scheduler(self, self.lr_scheduler_spec)
         self.to(self.device)
+        self.train()
 
     def __str__(self):
         return super(RecurrentNet, self).__str__() + f'\noptim: {self.optim}'
@@ -177,7 +178,6 @@ class RecurrentNet(Net, nn.Module):
         if hasattr(self, 'model_tails') and x is not None:
             raise ValueError('Loss computation from x,y not supported for multitails')
         self.lr_scheduler.step(epoch=ps.get(lr_clock, 'total_t'))
-        self.train()
         self.optim.zero_grad()
         if loss is None:
             out = self(x)
@@ -189,10 +189,3 @@ class RecurrentNet(Net, nn.Module):
         self.optim.step()
         logger.debug(f'Net training_step loss: {loss}')
         return loss
-
-    def wrap_eval(self, x):
-        '''
-        Completes one feedforward step, ensuring net is set to evaluation model returns: network output given input x
-        '''
-        self.eval()
-        return self(x)

--- a/slm_lab/env/unity.py
+++ b/slm_lab/env/unity.py
@@ -143,7 +143,7 @@ class UnityEnv(BaseEnv):
         state = env_info_a.states[b]
         reward = env_info_a.rewards[b] * self.reward_scale
         done = env_info_a.local_done[b]
-        if self.clock.t > self.max_t:
+        if not self.is_venv and self.clock.t > self.max_t:
             done = True
         self.done = done
         logger.debug(f'Env {self.e} step state: {state}, reward: {reward}, done: {done}')

--- a/slm_lab/experiment/analysis.py
+++ b/slm_lab/experiment/analysis.py
@@ -467,7 +467,7 @@ def save_session_data(spec, info_space, session_data, session_fitness_df, sessio
     session_data = util.session_df_to_data(session_df)
     '''
     prepath = util.get_prepath(spec, info_space, unit='session')
-    logger.info(f'Saving session data to {prepath}')
+    logger.info(f'Saving {body_df_kind} session data and graphs to {prepath}*')
     prefix = 'train' if body_df_kind == 'train' else ''
     if 'retro_analyze' not in os.environ['PREPATH']:
         save_session_df(session_data, f'{prepath}_{prefix}session_df.csv', info_space)
@@ -478,7 +478,7 @@ def save_session_data(spec, info_space, session_data, session_fitness_df, sessio
 def save_trial_data(spec, info_space, trial_df, trial_fitness_df, trial_fig, zip=True):
     '''Save the trial data: spec, trial_fitness_df.'''
     prepath = util.get_prepath(spec, info_space, unit='trial')
-    logger.info(f'Saving trial data to {prepath}')
+    logger.info(f'Saving trial data and graphs to {prepath}*')
     util.write(trial_df, f'{prepath}_trial_df.csv')
     util.write(trial_fitness_df, f'{prepath}_trial_fitness_df.csv')
     viz.save_image(trial_fig, f'{prepath}_trial_graph.png')

--- a/slm_lab/lib/viz.py
+++ b/slm_lab/lib/viz.py
@@ -1,6 +1,5 @@
 '''
 The data visualization module
-TODO pie, swarm, box plots
 '''
 from plotly import (
     graph_objs as go,
@@ -218,7 +217,6 @@ def save_image(figure, filepath=None):
     filepath = util.smart_path(filepath)
     try:
         pio.write_image(figure, filepath)
-        logger.info(f'Graph saved to {filepath}')
     except Exception as e:
         logger.warn(
             f'{e}\nFailed to generate graph. Fix the issue and run retro-analysis to generate graphs.')

--- a/test/agent/net/test_conv.py
+++ b/test/agent/net/test_conv.py
@@ -52,11 +52,6 @@ def test_forward():
     assert y.shape == (batch_size, out_dim)
 
 
-def test_wrap_eval():
-    y = net.wrap_eval(x)
-    assert y.shape == (batch_size, out_dim)
-
-
 def test_training_step():
     y = torch.rand((batch_size, out_dim))
     loss = net.training_step(x=x, y=y)

--- a/test/agent/net/test_mlp.py
+++ b/test/agent/net/test_mlp.py
@@ -48,11 +48,6 @@ def test_forward():
     assert y.shape == (batch_size, out_dim)
 
 
-def test_wrap_eval():
-    y = net.wrap_eval(x)
-    assert y.shape == (batch_size, out_dim)
-
-
 def test_training_step():
     y = torch.rand((batch_size, out_dim))
     loss = net.training_step(x=x, y=y)

--- a/test/agent/net/test_recurrent.py
+++ b/test/agent/net/test_recurrent.py
@@ -54,11 +54,6 @@ def test_forward():
     assert y.shape == (batch_size, out_dim)
 
 
-def test_wrap_eval():
-    y = net.wrap_eval(x)
-    assert y.shape == (batch_size, out_dim)
-
-
 def test_training_step():
     y = torch.rand((batch_size, out_dim))
     loss = net.training_step(x=x, y=y)


### PR DESCRIPTION
## make net, train() and eval() proper
`eval()` was used in unnecessary places but it was not needed; it is distinct from `torch.no_grad()`. remove it and standardize to just `train()` at network init.
- remove net, train() and eval(). set train() at network init
- remove `evaluate` flag in `calc_pdparam` and `calc_v`

## misc
- update env is_venv setting