### PR TITLE
Policy util rework

### DIFF
--- a/slm_lab/agent/algorithm/dqn.py
+++ b/slm_lab/agent/algorithm/dqn.py
@@ -131,7 +131,6 @@ class VanillaDQN(SARSA):
         Otherwise this function does nothing.
         '''
         if util.in_eval_lab_modes():
-            self.body.flush()
             return np.nan
         clock = self.body.env.clock
         tick = clock.get()
@@ -147,7 +146,6 @@ class VanillaDQN(SARSA):
             loss = total_loss / (self.training_epoch * self.training_batch_epoch)
             # reset
             self.to_train = 0
-            self.body.flush()
             logger.debug(f'Trained {self.name} at epi: {clock.epi}, total_t: {clock.total_t}, t: {clock.t}, total_reward so far: {self.body.total_reward}, loss: {loss:g}')
             return loss.item()
         else:

--- a/slm_lab/agent/algorithm/hydra_dqn.py
+++ b/slm_lab/agent/algorithm/hydra_dqn.py
@@ -52,9 +52,7 @@ class HydraDQN(DQN):
         xs = [torch.from_numpy(state).float() for state in states]
         pdparam = self.calc_pdparam(xs)
         # use multi-policy. note arg change
-        action_a, action_pd_a = self.action_policy(states, self, self.agent.nanflat_body_a, pdparam)
-        for idx, body in enumerate(self.agent.nanflat_body_a):
-            body.action_tensor, body.action_pd = action_a[idx], action_pd_a[idx]  # used for body.action_pd_update later
+        action_a = self.action_policy(states, self, self.agent.nanflat_body_a, pdparam)
         return action_a.cpu().numpy()
 
     @lab_api
@@ -99,7 +97,6 @@ class HydraDQN(DQN):
         Otherwise this function does nothing.
         '''
         if util.in_eval_lab_modes():
-            self.body.flush()
             return np.nan
         clock = self.body.env.clock  # main clock
         tick = util.s_get(self, 'aeb_space.clock').get(clock.max_tick_unit)
@@ -115,8 +112,6 @@ class HydraDQN(DQN):
             loss = total_loss / (self.training_epoch * self.training_batch_epoch)
             # reset
             self.to_train = 0
-            for body in self.agent.nanflat_body_a:
-                body.flush()
             logger.debug(f'Trained {self.name} at epi: {clock.epi}, total_t: {clock.total_t}, t: {clock.t}, total_reward so far: {self.body.total_reward}, loss: {loss:g}')
             return loss.item()
         else:

--- a/slm_lab/agent/algorithm/policy_util.py
+++ b/slm_lab/agent/algorithm/policy_util.py
@@ -105,16 +105,6 @@ def sample_action(ActionPD, pdparam):
     return action
 
 
-def calc_action_pd(state, algorithm, body):
-    '''
-    Do calc_pdparam from state and get action_pd to calc log_prob, entropy, etc.
-    This is used for batched loss calculation for efficiency
-    '''
-    pdparam = calc_pdparam(state, algorithm, body)
-    action_pd = init_action_pd(body.ActionPD, pdparam)
-    return action_pd
-
-
 # action_policy used by agent
 
 

--- a/slm_lab/agent/algorithm/ppo.py
+++ b/slm_lab/agent/algorithm/ppo.py
@@ -158,9 +158,6 @@ class PPO(ActorCritic):
         return policy_loss
 
     def train(self):
-        '''
-        Trains the network when the actor and critic share parameters
-        '''
         if util.in_eval_lab_modes():
             return np.nan
         clock = self.body.env.clock

--- a/slm_lab/agent/algorithm/reinforce.py
+++ b/slm_lab/agent/algorithm/reinforce.py
@@ -5,8 +5,6 @@ from slm_lab.agent.net import net_util
 from slm_lab.lib import logger, math_util, util
 from slm_lab.lib.decorator import lab_api
 import numpy as np
-import pydash as ps
-import torch
 
 logger = logger.get_logger(__name__)
 
