### PR TITLE
Cleanup env, commit init_fn logic

### DIFF
--- a/slm_lab/agent/__init__.py
+++ b/slm_lab/agent/__init__.py
@@ -58,7 +58,6 @@ class Agent:
     @lab_api
     def reset(self, state):
         '''Do agent reset per session, such as memory pointer'''
-        logger.debug(f'Agent {self.a} reset')
         self.body.memory.epi_reset(state)
 
     @lab_api
@@ -66,7 +65,6 @@ class Agent:
         '''Standard act method from algorithm.'''
         with torch.no_grad():  # for efficiency, only calc grad in algorithm.train
             action = self.algorithm.act(state)
-        logger.debug(f'Agent {self.a} act: {action}')
         return action
 
     @lab_api
@@ -78,7 +76,6 @@ class Agent:
         if not np.isnan(loss):  # set for log_summary()
             self.body.loss = loss
         explore_var = self.algorithm.update()
-        logger.debug(f'Agent {self.a} loss: {loss}, explore_var {explore_var}')
         return loss, explore_var
 
     @lab_api
@@ -120,7 +117,6 @@ class Agent:
     @lab_api
     def space_reset(self, state_a):
         '''Do agent reset per session, such as memory pointer'''
-        logger.debug(f'Agent {self.a} reset')
         for eb, body in util.ndenumerate_nonan(self.body_a):
             body.memory.epi_reset(state_a[eb])
 
@@ -129,7 +125,6 @@ class Agent:
         '''Standard act method from algorithm.'''
         with torch.no_grad():
             action_a = self.algorithm.space_act(state_a)
-        logger.debug(f'Agent {self.a} act: {action_a}')
         return action_a
 
     @lab_api
@@ -145,7 +140,6 @@ class Agent:
                 body.loss = loss_a[eb]
         explore_var_a = self.algorithm.space_update()
         explore_var_a = util.guard_data_a(self, explore_var_a, 'explore_var')
-        logger.debug(f'Agent {self.a} loss: {loss_a}, explore_var_a {explore_var_a}')
         # TODO below scheduled for update to be consistent with non-space mode
         for eb, body in util.ndenumerate_nonan(self.body_a):
             if body.env.done:
@@ -188,7 +182,6 @@ class AgentSpace:
             state_a = state_space.get(a=agent.a)
             agent.space_reset(state_a)
         _action_space, _loss_space, _explore_var_space = self.aeb_space.add(AGENT_DATA_NAMES, (_action_v, _loss_v, _explore_var_v))
-        logger.debug(f'action_space: {_action_space}')
         return _action_space
 
     @lab_api
@@ -201,7 +194,6 @@ class AgentSpace:
             action_a = agent.space_act(state_a)
             action_v[a, 0:len(action_a)] = action_a
         action_space, = self.aeb_space.add(data_names, (action_v,))
-        logger.debug(f'\naction_space: {action_space}')
         return action_space
 
     @lab_api
@@ -219,7 +211,6 @@ class AgentSpace:
             loss_v[a, 0:len(loss_a)] = loss_a
             explore_var_v[a, 0:len(explore_var_a)] = explore_var_a
         loss_space, explore_var_space = self.aeb_space.add(data_names, (loss_v, explore_var_v))
-        logger.debug(f'\nloss_space: {loss_space}\nexplore_var_space: {explore_var_space}')
         return loss_space, explore_var_space
 
     @lab_api

--- a/slm_lab/agent/algorithm/dqn.py
+++ b/slm_lab/agent/algorithm/dqn.py
@@ -215,10 +215,8 @@ class DQNBase(VanillaDQN):
         total_t = self.body.env.clock.total_t
         if total_t % self.net.update_frequency == 0:
             if self.net.update_type == 'replace':
-                logger.debug('Updating target_net by replacing')
                 net_util.copy(self.net, self.target_net)
             elif self.net.update_type == 'polyak':
