### PR TITLE
Safe Q-learning refactor

### DIFF
--- a/slm_lab/agent/algorithm/dqn.py
+++ b/slm_lab/agent/algorithm/dqn.py
@@ -95,12 +95,12 @@ class VanillaDQN(SARSA):
         states = batch['states']
         next_states = batch['next_states']
         q_preds = self.net(states)
-        next_q_preds = self.net(next_states)
+        with torch.no_grad():
+            next_q_preds = self.net(next_states)
         act_q_preds = q_preds.gather(-1, batch['actions'].long().unsqueeze(-1)).squeeze(-1)
         # Bellman equation: compute max_q_targets using reward and max estimated Q values (0 if no next_state)
         max_next_q_preds, _ = next_q_preds.max(dim=-1, keepdim=True)
         max_q_targets = batch['rewards'] + self.gamma * (1 - batch['dones']) * max_next_q_preds
-        max_q_targets = max_q_targets.detach()
         q_loss = self.net.loss_fn(act_q_preds, max_q_targets)
 
         # TODO use the same loss_fn but do not reduce yet
@@ -197,15 +197,15 @@ class DQNBase(VanillaDQN):
         states = batch['states']
         next_states = batch['next_states']
         q_preds = self.net(states)
-        # Use online_net to select actions in next state
-        online_next_q_preds = self.online_net(next_states)
-        # Use eval_net to calculate next_q_preds for actions chosen by online_net
-        next_q_preds = self.eval_net(next_states)
+        with torch.no_grad():
+            # Use online_net to select actions in next state
+            online_next_q_preds = self.online_net(next_states)
+            # Use eval_net to calculate next_q_preds for actions chosen by online_net
+            next_q_preds = self.eval_net(next_states)
         act_q_preds = q_preds.gather(-1, batch['actions'].long().unsqueeze(-1)).squeeze(-1)
         online_actions = online_next_q_preds.argmax(dim=-1, keepdim=True)
         max_next_q_preds = next_q_preds.gather(-1, online_actions).squeeze(-1)
         max_q_targets = batch['rewards'] + self.gamma * (1 - batch['dones']) * max_next_q_preds
-        max_q_targets = max_q_targets.detach()
         q_loss = self.net.loss_fn(act_q_preds, max_q_targets)
 
         # TODO use the same loss_fn but do not reduce yet

--- a/slm_lab/agent/algorithm/dqn.py
+++ b/slm_lab/agent/algorithm/dqn.py
@@ -101,6 +101,7 @@ class VanillaDQN(SARSA):
         # Bellman equation: compute max_q_targets using reward and max estimated Q values (0 if no next_state)
         max_next_q_preds, _ = next_q_preds.max(dim=-1, keepdim=True)
         max_q_targets = batch['rewards'] + self.gamma * (1 - batch['dones']) * max_next_q_preds
+        logger.debug(f'act_q_preds: {act_q_preds}\nmax_q_targets: {max_q_targets}')
         q_loss = self.net.loss_fn(act_q_preds, max_q_targets)
 
         # TODO use the same loss_fn but do not reduce yet
@@ -206,6 +207,7 @@ class DQNBase(VanillaDQN):
         online_actions = online_next_q_preds.argmax(dim=-1, keepdim=True)
         max_next_q_preds = next_q_preds.gather(-1, online_actions).squeeze(-1)
         max_q_targets = batch['rewards'] + self.gamma * (1 - batch['dones']) * max_next_q_preds
+        logger.debug(f'act_q_preds: {act_q_preds}\nmax_q_targets: {max_q_targets}')
         q_loss = self.net.loss_fn(act_q_preds, max_q_targets)
 
         # TODO use the same loss_fn but do not reduce yet

--- a/slm_lab/agent/algorithm/hydra_dqn.py
+++ b/slm_lab/agent/algorithm/hydra_dqn.py
@@ -99,8 +99,6 @@ class HydraDQN(DQN):
         if util.in_eval_lab_modes():
             return np.nan
         clock = self.body.env.clock  # main clock
-        tick = util.s_get(self, 'aeb_space.clock').get(clock.max_tick_unit)
-        self.to_train = (tick > self.training_start_step and tick % self.training_frequency == 0)
         if self.to_train == 1:
             total_loss = torch.tensor(0.0, device=self.net.device)
             for _ in range(self.training_epoch):

--- a/slm_lab/agent/algorithm/random.py
+++ b/slm_lab/agent/algorithm/random.py
@@ -20,6 +20,7 @@ class Random(Algorithm):
         '''Initialize other algorithm parameters'''
         self.to_train = 0
         self.training_frequency = 1
+        self.training_start_step = 0
 
     @lab_api
     def init_nets(self, global_nets=None):