@@ -52,6 +50,7 @@ class Reinforce(Algorithm):
             action_policy='default',
             explore_var_spec=None,
             entropy_coef_spec=None,
+            policy_loss_coef=1.0,
         ))
         util.set_attr(self, self.algorithm_spec, [
             'action_pdtype',
@@ -60,6 +59,7 @@ class Reinforce(Algorithm):
             'explore_var_spec',
             'gamma',  # the discount factor
             'entropy_coef_spec',
+            'policy_loss_coef',
             'training_frequency',
             'normalize_state',
         ])
@@ -97,7 +97,6 @@ class Reinforce(Algorithm):
         '''
         net = self.net if net is None else net
         pdparam = net(x)
-        logger.debug(f'pdparam: {pdparam}')
         return pdparam
 
     @lab_api
@@ -105,8 +104,7 @@ class Reinforce(Algorithm):
         body = self.body
         if self.normalize_state:
             state = policy_util.update_online_stats_and_normalize_state(body, state)
-        action, action_pd = self.action_policy(state, self, body)
-        body.action_tensor, body.action_pd = action, action_pd  # used for body.action_pd_update later
+        action = self.action_policy(state, self, body)
         return action.cpu().squeeze().numpy()  # squeeze to handle scalar
 
     @lab_api
@@ -118,39 +116,55 @@ class Reinforce(Algorithm):
         batch = util.to_torch_batch(batch, self.net.device, self.body.memory.is_episodic)
         return batch
 
+    def calc_pdparam_batch(self, batch):
+        '''Efficiently forward to get pdparam and by batch for loss computation'''
+        states = batch['states']
+        if self.body.env.is_venv:
+            states = math_util.venv_unpack(states)
+        pdparam = self.calc_pdparam(states)
+        return pdparam
+
+    def calc_ret_advs(self, batch):
+        '''Calculate plain returns; which is generalized to advantage in ActorCritic'''
+        rets = math_util.calc_returns(batch['rewards'], batch['dones'], self.gamma)
+        advs = rets
+        if self.body.env.is_venv:
+            advs = math_util.venv_unpack(advs)
+        logger.debug(f'advs: {advs}')
+        return advs
+
+    def calc_policy_loss(self, batch, pdparams, advs):
+        '''Calculate the actor's policy loss'''
+        action_pd = policy_util.init_action_pd(self.body.ActionPD, pdparams)
+        actions = batch['actions']
+        if self.body.env.is_venv:
+            actions = math_util.venv_unpack(actions)
+        log_probs = action_pd.log_prob(actions)
+        policy_loss = - self.policy_loss_coef * (log_probs * advs).mean()
+        if self.entropy_coef_spec:
+            entropy = action_pd.entropy().mean()
+            self.body.mean_entropy = entropy  # update logging variable
+            policy_loss += (-self.body.entropy_coef * entropy)
+        logger.debug(f'Actor policy loss: {policy_loss:g}')
+        return policy_loss
+
     @lab_api
     def train(self):
         if util.in_eval_lab_modes():
-            self.body.flush()
             return np.nan
         clock = self.body.env.clock
         if self.to_train == 1:
             batch = self.sample()
-            loss = self.calc_policy_loss(batch)
+            pdparams = self.calc_pdparam_batch(batch)
+            advs = self.calc_ret_advs(batch)
+            loss = self.calc_policy_loss(batch, pdparams, advs)
             self.net.training_step(loss=loss, lr_clock=clock)
             # reset
             self.to_train = 0
-            self.body.flush()
             logger.debug(f'Trained {self.name} at epi: {clock.epi}, total_t: {clock.total_t}, t: {clock.t}, total_reward so far: {self.body.total_reward}, loss: {loss:g}')
             return loss.item()
         else:
             return np.nan
