### PR TITLE
Fixed docker image build error

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -10,7 +10,7 @@ dependencies:
   - colorlog=3.1.0=py36_0
   - coverage=4.4.2=py36_0
   - cython=0.27.3=py36_0
-  - flaky=3.4.0=py_0
+  - flaky=3.5.3=py_0
   - hdf5=1.10.1=1
   - ipykernel=4.7.0=py36_0
   - libgcc


### PR DESCRIPTION
Docker fails to build the image because of the error in the last run statement which runs all the tests. The error is due to flaky using pytest internal apis, discussed more here:
https://github.com/box/flaky/issues/139

In the newer version of flaky this issue is fixed and simply updating the dependence to a newer version in the environment.yml fixes the docker build.