### PR TITLE
Cast numpy before pytorch for 2% speed gain

### DIFF
--- a/slm_lab/agent/algorithm/hydra_dqn.py
+++ b/slm_lab/agent/algorithm/hydra_dqn.py
@@ -49,7 +49,7 @@ class HydraDQN(DQN):
             if self.normalize_state:
                 state = policy_util.update_online_stats_and_normalize_state(body, state)
             states.append(state)
-        xs = [torch.from_numpy(state).float() for state in states]
+        xs = [torch.from_numpy(state.astype(np.float32)) for state in states]
         pdparam = self.calc_pdparam(xs)
         # use multi-policy. note arg change
         action_a = self.action_policy(states, self, self.agent.nanflat_body_a, pdparam)

--- a/slm_lab/agent/algorithm/policy_util.py
+++ b/slm_lab/agent/algorithm/policy_util.py
@@ -43,7 +43,7 @@ def try_preprocess(state, algorithm, body, append=True):
         state = state.__array__()  # from global env preprocessor
     if hasattr(body.memory, 'preprocess_state'):
         state = body.memory.preprocess_state(state, append=append)
-    state = torch.from_numpy(state).float()
+    state = torch.from_numpy(state.astype(np.float32))
     if not body.env.is_venv or util.in_eval_lab_modes():
         # singleton state, unsqueeze as minibatch for net input
         state = state.unsqueeze(dim=0)

--- a/slm_lab/agent/net/net_util.py
+++ b/slm_lab/agent/net/net_util.py
@@ -173,13 +173,13 @@ def save_algorithm(algorithm, ckpt=None):
     prepath = util.get_prepath(agent.spec, agent.info_space, unit='session')
     if ckpt is not None:
         prepath = f'{prepath}_ckpt-{ckpt}'
-    logger.info(f'Saving algorithm {util.get_class_name(algorithm)} nets {net_names} to {prepath}_*.pth')
     for net_name in net_names:
         net = getattr(algorithm, net_name)
         model_path = f'{prepath}_{net_name}_model.pth'
         save(net, model_path)
         optim_path = f'{prepath}_{net_name}_optim.pth'
         save(net.optim, optim_path)
+    logger.info(f'Saved algorithm {util.get_class_name(algorithm)} nets {net_names} to {prepath}_*.pth')
 
 
 def load(net, model_path):

--- a/slm_lab/env/openai.py
+++ b/slm_lab/env/openai.py
@@ -98,8 +98,8 @@ class OpenAIEnv(BaseEnv):
             state_e = self.space_reset()
             _reward_e, done_e = self.env_space.aeb_space.init_data_s(['reward', 'done'], e=self.e)
             return state_e, _reward_e, done_e, None
-        if not self.is_discrete:
-            action = np.array([action])
+        if not self.is_discrete and self.action_dim == 1:  # guard for continuous with action_dim 1, make array
+            action = np.expand_dims(action, axis=-1)
         state, reward, done, info = self.u_env.step(action)
         if self.reward_scale is not None:
             reward *= self.reward_scale