-
-    def calc_policy_loss(self, batch):
-        '''Calculate the policy loss for a batch of data.'''
-        # use simple returns as advs
-        advs = math_util.calc_returns(batch['rewards'], batch['dones'], self.gamma)
-        advs = math_util.standardize(advs)
-        logger.debug(f'advs: {advs}')
-        assert len(self.body.log_probs) == len(advs), f'batch_size of log_probs {len(self.body.log_probs)} vs advs: {len(advs)}'
-        log_probs = torch.stack(self.body.log_probs)
-        policy_loss = - log_probs * advs
-        if self.entropy_coef_spec is not None:
-            entropies = torch.stack(self.body.entropies)
-            policy_loss += (-self.body.entropy_coef * entropies)
-        policy_loss = torch.sum(policy_loss)
-        logger.debug(f'Actor policy loss: {policy_loss:g}')
-        return policy_loss
 
     @lab_api
     def update(self):

--- a/slm_lab/agent/memory/base.py
+++ b/slm_lab/agent/memory/base.py
@@ -34,7 +34,6 @@ class Memory(ABC):
 
     def epi_reset(self, state):
         '''Method to reset at new episode'''
-        self.body.epi_reset()
         self.state_buffer.clear()
         for _ in range(self.state_buffer.maxlen):
             self.state_buffer.append(np.zeros(self.body.state_dim))

--- a/slm_lab/lib/distribution.py
+++ b/slm_lab/lib/distribution.py
@@ -78,7 +78,8 @@ class MultiCategorical(distributions.Categorical):
         return torch.stack([cat.sample(sample_shape=sample_shape) for cat in self.categoricals])
 
     def log_prob(self, value):
-        return torch.stack([cat.log_prob(value[idx]) for idx, cat in enumerate(self.categoricals)])
+        value_t = value.transpose(0, 1)
+        return torch.stack([cat.log_prob(value_t[idx]) for idx, cat in enumerate(self.categoricals)])
 
     def entropy(self):
         return torch.stack([cat.entropy() for cat in self.categoricals])

--- a/slm_lab/spec/experimental/reinforce.json
+++ b/slm_lab/spec/experimental/reinforce.json
@@ -370,7 +370,7 @@
       "name": "Reinforce",
       "algorithm": {
         "name": "Reinforce",
-        "action_pdtype": "default",
+        "action_pdtype": "MultiCategorical",
         "action_policy": "default",
         "explore_var_spec": null,
         "gamma": 0.99,
@@ -418,7 +418,7 @@
     "env": [{
       "name": "vizdoom-v0",
       "cfg_name": "basic",
-      "max_t": null,
+      "max_t": 400000,
       "max_tick": 100
     }],
     "body": {

--- a/slm_lab/spec/experimental/sil.json
+++ b/slm_lab/spec/experimental/sil.json
@@ -69,7 +69,7 @@
       "distributed": false,
       "eval_frequency": 1000,
       "max_tick_unit": "epi",
-      "max_session": 4,
+      "max_session": 1,
       "max_trial": 100,
       "search": "RandomSearch"
     },


### PR DESCRIPTION
## Policy util rework for training speedup
This PR reworks the way `pdparam` and `action_pd` are computed to produce near 5x speedup (200 FPS to 1000 FPS for A2C). The key is in noticing that forward and backpropagation are the most costly operations.
- enforce `no_grad` during agent action to speed up forward propagation
- compute gradient in batch during training, and minimize forward passes to only single passes without wastage.
- improve overall `pdparam -> action_pd -> log_probs/entropy` logic

## Remove variable tracking
As a result from above, all the related variables no longer need to be tracked via the `body`. This allows us to significantly simplify the API.
- remove body attributes: `action_tensor, action_pd, entropies, log_probs, mean_log_prob`
- remove body methods: `action_pd_update, epi_reset, flush, space_fix_stats`
- propagate their removals to everywhere in the code

## Generalization from A2C
Following #310 , `REINFORCE, PPO, SIL` are updated and generalized to work on vector environments like A2C.
- NOTE: PPO still needs the minibatch sampling. Delegating to @lgraesser . Otherwise, it should work properly