-                logger.debug('Updating net by averaging')
                 net_util.polyak_update(self.net, self.target_net, self.net.polyak_coef)
             else:
                 raise ValueError('Unknown net.update_type. Should be "replace" or "polyak". Exiting.')

--- a/slm_lab/agent/algorithm/policy_util.py
+++ b/slm_lab/agent/algorithm/policy_util.py
@@ -277,7 +277,6 @@ def update_online_stats(body, state):
         variance = S_n / (n - 1)
         std_dev = sqrt(variance)
     '''
-    logger.debug(f'mean: {body.state_mean}, std: {body.state_std_dev}, num examples: {body.state_n}')
     # Assumes only one state is given
     if ('Atari' in util.get_class_name(body.memory)):
         assert state.ndim == 3
@@ -301,7 +300,6 @@ def update_online_stats(body, state):
         # Guard against very small std devs
         if (body.state_std_dev < 1e-8).any():
             body.state_std_dev[np.where(body.state_std_dev < 1e-8)] += 1e-8
-    logger.debug(f'new mean: {body.state_mean}, new std: {body.state_std_dev}, num examples: {body.state_n}')
 
 
 def normalize_state(body, state):
@@ -314,11 +312,9 @@ def normalize_state(body, state):
     has_preprocess = getattr(body.memory, 'preprocess_state', False)
     if ('Atari' in util.get_class_name(body.memory)):
         # never normalize atari, it has its own normalization step
-        logger.debug('skipping normalizing for Atari, already handled by preprocess')
         return state
     elif ('Replay' in util.get_class_name(body.memory)) and has_preprocess:
         # normalization handled by preprocess_state function in the memory
-        logger.debug('skipping normalizing, already handled by preprocess')
         return state
     elif same_shape:
         # if not atari, always normalize the state the first time we see it during act
@@ -329,7 +325,6 @@ def normalize_state(body, state):
             return np.clip((state - body.state_mean) / body.state_std_dev, -10, 10)
     else:
         # broadcastable sample from an un-normalized memory so we should normalize
-        logger.debug('normalizing sample from memory')
         if np.sum(body.state_std_dev) == 0:
             return np.clip(state - body.state_mean, -10, 10)
         else:

--- a/slm_lab/agent/net/conv.py
+++ b/slm_lab/agent/net/conv.py
@@ -208,7 +208,6 @@ class ConvNet(Net, nn.Module):
         if self.clip_grad_val is not None:
             nn.utils.clip_grad_norm_(self.parameters(), self.clip_grad_val)
         self.optim.step()
-        logger.debug(f'Net training_step loss: {loss}')
         return loss
 
 

--- a/slm_lab/agent/net/mlp.py
+++ b/slm_lab/agent/net/mlp.py
@@ -143,7 +143,6 @@ class MLPNet(Net, nn.Module):
         if self.clip_grad_val is not None:
             nn.utils.clip_grad_norm_(self.parameters(), self.clip_grad_val)
         self.optim.step()
-        logger.debug(f'Net training_step loss: {loss}')
         return loss
 
 
@@ -322,7 +321,6 @@ class HydraMLPNet(Net, nn.Module):
         if self.clip_grad_val is not None:
             nn.utils.clip_grad_norm_(self.parameters(), self.clip_grad_val)
         self.optim.step()
-        logger.debug(f'Net training_step loss: {loss}')
         return loss
 
 

--- a/slm_lab/agent/net/net_util.py
+++ b/slm_lab/agent/net/net_util.py
@@ -277,10 +277,10 @@ def dev_check_training_step(fn):
                 try:
                     grad_norm = param.grad.norm()
                     assert min_norm < grad_norm < max_norm, f'Gradient norm for {p_name} is {grad_norm:g}, fails the extreme value check {min_norm} < grad_norm < {max_norm}. Loss: {loss:g}. Check your network and loss computation.'
-                    logger.info(f'Gradient norm for {p_name} is {grad_norm:g}; passes value check.')
                 except Exception as e:
                     logger.warn(e)
-        logger.debug('Passed network parameter update check.')
+            logger.info(f'Gradient norms passed value check.')
+        logger.info('Training passed network parameter update check.')
         # store grad norms for debugging
         net.store_grad_norms()
         return loss

--- a/slm_lab/agent/net/net_util.py
+++ b/slm_lab/agent/net/net_util.py
@@ -150,7 +150,7 @@ def init_params(module, init_fn):
     classname = util.get_class_name(module)
     if 'Net' in classname:  # skip if it's a net, not pytorch layer
         pass
-    elif any(k in classname for k in 'BatchNorm', 'Conv', 'Linear'):
+    elif any(k in classname for k in ('BatchNorm', 'Conv', 'Linear')):
         init_fn(module.weight)
         nn.init.constant_(module.bias, bias_init)
     elif 'GRU' in classname:

--- a/slm_lab/agent/net/recurrent.py
+++ b/slm_lab/agent/net/recurrent.py
@@ -187,5 +187,4 @@ class RecurrentNet(Net, nn.Module):
         if self.clip_grad_val is not None:
             nn.utils.clip_grad_norm_(self.parameters(), self.clip_grad_val)
         self.optim.step()
-        logger.debug(f'Net training_step loss: {loss}')
         return loss

--- a/slm_lab/env/__init__.py
+++ b/slm_lab/env/__init__.py
@@ -51,13 +51,11 @@ class EnvSpace:
 
     @lab_api
     def reset(self):
-        logger.debug('EnvSpace.reset')
         state_v, = self.aeb_space.init_data_v(['state'])
         for env in self.envs:
             state_e = env.space_reset()
             state_v[env.e, 0:len(state_e)] = state_e
         state_space = self.aeb_space.add('state', state_v)
-        logger.debug(f'\nstate_space: {state_space}')
         return state_space
 
     @lab_api
@@ -73,7 +71,6 @@ class EnvSpace:
             done_v[e, 0:len(done_e)] = done_e
             info_v.append(info_e)
         state_space, reward_space, done_space = self.aeb_space.add(ENV_DATA_NAMES, (state_v, reward_v, done_v))
-        logger.debug(f'\nstate_space: {state_space}\nreward_space: {reward_space}\ndone_space: {done_space}')
         return state_space, reward_space, done_space, info_v
 
     @lab_api

--- a/slm_lab/env/base.py
+++ b/slm_lab/env/base.py
@@ -116,6 +116,7 @@ class BaseEnv(ABC):
         self.is_venv = self.num_envs is not None
         self.clock_speed = 1 * (self.num_envs or 1)  # tick with a multiple of num_envs to properly count frames
         self.clock = Clock(self.max_tick, self.max_tick_unit, self.clock_speed)
+        self.to_render = util.to_render()
 
     def _set_attr_from_u_env(self, u_env):
         '''Set the observation, action dimensions and action type from u_env'''

--- a/slm_lab/env/openai.py
+++ b/slm_lab/env/openai.py
@@ -50,7 +50,7 @@ class OpenAIEnv(BaseEnv):
     def reset(self):
         self.done = False
         state = self.u_env.reset()
-        if util.to_render():
+        if self.to_render:
             self.u_env.render()
         return state
 
@@ -61,7 +61,7 @@ class OpenAIEnv(BaseEnv):
         state, reward, done, info = self.u_env.step(action)
         if self.reward_scale is not None:
             reward *= self.reward_scale
-        if util.to_render():
+        if self.to_render:
             self.u_env.render()
         if not self.is_venv and self.clock.t > self.max_t:
             done = True
@@ -89,7 +89,7 @@ class OpenAIEnv(BaseEnv):
         for ab, body in util.ndenumerate_nonan(self.body_e):
             state = self.u_env.reset()
             state_e[ab] = state
-        if util.to_render():
+        if self.to_render:
             self.u_env.render()
         return state_e
 
@@ -105,7 +105,7 @@ class OpenAIEnv(BaseEnv):
         state, reward, done, info = self.u_env.step(action)
         if self.reward_scale is not None:
             reward *= self.reward_scale
-        if util.to_render():
+        if self.to_render:
             self.u_env.render()
         if not self.is_venv and self.clock.t > self.max_t:
             done = True

--- a/slm_lab/env/openai.py
+++ b/slm_lab/env/openai.py
@@ -1,7 +1,7 @@
 from slm_lab.env.base import BaseEnv, ENV_DATA_NAMES
 from slm_lab.env.wrapper import make_gym_env
 from slm_lab.env.vec_env import make_gym_venv
-from slm_lab.env.registration import register_env
+from slm_lab.env.registration import try_register_env
 from slm_lab.lib import logger, util
 from slm_lab.lib.decorator import lab_api
 import gym
@@ -26,11 +26,7 @@ class OpenAIEnv(BaseEnv):
 
     def __init__(self, spec, e=None, env_space=None):
         super(OpenAIEnv, self).__init__(spec, e, env_space)
-        try:
-            # register any additional environments first. guard for re-registration
-            register_env(spec)
-        except Exception as e:
-            pass
+        try_register_env(spec)  # register if it's a custom gym env
         seed = ps.get(spec, 'meta.random_seed')
         stack_len = ps.get(spec, 'agent.0.memory.stack_len')
         if self.is_venv:  # make vector environment

--- a/slm_lab/env/registration.py
+++ b/slm_lab/env/registration.py
@@ -13,13 +13,15 @@ def get_env_path(env_name):
     return env_path
 
 
-def register_env(spec):
-    '''Register additional environments for OpenAI gym.'''
-    env_name = spec['env'][0]['name']
-
-    if env_name.lower() == 'vizdoom-v0':
-        assert 'cfg_name' in spec['env'][0].keys(), 'Environment config name must be defined for vizdoom.'
-        cfg_name = spec['env'][0]['cfg_name']
-        register(id='vizdoom-v0',
-                 entry_point='slm_lab.env.vizdoom.vizdoom_env:VizDoomEnv',
-                 kwargs={'cfg_name': cfg_name})
+def try_register_env(spec):
+    '''Try to additional environments for OpenAI gym.'''
+    try:
+        env_name = spec['env'][0]['name']
+        if env_name.lower() == 'vizdoom-v0':
+            assert 'cfg_name' in spec['env'][0].keys(), 'Environment config name must be defined for vizdoom.'
+            cfg_name = spec['env'][0]['cfg_name']
+            register(id='vizdoom-v0',
+                     entry_point='slm_lab.env.vizdoom.vizdoom_env:VizDoomEnv',
+                     kwargs={'cfg_name': cfg_name})
+    except Exception as e:
+        pass

--- a/slm_lab/experiment/control.py
+++ b/slm_lab/experiment/control.py
@@ -109,9 +109,9 @@ class Session:
                     clock.tick('epi')
                     state = self.env.reset()
                     done = False
-                else:  # exit loop
-                    break
             self.try_ckpt(self.agent, self.env)
+            if clock.get() >= clock.max_tick:  # finish
+                break
             clock.tick('t')
             action = self.agent.act(state)
             next_state, reward, done, info = self.env.step(action)

--- a/slm_lab/experiment/control.py
+++ b/slm_lab/experiment/control.py
@@ -97,7 +97,7 @@ class Session:
 
     def run_rl(self):
         '''Run the main RL loop until clock.max_tick'''
-        logger.info(f'Running RL loop for trial {self.info_space.get("trial")} session {self.index}')
+        logger.info(f'Running RL loop training for trial {self.info_space.get("trial")} session {self.index}')
         clock = self.env.clock
         state = self.env.reset()
         self.agent.reset(state)

--- a/slm_lab/spec/experimental/a2c_pong.json
+++ b/slm_lab/spec/experimental/a2c_pong.json
@@ -64,7 +64,7 @@
       "name": "PongNoFrameskip-v4",
       "num_envs": 16,
       "max_t": null,
-      "max_tick": 10000000
+      "max_tick": 1e7
     }],
     "body": {
       "product": "outer",

--- a/slm_lab/spec/experimental/a2c_pong.json
+++ b/slm_lab/spec/experimental/a2c_pong.json
@@ -23,7 +23,8 @@
         "normalize_state": false
       },
       "memory": {
-        "name": "OnPolicyAtariBatchReplay"
+        "name": "OnPolicyAtariBatchReplay",
+        "stack_len": 4
       },
       "net": {
         "type": "ConvNet",

--- a/slm_lab/spec/experimental/ppo_pong.json
+++ b/slm_lab/spec/experimental/ppo_pong.json
@@ -29,7 +29,8 @@
         "normalize_state": false
       },
       "memory": {
-        "name": "OnPolicyAtariBatchReplay"
+        "name": "OnPolicyAtariBatchReplay",
+        "stack_len": 4
       },
       "net": {
         "type": "ConvNet",

--- a/slm_lab/spec/experimental/ppo_pong.json
+++ b/slm_lab/spec/experimental/ppo_pong.json
@@ -70,7 +70,7 @@
       "name": "PongNoFrameskip-v4",
       "num_envs": 16,
       "max_t": null,
-      "max_tick": 10000000
+      "max_tick": 1e7
     }],
     "body": {
       "product": "outer",

--- a/slm_lab/spec/spec_util.py
+++ b/slm_lab/spec/spec_util.py
@@ -27,8 +27,8 @@ SPEC_FORMAT = {
     }],
     "env": [{
         "name": str,
-        "max_t": (type(None), int),
-        "max_tick": int,
+        "max_t": (type(None), int, float),
+        "max_tick": (int, float),
     }],
     "body": {
         "product": ["outer", "inner", "custom"],
@@ -36,7 +36,7 @@ SPEC_FORMAT = {
     },
     "meta": {
         "distributed": bool,
-        "eval_frequency": int,
+        "eval_frequency": (int, float),
         "max_tick_unit": str,
         "max_session": int,
         "max_trial": (type(None), int),
@@ -57,6 +57,9 @@ def check_comp_spec(comp_spec, comp_spec_format):
         else:
             v_type = spec_format_v
             assert isinstance(comp_spec_v, v_type), f'Component spec {ps.pick(comp_spec, spec_k)} needs to be of type: {v_type}'
+            if isinstance(v_type, tuple) and int in v_type and comp_spec_v is not None:
+                # cast if it can be int
+                comp_spec[spec_k] = int(comp_spec_v)
 
 
 def check_body_spec(spec):

--- a/slm_lab/spec/spec_util.py
+++ b/slm_lab/spec/spec_util.py
@@ -57,7 +57,7 @@ def check_comp_spec(comp_spec, comp_spec_format):
         else:
             v_type = spec_format_v
             assert isinstance(comp_spec_v, v_type), f'Component spec {ps.pick(comp_spec, spec_k)} needs to be of type: {v_type}'
-            if isinstance(v_type, tuple) and int in v_type and comp_spec_v is not None:
+            if isinstance(v_type, tuple) and int in v_type and isinstance(comp_spec_v, float):
                 # cast if it can be int
                 comp_spec[spec_k] = int(comp_spec_v)
 


### PR DESCRIPTION
## Cleanup env
- remove heavy debug logging, cache `to_render` for speedup frequent operations
- add missing break loop for venv termination

## A2C performance fix
- restore `stack_len` in committed spec causing breakage
- commit `net_util.init_layers` method, a2c is sensitive to it and fails to learn without the proper init