--- a/slm_lab/experiment/analysis.py
+++ b/slm_lab/experiment/analysis.py
@@ -468,21 +468,21 @@ def save_session_data(spec, info_space, session_data, session_fitness_df, sessio
     session_data = util.session_df_to_data(session_df)
     '''
     prepath = util.get_prepath(spec, info_space, unit='session')
-    logger.info(f'Saving {body_df_kind} session data and graphs to {prepath}*')
     prefix = 'train' if body_df_kind == 'train' else ''
     if 'retro_analyze' not in os.environ['PREPATH']:
         save_session_df(session_data, f'{prepath}_{prefix}session_df.csv', info_space)
     util.write(session_fitness_df, f'{prepath}_{prefix}session_fitness_df.csv')
     viz.save_image(session_fig, f'{prepath}_{prefix}session_graph.png')
+    logger.info(f'Saved {body_df_kind} session data and graphs to {prepath}*')
 
 
 def save_trial_data(spec, info_space, trial_df, trial_fitness_df, trial_fig, zip=True):
     '''Save the trial data: spec, trial_fitness_df.'''
     prepath = util.get_prepath(spec, info_space, unit='trial')
-    logger.info(f'Saving trial data and graphs to {prepath}*')
     util.write(trial_df, f'{prepath}_trial_df.csv')
     util.write(trial_fitness_df, f'{prepath}_trial_fitness_df.csv')
     viz.save_image(trial_fig, f'{prepath}_trial_graph.png')
+    logger.info(f'Saved trial data and graphs to {prepath}*')
     if util.get_lab_mode() == 'train' and zip:
         predir, _, _, _, _, _ = util.prepath_split(prepath)
         shutil.make_archive(predir, 'zip', predir)
@@ -492,9 +492,9 @@ def save_trial_data(spec, info_space, trial_df, trial_fitness_df, trial_fig, zip
 def save_experiment_data(spec, info_space, experiment_df, experiment_fig):
     '''Save the experiment data: best_spec, experiment_df, experiment_graph.'''
     prepath = util.get_prepath(spec, info_space, unit='experiment')
-    logger.info(f'Saving experiment data to {prepath}')
     util.write(experiment_df, f'{prepath}_experiment_df.csv')
     viz.save_image(experiment_fig, f'{prepath}_experiment_graph.png')
+    logger.info(f'Saved experiment data to {prepath}')
     # zip for ease of upload
     predir, _, _, _, _, _ = util.prepath_split(prepath)
     shutil.make_archive(predir, 'zip', predir)

--- a/slm_lab/lib/util.py
+++ b/slm_lab/lib/util.py
@@ -658,7 +658,7 @@ def to_torch_batch(batch, device, is_episodic):
             batch[k] = np.concatenate(batch[k])
         elif ps.is_list(batch[k]):
             batch[k] = np.array(batch[k])
-        batch[k] = torch.from_numpy(batch[k].astype('float32')).to(device)
+        batch[k] = torch.from_numpy(batch[k].astype(np.float32)).to(device)
     return batch
 
 

--- a/test/agent/memory/test_per_memory.py
+++ b/test/agent/memory/test_per_memory.py
@@ -126,7 +126,7 @@ class TestPERMemory:
         memory.batch_idxs = np.asarray([0, 1, 2, 3]).astype(int)
         memory.tree_idxs = [3, 4, 5, 6]
         print(f'batch_size: {batch_size}, batch_idxs: {memory.batch_idxs}, tree_idxs: {memory.tree_idxs}')
-        new_errors = torch.from_numpy(np.asarray([0, 10, 10, 20])).float().unsqueeze(dim=1)
+        new_errors = torch.from_numpy(np.array([0, 10, 10, 20]).astype(np.float32)).unsqueeze(dim=1)
         print(f'new_errors: {new_errors}')
         memory.update_priorities(new_errors)
         memory.tree.print_tree()
@@ -136,7 +136,7 @@ class TestPERMemory:
         assert memory.priorities[2] == 10
         assert memory.priorities[3] == 20
         # Second update
-        new_errors = torch.from_numpy(np.asarray([90, 0, 30, 0])).float().unsqueeze(dim=1)
+        new_errors = torch.from_numpy(np.array([90, 0, 30, 0]).astype(np.float32)).unsqueeze(dim=1)
         # Manually change tree idxs and batch idxs
         memory.batch_idxs = np.asarray([0, 1, 2, 3]).astype(int)
         memory.tree_idxs = [3, 4, 5, 6]


### PR DESCRIPTION
## Feature / Fix
- profiling and test shows that casting in numpy to float32 before converting to pytorch then casting is 2% faster in terms of overall run time (former operation takes 1/3 the time now)
- clarify logging