--- a/slm_lab/agent/algorithm/sarsa.py
+++ b/slm_lab/agent/algorithm/sarsa.py
@@ -122,7 +122,8 @@ class SARSA(Algorithm):
             states = math_util.venv_unpack(states)
             next_states = math_util.venv_unpack(next_states)
         q_preds = self.net(states)
-        next_q_preds = self.net(next_states)
+        with torch.no_grad():
+            next_q_preds = self.net(next_states)
         if self.body.env.is_venv:
             q_preds = math_util.venv_pack(q_preds, self.body.env.num_envs)
             next_q_preds = math_util.venv_pack(next_q_preds, self.body.env.num_envs)

--- a/slm_lab/agent/algorithm/sarsa.py
+++ b/slm_lab/agent/algorithm/sarsa.py
@@ -2,7 +2,7 @@ from slm_lab.agent import net
 from slm_lab.agent.algorithm import policy_util
 from slm_lab.agent.algorithm.base import Algorithm
 from slm_lab.agent.net import net_util
-from slm_lab.lib import logger, util
+from slm_lab.lib import logger, math_util, util
 from slm_lab.lib.decorator import lab_api
 import numpy as np
 import pydash as ps
@@ -102,16 +102,6 @@ class SARSA(Algorithm):
         action = self.action_policy(state, self, body)
         return action.cpu().squeeze().numpy()  # squeeze to handle scalar
 
-    def calc_q_loss(self, batch):
-        '''Compute the Q value loss using predicted and target Q values from the appropriate networks'''
-        q_preds = self.net(batch['states'])
-        act_q_preds = q_preds.gather(-1, batch['actions'].long().unsqueeze(-1)).squeeze(-1)
-        next_q_preds = self.net(batch['next_states'])
-        act_next_q_preds = q_preds.gather(-1, batch['next_actions'].long().unsqueeze(-1)).squeeze(-1)
-        act_q_targets = batch['rewards'] + self.gamma * (1 - batch['dones']) * act_next_q_preds
-        q_loss = self.net.loss_fn(act_q_preds, act_q_targets)
-        return q_loss
-
     @lab_api
     def sample(self):
         '''Samples a batch from memory'''
@@ -123,6 +113,24 @@ class SARSA(Algorithm):
             batch = policy_util.normalize_states_and_next_states(self.body, batch)
         batch = util.to_torch_batch(batch, self.net.device, self.body.memory.is_episodic)
         return batch
+
+    def calc_q_loss(self, batch):
+        '''Compute the Q value loss using predicted and target Q values from the appropriate networks'''
+        states = batch['states']
+        next_states = batch['next_states']
+        if self.body.env.is_venv:
+            states = math_util.venv_unpack(states)
+            next_states = math_util.venv_unpack(next_states)
+        q_preds = self.net(states)
+        next_q_preds = self.net(next_states)
+        if self.body.env.is_venv:
+            q_preds = math_util.venv_pack(q_preds, self.body.env.num_envs)
+            next_q_preds = math_util.venv_pack(next_q_preds, self.body.env.num_envs)
+        act_q_preds = q_preds.gather(-1, batch['actions'].long().unsqueeze(-1)).squeeze(-1)
+        act_next_q_preds = q_preds.gather(-1, batch['next_actions'].long().unsqueeze(-1)).squeeze(-1)
+        act_q_targets = batch['rewards'] + self.gamma * (1 - batch['dones']) * act_next_q_preds
+        q_loss = self.net.loss_fn(act_q_preds, act_q_targets)
+        return q_loss
 
     @lab_api
     def train(self):

--- a/slm_lab/agent/algorithm/sarsa.py
+++ b/slm_lab/agent/algorithm/sarsa.py
@@ -127,7 +127,7 @@ class SARSA(Algorithm):
             q_preds = math_util.venv_pack(q_preds, self.body.env.num_envs)
             next_q_preds = math_util.venv_pack(next_q_preds, self.body.env.num_envs)
         act_q_preds = q_preds.gather(-1, batch['actions'].long().unsqueeze(-1)).squeeze(-1)
-        act_next_q_preds = q_preds.gather(-1, batch['next_actions'].long().unsqueeze(-1)).squeeze(-1)
+        act_next_q_preds = next_q_preds.gather(-1, batch['next_actions'].long().unsqueeze(-1)).squeeze(-1)
         act_q_targets = batch['rewards'] + self.gamma * (1 - batch['dones']) * act_next_q_preds
         q_loss = self.net.loss_fn(act_q_preds, act_q_targets)
         return q_loss

--- a/slm_lab/agent/algorithm/sarsa.py
+++ b/slm_lab/agent/algorithm/sarsa.py
@@ -130,6 +130,7 @@ class SARSA(Algorithm):
         act_q_preds = q_preds.gather(-1, batch['actions'].long().unsqueeze(-1)).squeeze(-1)
         act_next_q_preds = next_q_preds.gather(-1, batch['next_actions'].long().unsqueeze(-1)).squeeze(-1)
         act_q_targets = batch['rewards'] + self.gamma * (1 - batch['dones']) * act_next_q_preds
+        logger.debug(f'act_q_preds: {act_q_preds}\nact_q_targets: {act_q_targets}')
         q_loss = self.net.loss_fn(act_q_preds, act_q_targets)
         return q_loss
 

--- a/slm_lab/agent/memory/prioritized.py
+++ b/slm_lab/agent/memory/prioritized.py
@@ -181,5 +181,10 @@ class PrioritizedReplay(Replay):
 
 
 class AtariPrioritizedReplay(PrioritizedReplay, AtariReplay):
-    '''Make a Prioritized AtariReplay via nice multi-inheritance (python magic)'''
-    pass
+    '''Make a Atari PrioritizedReplay via nice multi-inheritance (python magic)'''
+
+    def __init__(self, memory_spec, body):
+        super(AtariPrioritizedReplay, self).__init__(memory_spec, body)
+        # the above initializes AtariReplay, then PrioritizedReplay which overrides states. Restore the custom AtariReplay init logic below
+        self.states_shape = self.scalar_shape
+        self.states = [None] * self.max_size

--- a/slm_lab/agent/memory/prioritized.py
+++ b/slm_lab/agent/memory/prioritized.py
@@ -174,27 +174,12 @@ class PrioritizedReplay(Replay):
         body_errors = self.get_body_errors(errors)
         priorities = self.get_priority(body_errors)
         assert len(priorities) == self.batch_idxs.size
-        self.priorities[self.batch_idxs] = priorities
+        for idx, p in zip(self.batch_idxs, priorities):
+            self.priorities[idx] = p
         for p, i in zip(priorities, self.tree_idxs):
             self.tree.update(i, p)
 
 
 class AtariPrioritizedReplay(PrioritizedReplay, AtariReplay):
     '''Make a Prioritized AtariReplay via nice multi-inheritance (python magic)'''
-
-    def __init__(self, memory_spec, body):
-        util.set_attr(self, memory_spec, [
-            'alpha',
-            'epsilon',
-            'batch_size',
-            'max_size',
-            'use_cer',
-        ])
-        AtariReplay.__init__(self, memory_spec, body)
-        self.epsilon = torch.full((1,), self.epsilon)
-        self.alpha = torch.full((1,), self.alpha)
-        # adds a 'priorities' scalar to the data_keys and call reset again
-        self.data_keys = ['states', 'actions', 'rewards', 'next_states', 'dones', 'priorities']
-        self.reset()
-        self.states_shape = self.scalar_shape
-        self.states = [None] * self.max_size
+    pass

--- a/slm_lab/agent/memory/replay.py
+++ b/slm_lab/agent/memory/replay.py
@@ -105,6 +105,11 @@ class Replay(Memory):
         if self.size < self.max_size:
             self.size += 1
         self.seen_size += 1
+        # set to_train
+        tick = self.body.env.clock.get()
+        algorithm = self.body.agent.algorithm
+        # set to self to handle venv stepping multiple ticks; to_train will be set to 0 after training step
+        algorithm.to_train = algorithm.to_train or (tick > algorithm.training_start_step and tick % algorithm.training_frequency == 0)
 
     @lab_api
     def sample(self):

--- a/slm_lab/agent/net/net_util.py
+++ b/slm_lab/agent/net/net_util.py
@@ -276,9 +276,9 @@ def dev_check_training_step(fn):
                 try:
                     grad_norm = param.grad.norm()
                     assert min_norm < grad_norm < max_norm, f'Gradient norm for {p_name} is {grad_norm:g}, fails the extreme value check {min_norm} < grad_norm < {max_norm}. Loss: {loss:g}. Check your network and loss computation.'
-                    logger.info(f'Gradient norm for {p_name} is {grad_norm:g}; passes value check.')
                 except Exception as e:
                     logger.warn(e)
+            logger.info(f'Gradient norms passed value check.')
         logger.debug('Passed network parameter update check.')
         # store grad norms for debugging
         net.store_grad_norms()

--- a/slm_lab/env/base.py
+++ b/slm_lab/env/base.py
@@ -114,6 +114,8 @@ class BaseEnv(ABC):
             self.max_tick = NUM_EVAL_EPI - 1
             self.max_tick_unit = 'epi'
         self.is_venv = self.num_envs is not None
+        if self.is_venv:
+            assert self.log_frequency is not None, f'Specify log_frequency when using num_envs'
         self.clock_speed = 1 * (self.num_envs or 1)  # tick with a multiple of num_envs to properly count frames
         self.clock = Clock(self.max_tick, self.max_tick_unit, self.clock_speed)
         self.to_render = util.to_render()

--- a/slm_lab/env/wrapper.py
+++ b/slm_lab/env/wrapper.py
@@ -182,6 +182,10 @@ class LazyFrames(object):
     def __getitem__(self, i):
         return self._force()[i]
 
+    def astype(self, dtype):
+        '''To prevent state.astype(np.float16) breaking on LazyFrames'''
+        return self
+
 
 class FrameStack(gym.Wrapper):
     def __init__(self, env, k):
@@ -206,12 +210,12 @@ class FrameStack(gym.Wrapper):
     def reset(self):
         ob = self.env.reset()
         for _ in range(self.k):
-            self.frames.append(ob)
+            self.frames.append(ob.astype(np.float16))
         return self._get_ob()
 
     def step(self, action):
         ob, reward, done, info = self.env.step(action)
-        self.frames.append(ob)
+        self.frames.append(ob.astype(np.float16))
         return self._get_ob(), reward, done, info
 
     def _get_ob(self):

--- a/slm_lab/lib/distribution.py
+++ b/slm_lab/lib/distribution.py
@@ -10,17 +10,8 @@ class Argmax(distributions.Categorical):
     NOTE although argmax is not a sampling distribution, this implementation is for API consistency.
     '''
 
-    def __init__(self, probs=None, logits=None, validate_args=None):
-        if probs is not None:
-            new_probs = torch.zeros_like(probs, dtype=torch.float)
-            new_probs[probs == probs.max(dim=-1, keepdim=True)[0]] = 1.0
-            probs = new_probs
-        elif logits is not None:
-            new_logits = torch.full_like(logits, -1e8, dtype=torch.float)
-            new_logits[logits == logits.max(dim=-1, keepdim=True)[0]] = 1.0
-            logits = new_logits
-
-        super(Argmax, self).__init__(probs=probs, logits=logits, validate_args=validate_args)
+    def sample(self, sample_shape=torch.Size()):
+        return self.logits.argmax(dim=-1)
 
 
 class GumbelCategorical(distributions.Categorical):

--- a/slm_lab/lib/distribution.py
+++ b/slm_lab/lib/distribution.py
@@ -10,8 +10,17 @@ class Argmax(distributions.Categorical):
     NOTE although argmax is not a sampling distribution, this implementation is for API consistency.
     '''
 
-    def sample(self, sample_shape=torch.Size()):
-        return self.logits.argmax(dim=-1)
+    def __init__(self, probs=None, logits=None, validate_args=None):
+        if probs is not None:
+            new_probs = torch.zeros_like(probs, dtype=torch.float)
+            new_probs[probs == probs.max(dim=-1, keepdim=True)[0]] = 1.0
+            probs = new_probs
+        elif logits is not None:
+            new_logits = torch.full_like(logits, -1e8, dtype=torch.float)
+            new_logits[logits == logits.max(dim=-1, keepdim=True)[0]] = 1.0
+            logits = new_logits
+
+        super(Argmax, self).__init__(probs=probs, logits=logits, validate_args=validate_args)
 
 
 class GumbelCategorical(distributions.Categorical):

--- a/slm_lab/lib/distribution.py
+++ b/slm_lab/lib/distribution.py
@@ -13,12 +13,11 @@ class Argmax(distributions.Categorical):
     def __init__(self, probs=None, logits=None, validate_args=None):
         if probs is not None:
             new_probs = torch.zeros_like(probs, dtype=torch.float)
-            new_probs[torch.argmax(probs, dim=0)] = 1.0
+            new_probs[probs == probs.max(dim=-1, keepdim=True)[0]] = 1.0
             probs = new_probs
         elif logits is not None:
             new_logits = torch.full_like(logits, -1e8, dtype=torch.float)
-            max_idx = torch.argmax(logits, dim=0)
-            new_logits[max_idx] = logits[max_idx]
+            new_logits[logits == logits.max(dim=-1, keepdim=True)[0]] = 1.0
             logits = new_logits
 
         super(Argmax, self).__init__(probs=probs, logits=logits, validate_args=validate_args)


### PR DESCRIPTION
## Safe Q-learning refactor
- reorder q-family calculation without logic changes
- move `to_train` setting to memory to unify
- cleanup `AtariPrioritizedReplay`
- use `torch.no_grad()` for q-learning prediction in place of `detach()` to avoid op tracking
- use float16 downcast directly in LazyFrames

## SARSA bug fix
- `next_q_preds` was never used. should be used for `next_actions`. corrected.
- `next_q_preds` was not detached. use `torch.no_grad()` for it now.

## Argmax batched bug
- we switched to using batched `probs` and `logits` inputs to distributions, but `Argmax` internal did not, causing DQN to fail. Update `Argmax` to use batched inputs as well to fix DQN.
- testrun: DQN and DQN PER works again. A2C also works