### PR TITLE
Unify preprocessing, retire some memory classes

### DIFF
--- a/slm_lab/agent/__init__.py
+++ b/slm_lab/agent/__init__.py
@@ -58,7 +58,7 @@ class Agent:
     @lab_api
     def reset(self, state):
         '''Do agent reset per session, such as memory pointer'''
-        self.body.memory.epi_reset(state)
+        pass
 
     @lab_api
     def act(self, state):
@@ -117,8 +117,7 @@ class Agent:
     @lab_api
     def space_reset(self, state_a):
         '''Do agent reset per session, such as memory pointer'''
-        for eb, body in util.ndenumerate_nonan(self.body_a):
-            body.memory.epi_reset(state_a[eb])
+        pass
 
     @lab_api
     def space_act(self, state_a):

--- a/slm_lab/agent/algorithm/dqn.py
+++ b/slm_lab/agent/algorithm/dqn.py
@@ -47,7 +47,7 @@ class VanillaDQN(SARSA):
         "training_epoch": 4,
         "training_frequency": 10,
         "training_start_step": 10,
-        "normalize_state": true
+        "normalize_state": false
     }
     '''
 

--- a/slm_lab/agent/algorithm/ppo.py
+++ b/slm_lab/agent/algorithm/ppo.py
@@ -54,7 +54,7 @@ class PPO(ActorCritic):
         "minibatch_size": 256,
         "training_frequency": 1,
         "training_epoch": 8,
-        "normalize_state": true
+        "normalize_state": false
     }
 
     e.g. special net_spec param "shared" to share/separate Actor/Critic

--- a/slm_lab/agent/algorithm/reinforce.py
+++ b/slm_lab/agent/algorithm/reinforce.py
@@ -37,7 +37,7 @@ class Reinforce(Algorithm):
           "end_step": 5000,
         },
         "training_frequency": 1,
-        "normalize_state": true
+        "normalize_state": false
     }
     '''
 

--- a/slm_lab/agent/algorithm/sarsa.py
+++ b/slm_lab/agent/algorithm/sarsa.py
@@ -39,7 +39,7 @@ class SARSA(Algorithm):
         },
         "gamma": 0.99,
         "training_frequency": 10,
-        "normalize_state": true
+        "normalize_state": false
     }
     '''
 

--- a/slm_lab/agent/algorithm/sil.py
+++ b/slm_lab/agent/algorithm/sil.py
@@ -39,7 +39,7 @@ class SIL(ActorCritic):
         "training_batch_epoch": 8,
         "training_frequency": 1,
         "training_epoch": 8,
-        "normalize_state": true
+        "normalize_state": false
     }
 
     e.g. special memory_spec
@@ -188,7 +188,7 @@ class PPOSIL(SIL, PPO):
         "training_frequency": 1,
         "training_batch_epoch": 8,
         "training_epoch": 8,
-        "normalize_state": true
+        "normalize_state": false
     }
 
     e.g. special memory_spec

--- a/slm_lab/agent/memory/base.py
+++ b/slm_lab/agent/memory/base.py
@@ -24,19 +24,11 @@ class Memory(ABC):
 
         # declare what data keys to store
         self.data_keys = ['states', 'actions', 'rewards', 'next_states', 'dones', 'priorities']
-        # for API consistency, reset to some max_len in your specific memory class
-        self.state_buffer = deque(maxlen=0)
 
     @abstractmethod
     def reset(self):
         '''Method to fully reset the memory storage and related variables'''
         raise NotImplementedError
-
-    def epi_reset(self, state):
-        '''Method to reset at new episode'''
-        self.state_buffer.clear()
-        for _ in range(self.state_buffer.maxlen):
-            self.state_buffer.append(np.zeros(self.body.state_dim))
 
     @abstractmethod
     def update(self, state, action, reward, next_state, done):
@@ -47,16 +39,6 @@ class Memory(ABC):
     def sample(self):
         '''Implement memory sampling mechanism'''
         raise NotImplementedError
-
-    def preprocess_append(self, state, append=True):
-        '''Method to conditionally append to state buffer'''
-        if append:
-            assert id(state) != id(self.state_buffer[-1]), 'Do not append to buffer other than during action'
-            self.state_buffer.append(state)
-
-    def preprocess_state(self, state, append=True):
-        '''Transforms the raw state into format that is fed into the network'''
-        return state
 
     def print_memory_info(self):
         '''Prints size of all of the memory arrays'''

--- a/slm_lab/agent/memory/onpolicy.py
+++ b/slm_lab/agent/memory/onpolicy.py
@@ -39,7 +39,6 @@ class OnPolicyReplay(Memory):
         super().__init__(memory_spec, body)
         # NOTE for OnPolicy replay, frequency = episode; for other classes below frequency = frames
         util.set_attr(self, self.body.agent.agent_spec['algorithm'], ['training_frequency'])
-        self.state_buffer = deque(maxlen=0)  # for API consistency
         # Don't want total experiences reset when memory is
         self.is_episodic = True
         self.size = 0  # total experiences stored
@@ -56,17 +55,11 @@ class OnPolicyReplay(Memory):
         self.cur_epi_data = {k: [] for k in self.data_keys}
         self.most_recent = [None] * len(self.data_keys)
         self.size = 0
-        self.state_buffer.clear()
-        for _ in range(self.state_buffer.maxlen):
-            self.state_buffer.append(np.zeros(self.body.state_dim))
 
     @lab_api
     def update(self, state, action, reward, next_state, done):
         '''Interface method to update memory'''
-        if not self.body.env.is_venv and np.isnan(reward):  # start of episode (venv is not episodic)
-            self.epi_reset(next_state)
-        else:
-            self.add_experience(state, action, reward, next_state, done)
+        self.add_experience(state, action, reward, next_state, done)
 
     def add_experience(self, state, action, reward, next_state, done):
         '''Interface helper method for update() to add experience to memory'''
@@ -105,78 +98,6 @@ class OnPolicyReplay(Memory):
         batch = {k: getattr(self, k) for k in self.data_keys}
         self.reset()
         return batch
-
-
-class OnPolicySeqReplay(OnPolicyReplay):
-    '''
-    Same as OnPolicyReplay Memory but returns the last `seq_len` states and next_states for input to a recurrent network.
-    Experiences with less than `seq_len` previous examples are padded with a 0 valued state and action vector.
-
-    e.g. memory_spec
-    "memory": {
-        "name": "OnPolicySeqReplay"
-    }
-    * seq_len provided by net_spec
-    '''
-
-    def __init__(self, memory_spec, body):
-        super().__init__(memory_spec, body)
-        self.seq_len = self.body.agent.agent_spec['net']['seq_len']
-        self.state_buffer = deque(maxlen=self.seq_len)
-        self.reset()
-
-    def preprocess_state(self, state, append=True):
-        '''
-        Transforms the raw state into format that is fed into the network
-        NOTE for onpolicy memory this method only gets called in policy util, not here.
-        '''
-        self.preprocess_append(state, append)
-        return np.stack(self.state_buffer)
-
-    def sample(self):
-        '''
-        Returns all the examples from memory in a single batch. Batch is stored as a dict.
-        Keys are the names of the different elements of an experience. Values are nested lists of the corresponding sampled elements. Elements are nested into episodes
-        states and next_states have are further nested into sequences containing the previous `seq_len` - 1 relevant states
-        e.g.
-        let s_seq_0 be [0, ..., s0] (zero-padded), s_seq_k be [s_{k-seq_len}, ..., s_k], so the states are nested for passing into RNN.
-        batch = {
-            'states'    : [
-                [s_seq_0, s_seq_1, ..., s_seq_k]_epi_1,
-                [s_seq_0, s_seq_1, ..., s_seq_k]_epi_2,
-                ...]
-            'actions'   : [[a_epi1], [a_epi2], ...],
-            'rewards'   : [[r_epi1], [r_epi2], ...],
-            'next_states: [
-                [ns_seq_0, ns_seq_1, ..., ns_seq_k]_epi_1,
-                [ns_seq_0, ns_seq_1, ..., ns_seq_k]_epi_2,
-                ...]
-            'dones'     : [[d_epi1], [d_epi2], ...]}
-        '''
-        batch = {}
-        batch['states'] = self.build_seqs(self.states)
-        batch['actions'] = self.actions
-        batch['rewards'] = self.rewards
-        batch['next_states'] = self.build_seqs(self.next_states)
-        batch['dones'] = self.dones
-        self.reset()
-        return batch
-
-    def build_seqs(self, data):
-        '''Construct the epi-nested-seq data for sampling'''
-        all_epi_data_seq = []
-        for epi_data in data:
-            data_seq = []
-            # make [0, ..., *epi_data]
-            padded_epi_data = deepcopy(epi_data)
-            padding = np.zeros_like(epi_data[0])
-            for i in range(self.seq_len - 1):
-                padded_epi_data.insert(0, padding)
-            # slide seqs and build for one epi
-            for i in range(len(epi_data)):
-                data_seq.append(padded_epi_data[i:i + self.seq_len])
-            all_epi_data_seq.append(data_seq)
-        return all_epi_data_seq
 
 
 class OnPolicyBatchReplay(OnPolicyReplay):
@@ -225,126 +146,12 @@ class OnPolicyBatchReplay(OnPolicyReplay):
         return super().sample()
 
 
-class OnPolicySeqBatchReplay(OnPolicyBatchReplay):
-    '''
-    Same as OnPolicyBatchReplay Memory but returns the last `seq_len` states and next_states for input to a recurrent network.
-    Experiences with less than `seq_len` previous examples are padded with a 0 valued state and action vector.
-
-    e.g. memory_spec
-    "memory": {
-        "name": "OnPolicySeqBatchReplay"
-    }
-    * seq_len provided by net_spec
-    * batch_size is training_frequency provided by algorithm_spec
-    '''
-
-    def __init__(self, memory_spec, body):
-        super().__init__(memory_spec, body)
-        self.is_episodic = False
-        self.seq_len = self.body.agent.agent_spec['net']['seq_len']
-        self.state_buffer = deque(maxlen=self.seq_len)
-        self.reset()
-
-    def preprocess_state(self, state, append=True):
-        # delegate to OnPolicySeqReplay sequential method
-        return OnPolicySeqReplay.preprocess_state(self, state, append)
-
-    def sample(self):
-        '''
-        Batched version of OnPolicySeqBatchReplay.sample()
-        e.g.
-        let s_seq_0 be [0, ..., s0] (zero-padded), s_seq_k be [s_{k-seq_len}, ..., s_k], so the states are nested for passing into RNN.
-        batch = {
-            'states'     : [[s_seq_0, s_seq_1, ..., s_seq_k]],
-            'actions'    : actions,
-            'rewards'    : rewards,
-            'next_states': [[ns_seq_0, ns_seq_1, ..., ns_seq_k]],
-            'dones'      : dones}
-        '''
-        # delegate method
-        return OnPolicySeqReplay.sample(self)
-
-    def build_seqs(self, data):
-        '''Construct the seq data for sampling'''
-        data_seq = []
-        # make [0, ..., *data]
-        padded_data = deepcopy(data)
-        padding = np.zeros_like(data[0])
-        for i in range(self.seq_len - 1):
-            padded_data.insert(0, padding)
-        # slide seqs and build for one epi
-        for i in range(len(data)):
-            data_seq.append(padded_data[i:i + self.seq_len])
-        return data_seq
-
-
-class OnPolicyConcatReplay(OnPolicyReplay):
-    '''
-    Preprocesses a state to be the concatenation of the last n states. Otherwise the same as Replay memory
-
-    e.g. memory_spec
-    "memory": {
-        "name": "OnPolicyConcatReplay",
-        "concat_len": 4
-    }
-    '''
-
-    def __init__(self, memory_spec, body):
-        util.set_attr(self, memory_spec, [
-            'concat_len',  # number of stack states
-        ])
-        self.raw_state_dim = deepcopy(body.state_dim)  # used for state_buffer
-        body.state_dim = body.state_dim * self.concat_len  # modify to use for net init for concat input
-        super().__init__(memory_spec, body)
-        self.state_buffer = deque(maxlen=self.concat_len)
-        self.reset()
-
-    def reset(self):
-        '''Initializes the memory arrays, size and head pointer'''
-        super().reset()
-        self.state_buffer.clear()
-        for _ in range(self.state_buffer.maxlen):
-            self.state_buffer.append(np.zeros(self.raw_state_dim))
-
-    def epi_reset(self, state):
-        '''Method to reset at new episode'''
-        state = self.preprocess_state(state, append=False)  # prevent conflict with preprocess in epi_reset
-        super().epi_reset(state)
-        # reappend buffer with custom shape
-        self.state_buffer.clear()
-        for _ in range(self.state_buffer.maxlen):
-            self.state_buffer.append(np.zeros(self.raw_state_dim))
-
-    def preprocess_state(self, state, append=True):
-        '''Transforms the raw state into format that is fed into the network'''
-        # append when state is first seen when acting in policy_util, don't append elsewhere in memory
-        self.preprocess_append(state, append)
-        return np.concatenate(self.state_buffer)
-
-    @lab_api
-    def update(self, state, action, reward, next_state, done):
-        '''Interface method to update memory'''
-        if not self.body.env.is_venv and np.isnan(reward):  # start of episode (venv is not episodic)
-            self.epi_reset(next_state)
-        else:
-            # prevent conflict with preprocess in epi_reset
-            state = self.preprocess_state(state, append=False)
-            next_state = self.preprocess_state(next_state, append=False)
-            self.add_experience(state, action, reward, next_state, done)
-
-
 class OnPolicyAtariReplay(OnPolicyReplay):
     '''
     Preprocesses an state to be the concatenation of the last four states, after converting the 210 x 160 x 3 image to 84 x 84 x 1 grayscale image, and clips all rewards to [-10, 10] as per "Playing Atari with Deep Reinforcement Learning", Mnih et al, 2013
     Note: Playing Atari with Deep RL clips the rewards to + / - 1
     Otherwise the same as OnPolicyReplay memory
     '''
-
-    def __init__(self, memory_spec, body):
-        util.set_attr(self, memory_spec, [
-            'stack_len',  # number of stack states
-        ])
-        OnPolicyReplay.__init__(self, memory_spec, body)
 
     def add_experience(self, state, action, reward, next_state, done):
         # clip reward, done here to minimize change to only training data data
@@ -356,17 +163,3 @@ class OnPolicyAtariBatchReplay(OnPolicyBatchReplay, OnPolicyAtariReplay):
     OnPolicyBatchReplay with Atari concat
     '''
     pass
-
-
-class OnPolicyImageReplay(OnPolicyReplay):
-    '''
-    An on policy replay buffer that normalizes (preprocesses) images through
-    division by 255 and subtraction of 0.5.
-    '''
-
-    def __init__(self, memory_spec, body):
-        super().__init__(memory_spec, body)
-
-    def preprocess_state(self, state, append=True):
-        state = util.normalize_image(state) - 0.5
-        return state

--- a/slm_lab/agent/net/recurrent.py
+++ b/slm_lab/agent/net/recurrent.py
@@ -111,6 +111,8 @@ class RecurrentNet(Net, nn.Module):
             'polyak_coef',
             'gpu',
         ])
+        # restore proper in_dim from env stacked state_dim (stack_len, *raw_state_dim)
+        self.in_dim = in_dim[1:] if len(in_dim) > 2 else in_dim[1]
         # fc body: state processing model
         if ps.is_empty(self.fc_hid_layers):
             self.rnn_input_dim = self.in_dim

--- a/slm_lab/env/base.py
+++ b/slm_lab/env/base.py
@@ -3,6 +3,7 @@ from gym import spaces
 from slm_lab.lib import logger, util
 from slm_lab.lib.decorator import lab_api
 import numpy as np
+import pydash as ps
 import time
 
 ENV_DATA_NAMES = ['state', 'reward', 'done']
@@ -95,6 +96,8 @@ class BaseEnv(ABC):
         # set default
         util.set_attr(self, dict(
             log_frequency=None,  # default to log at epi done
+            frame_op=None,
+            frame_op_len=None,
             num_envs=None,
             reward_scale=None,
         ))
@@ -105,11 +108,18 @@ class BaseEnv(ABC):
         ])
         util.set_attr(self, self.env_spec, [
             'name',
+            'frame_op',
+            'frame_op_len',
             'num_envs',
             'max_t',
             'max_tick',
             'reward_scale',
         ])
+        # infer if using RNN
+        seq_len = ps.get(spec, 'agent.0.net.seq_len')
+        if seq_len is not None:
+            self.frame_op = 'stack'
+            self.frame_op_len = seq_len
         if util.get_lab_mode() == 'eval':
             self.num_envs = None  # use singleton for eval
             # override for eval, offset so epi is 0 - (num_eval_epi - 1)

--- a/slm_lab/env/openai.py
+++ b/slm_lab/env/openai.py
@@ -95,13 +95,11 @@ class OpenAIEnv(BaseEnv):
     @lab_api
     def space_step(self, action_e):
         action = action_e[(0, 0)]  # single body
-        if self.done:  # space envs run continually without a central reset signal
-            state_e = self.space_reset()
-            _reward_e, done_e = self.env_space.aeb_space.init_data_s(['reward', 'done'], e=self.e)
-            return state_e, _reward_e, done_e, None
         if not self.is_discrete and self.action_dim == 1:  # guard for continuous with action_dim 1, make array
             action = np.expand_dims(action, axis=-1)
         state, reward, done, info = self.u_env.step(action)
+        if done:
+            state = self.u_env.reset()
         if self.reward_scale is not None:
             reward *= self.reward_scale
         if self.to_render:

--- a/slm_lab/env/openai.py
+++ b/slm_lab/env/openai.py
@@ -20,6 +20,8 @@ class OpenAIEnv(BaseEnv):
     e.g. env_spec
     "env": [{
       "name": "CartPole-v0",
+      "frame_op": "concat",
+      "frame_op_len": 4,
       "num_envs": null,
       "max_t": null,
       "max_tick": 10000,
@@ -30,11 +32,10 @@ class OpenAIEnv(BaseEnv):
         super().__init__(spec, e, env_space)
         try_register_env(spec)  # register if it's a custom gym env
         seed = ps.get(spec, 'meta.random_seed')
-        stack_len = ps.get(spec, 'agent.0.memory.stack_len')
         if self.is_venv:  # make vector environment
-            self.u_env = make_gym_venv(self.name, seed, stack_len, self.num_envs)
+            self.u_env = make_gym_venv(self.name, seed, self.frame_op, self.frame_op_len, self.num_envs)
         else:
-            self.u_env = make_gym_env(self.name, seed, stack_len)
+            self.u_env = make_gym_env(self.name, seed, self.frame_op, self.frame_op_len)
         self._set_attr_from_u_env(self.u_env)
         self.max_t = self.max_t or self.u_env.spec.max_episode_steps
         assert self.max_t is not None

--- a/slm_lab/env/unity.py
+++ b/slm_lab/env/unity.py
@@ -179,13 +179,11 @@ class UnityEnv(BaseEnv):
     @lab_api
     def space_step(self, action_e):
         # TODO implement clock_speed: step only if self.clock.to_step()
-        if self.done:
-            state_e = self.space_reset()
-            _reward_e, done_e = self.env_space.aeb_space.init_data_s(['reward', 'done'], e=self.e)
-            return state_e, _reward_e, done_e, None
         action_e = util.nanflatten(action_e)
         env_info_dict = self.u_env.step(action_e)
         state_e, reward_e, done_e = self.env_space.aeb_space.init_data_s(ENV_DATA_NAMES, e=self.e)
+        if util.nonan_all(done_e):
+            state_e = self.space_reset()
         for (a, b), body in util.ndenumerate_nonan(self.body_e):
             env_info_a = self._get_env_info(env_info_dict, a)
             state_e[(a, b)] = env_info_a.states[b]

--- a/slm_lab/spec/benchmark/ddqn_lunar.json
+++ b/slm_lab/spec/benchmark/ddqn_lunar.json
@@ -18,14 +18,13 @@
         "training_epoch": 4,
         "training_frequency": 4,
         "training_start_step": 32,
-        "normalize_state": true
+        "normalize_state": false
       },
       "memory": {
         "name": "Replay",
         "batch_size": 32,
         "max_size": 100000,
-        "use_cer": false,
-        "concat_len": 4
+        "use_cer": false
       },
       "net": {
         "type": "MLPNet",
@@ -57,6 +56,8 @@
     }],
     "env": [{
       "name": "LunarLander-v2",
+      "frame_op": "concat",
+      "frame_op_len": 4,
       "max_t": null,
       "max_tick": 250000
     }],

--- a/slm_lab/spec/benchmark/dqn_lunar.json
+++ b/slm_lab/spec/benchmark/dqn_lunar.json
@@ -24,8 +24,7 @@
         "name": "Replay",
         "batch_size": 32,
         "max_size": 100000,
-        "use_cer": false,
-        "concat_len": 4
+        "use_cer": false
       },
       "net": {
         "type": "MLPNet",
@@ -56,6 +55,8 @@
     }],
     "env": [{
       "name": "LunarLander-v2",
+      "frame_op": "concat",
+      "frame_op_len": 4,
       "max_t": null,
       "max_tick": 250000
     }],

--- a/slm_lab/spec/experimental/a2c.json
+++ b/slm_lab/spec/experimental/a2c.json
@@ -21,7 +21,7 @@
         "val_loss_coef": 0.01,
         "training_frequency": 1,
         "training_epoch": 8,
-        "normalize_state": true
+        "normalize_state": false
       },
       "memory": {
         "name": "OnPolicyReplay"
@@ -105,7 +105,7 @@
         "val_loss_coef": 0.01,
         "training_frequency": 1,
         "training_epoch": 8,
-        "normalize_state": true
+        "normalize_state": false
       },
       "memory": {
         "name": "OnPolicyReplay"
@@ -189,11 +189,10 @@
         "val_loss_coef": 0.01,
         "training_frequency": 1,
         "training_epoch": 8,
-        "normalize_state": true
+        "normalize_state": false
       },
       "memory": {
-        "name": "OnPolicyConcatReplay",
-        "concat_len": 4
+        "name": "OnPolicyReplay"
       },
       "net": {
         "type": "MLPNet",
@@ -220,6 +219,8 @@
     }],
     "env": [{
       "name": "CartPole-v0",
+      "frame_op": "concat",
+      "frame_op_len": 4,
       "max_t": null,
       "max_tick": 500,
     }],
@@ -274,10 +275,10 @@
         "val_loss_coef": 0.01,
         "training_frequency": 1,
         "training_epoch": 8,
-        "normalize_state": true
+        "normalize_state": false
       },
       "memory": {
-        "name": "OnPolicySeqReplay"
+        "name": "OnPolicyReplay"
       },
       "net": {
         "type": "RecurrentNet",
@@ -362,10 +363,10 @@
         "val_loss_coef": 0.01,
         "training_frequency": 1,
         "training_epoch": 8,
-        "normalize_state": true
+        "normalize_state": false
       },
       "memory": {
-        "name": "OnPolicySeqReplay"
+        "name": "OnPolicyReplay"
       },
       "net": {
         "type": "RecurrentNet",
@@ -450,7 +451,7 @@
         "val_loss_coef": 0.01,
         "training_frequency": 1,
         "training_epoch": 8,
-        "normalize_state": true
+        "normalize_state": false
       },
       "memory": {
         "name": "OnPolicyReplay"
@@ -534,7 +535,7 @@
         "val_loss_coef": 0.01,
         "training_frequency": 1,
         "training_epoch": 8,
-        "normalize_state": true
+        "normalize_state": false
       },
       "memory": {
         "name": "OnPolicyReplay"
@@ -618,10 +619,10 @@
         "val_loss_coef": 0.01,
         "training_frequency": 1,
         "training_epoch": 8,
-        "normalize_state": true
+        "normalize_state": false
       },
       "memory": {
-        "name": "OnPolicySeqReplay"
+        "name": "OnPolicyReplay"
       },
       "net": {
         "type": "RecurrentNet",
@@ -706,10 +707,10 @@
         "val_loss_coef": 0.01,
         "training_frequency": 1,
         "training_epoch": 8,
-        "normalize_state": true
+        "normalize_state": false
       },
       "memory": {
-        "name": "OnPolicySeqReplay"
+        "name": "OnPolicyReplay"
       },
       "net": {
         "type": "RecurrentNet",
@@ -798,7 +799,6 @@
       },
       "memory": {
         "name": "OnPolicyAtariReplay",
-        "stack_len": 4
       },
       "net": {
         "type": "ConvNet",
@@ -831,6 +831,8 @@
     }],
     "env": [{
       "name": "PongNoFrameskip-v4",
+      "frame_op": "concat",
+      "frame_op_len": 4,
       "max_t": null,
       "max_tick": 10000000,
     }],

--- a/slm_lab/spec/experimental/a2c_pong.json
+++ b/slm_lab/spec/experimental/a2c_pong.json
@@ -24,7 +24,6 @@
       },
       "memory": {
         "name": "OnPolicyAtariBatchReplay",
-        "stack_len": 4
       },
       "net": {
         "type": "ConvNet",
@@ -62,6 +61,8 @@
     }],
     "env": [{
       "name": "PongNoFrameskip-v4",
+      "frame_op": "concat",
+      "frame_op_len": 4,
       "num_envs": 16,
       "max_t": null,
       "max_tick": 1e7

--- a/slm_lab/spec/experimental/a3c.json
+++ b/slm_lab/spec/experimental/a3c.json
@@ -21,7 +21,7 @@
         "val_loss_coef": 0.96,
         "training_frequency": 1,
         "training_epoch": 8,
-        "normalize_state": true
+        "normalize_state": false
       },
       "memory": {
         "name": "OnPolicyReplay"
@@ -105,7 +105,7 @@
         "val_loss_coef": 0.01,
         "training_frequency": 1,
         "training_epoch": 8,
-        "normalize_state": true
+        "normalize_state": false
       },
       "memory": {
         "name": "OnPolicyReplay"
@@ -189,7 +189,7 @@
         "val_loss_coef": 0.08,
         "training_frequency": 1,
         "training_epoch": 4,
-        "normalize_state": true
+        "normalize_state": false
       },
       "memory": {
         "name": "OnPolicyReplay"
@@ -273,10 +273,10 @@
         "val_loss_coef": 0.01,
         "training_frequency": 1,
         "training_epoch": 8,
-        "normalize_state": true
+        "normalize_state": false
       },
       "memory": {
-        "name": "OnPolicySeqReplay"
+        "name": "OnPolicyReplay"
       },
       "net": {
         "type": "RecurrentNet",
@@ -361,10 +361,10 @@
         "val_loss_coef": 0.01,
         "training_frequency": 1,
         "training_epoch": 8,
-        "normalize_state": true
+        "normalize_state": false
       },
       "memory": {
-        "name": "OnPolicySeqReplay"
+        "name": "OnPolicyReplay"
       },
       "net": {
         "type": "RecurrentNet",
@@ -449,7 +449,7 @@
         "val_loss_coef": 0.01,
         "training_frequency": 1,
         "training_epoch": 8,
-        "normalize_state": true
+        "normalize_state": false
       },
       "memory": {
         "name": "OnPolicyReplay"
@@ -533,7 +533,7 @@
         "val_loss_coef": 0.01,
         "training_frequency": 1,
         "training_epoch": 8,
-        "normalize_state": true
+        "normalize_state": false
       },
       "memory": {
         "name": "OnPolicyReplay"
@@ -617,10 +617,10 @@
         "val_loss_coef": 0.01,
         "training_frequency": 1,
         "training_epoch": 8,
-        "normalize_state": true
+        "normalize_state": false
       },
       "memory": {
-        "name": "OnPolicySeqReplay"
+        "name": "OnPolicyReplay"
       },
       "net": {
         "type": "RecurrentNet",
@@ -705,10 +705,10 @@
         "val_loss_coef": 0.01,
         "training_frequency": 1,
         "training_epoch": 8,
-        "normalize_state": true
+        "normalize_state": false
       },
       "memory": {
-        "name": "OnPolicySeqReplay"
+        "name": "OnPolicyReplay"
       },
       "net": {
         "type": "RecurrentNet",

--- a/slm_lab/spec/experimental/cartpole.json
+++ b/slm_lab/spec/experimental/cartpole.json
@@ -16,7 +16,7 @@
           "end_step": 2000,
         },
         "training_frequency": 1,
-        "normalize_state": true
+        "normalize_state": false
       },
       "memory": {
         "name": "OnPolicyReplay"
@@ -95,10 +95,10 @@
           "end_step": 2000,
         },
         "training_frequency": 1,
-        "normalize_state": true
+        "normalize_state": false
       },
       "memory": {
-        "name": "OnPolicySeqReplay"
+        "name": "OnPolicyReplay"
       },
       "net": {
         "type": "RecurrentNet",
@@ -270,7 +270,7 @@
         "val_loss_coef": 0.01,
         "training_frequency": 1,
         "training_epoch": 4,
-        "normalize_state": true
+        "normalize_state": false
       },
       "memory": {
         "name": "OnPolicyReplay"
@@ -360,7 +360,7 @@
         "val_loss_coef": 0.01,
         "training_frequency": 1,
         "training_epoch": 4,
-        "normalize_state": true
+        "normalize_state": false
       },
       "memory": {
         "name": "OnPolicyReplay"
@@ -450,10 +450,10 @@
         "val_loss_coef": 0.01,
         "training_frequency": 1,
         "training_epoch": 8,
-        "normalize_state": true
+        "normalize_state": false
       },
       "memory": {
-        "name": "OnPolicySeqReplay"
+        "name": "OnPolicyReplay"
       },
       "net": {
         "type": "RecurrentNet",
@@ -544,7 +544,7 @@
         "val_loss_coef": 0.01,
         "training_frequency": 1,
         "training_epoch": 8,
-        "normalize_state": true
+        "normalize_state": false
       },
       "memory": {
         "name": "OnPolicyReplay"
@@ -632,7 +632,7 @@
         "val_loss_coef": 0.01,
         "training_frequency": 1,
         "training_epoch": 8,
-        "normalize_state": true
+        "normalize_state": false
       },
       "memory": {
         "name": "OnPolicyReplay"
@@ -723,7 +723,7 @@
         "val_loss_coef": 0.01,
         "training_frequency": 1,
         "training_epoch": 8,
-        "normalize_state": true
+        "normalize_state": false
       },
       "memory": {
         "name": "OnPolicyReplay"
@@ -810,10 +810,10 @@
         "val_loss_coef": 0.01,
         "training_frequency": 1,
         "training_epoch": 8,
-        "normalize_state": true
+        "normalize_state": false
       },
       "memory": {
-        "name": "OnPolicySeqReplay"
+        "name": "OnPolicyReplay"
       },
       "net": {
         "type": "RecurrentNet",
@@ -910,7 +910,7 @@
         "val_loss_coef": 0.1,
         "training_frequency": 8,
         "training_epoch": 8,
-        "normalize_state": true
+        "normalize_state": false
       },
       "memory": {
         "name": "OnPolicyReplay"
@@ -1008,7 +1008,7 @@
         "training_frequency": 8,
         "training_batch_epoch": 8,
         "training_epoch": 8,
-        "normalize_state": true
+        "normalize_state": false
       },
       "memory": {
         "name": "OnPolicyReplay",
@@ -1105,7 +1105,7 @@
         "training_frequency": 1,
         "training_batch_epoch": 10,
         "training_epoch": 8,
-        "normalize_state": true
+        "normalize_state": false
       },
       "memory": {
         "name": "OnPolicyReplay",
@@ -1195,7 +1195,7 @@
         },
         "gamma": 0.99,
         "training_frequency": 20,
-        "normalize_state": true
+        "normalize_state": false
       },
       "memory": {
         "name": "OnPolicyBatchReplay"
@@ -1272,10 +1272,10 @@
         },
         "gamma": 0.99,
         "training_frequency": 20,
-        "normalize_state": true
+        "normalize_state": false
       },
       "memory": {
-        "name": "OnPolicySeqBatchReplay"
+        "name": "OnPolicyBatchReplay"
       },
       "net": {
         "type": "RecurrentNet",
@@ -1357,14 +1357,13 @@
         "training_epoch": 4,
         "training_frequency": 4,
         "training_start_step": 128,
-        "normalize_state": true
+        "normalize_state": false
       },
       "memory": {
         "name": "Replay",
         "batch_size": 32,
         "max_size": 10000,
-        "use_cer": false,
-        "concat_len": 4,
+        "use_cer": false
       },
       "net": {
         "type": "MLPNet",
@@ -1390,6 +1389,8 @@
     }],
     "env": [{
       "name": "CartPole-v0",
+      "frame_op": "concat",
+      "frame_op_len": 4,
       "max_t": null,
       "max_tick": 40000,
     }],
@@ -1417,7 +1418,6 @@
           },
         },
         "memory": {
-          "name__choice": ["Replay", "ConcatReplay"],
           "batch_size__choice": [32, 64, 128],
           "use_cer__choice": [false, true],
         },
@@ -1449,7 +1449,7 @@
         "training_epoch": 4,
         "training_frequency": 8,
         "training_start_step": 32,
-        "normalize_state": true
+        "normalize_state": false
       },
       "memory": {
         "name": "Replay",
@@ -1536,14 +1536,13 @@
         "training_epoch": 4,
         "training_frequency": 4,
         "training_start_step": 128,
-        "normalize_state": true
+        "normalize_state": false
       },
       "memory": {
         "name": "Replay",
         "batch_size": 32,
         "max_size": 10000,
-        "use_cer": false,
-        "concat_len": 4,
+        "use_cer": false
       },
       "net": {
         "type": "MLPNet",
@@ -1569,6 +1568,8 @@
     }],
     "env": [{
       "name": "CartPole-v0",
+      "frame_op": "concat",
+      "frame_op_len": 4,
       "max_t": null,
       "max_tick": 40000,
     }],
@@ -1596,7 +1597,6 @@
           },
         },
         "memory": {
-          "name__choice": ["Replay", "ConcatReplay"],
           "batch_size__choice": [32, 64, 128],
           "use_cer__choice": [false, true],
         },
@@ -1628,10 +1628,10 @@
         "training_epoch": 4,
         "training_frequency": 4,
         "training_start_step": 128,
-        "normalize_state": true
+        "normalize_state": false
       },
       "memory": {
-        "name": "SeqReplay",
+        "name": "Replay",
         "batch_size": 32,
         "max_size": 10000,
         "use_cer": false,
@@ -1722,10 +1722,10 @@
         "training_epoch": 4,
         "training_frequency": 4,
         "training_start_step": 128,
-        "normalize_state": true
+        "normalize_state": false
       },
       "memory": {
-        "name": "SeqReplay",
+        "name": "Replay",
         "batch_size": 32,
         "max_size": 10000,
         "use_cer": false,
@@ -1816,14 +1816,13 @@
         "training_epoch": 4,
         "training_frequency": 4,
         "training_start_step": 128,
-        "normalize_state": true
+        "normalize_state": false
       },
       "memory": {
         "name": "Replay",
         "batch_size": 32,
         "max_size": 10000,
-        "use_cer": false,
-        "concat_len": 4,
+        "use_cer": false
       },
       "net": {
         "type": "MLPNet",
@@ -1849,6 +1848,8 @@
     }],
     "env": [{
       "name": "CartPole-v0",
+      "frame_op": "concat",
+      "frame_op_len": 4,
       "max_t": null,
       "max_tick": 40000,
     }],
@@ -1876,7 +1877,6 @@
           },
         },
         "memory": {
-          "name__choice": ["Replay", "ConcatReplay"],
           "batch_size__choice": [32, 64, 128],
           "use_cer__choice": [false, true],
         },
@@ -1908,14 +1908,13 @@
         "training_epoch": 4,
         "training_frequency": 4,
         "training_start_step": 128,
-        "normalize_state": true
+        "normalize_state": false
       },
       "memory": {
         "name": "Replay",
         "batch_size": 32,
         "max_size": 10000,
-        "use_cer": false,
-        "concat_len": 4,
+        "use_cer": false
       },
       "net": {
         "type": "MLPNet",
@@ -1941,6 +1940,8 @@
     }],
     "env": [{
       "name": "CartPole-v0",
+      "frame_op": "concat",
+      "frame_op_len": 4,
       "max_t": null,
       "max_tick": 40000,
     }],
@@ -1968,7 +1969,6 @@
           },
         },
         "memory": {
-          "name__choice": ["Replay", "ConcatReplay"],
           "batch_size__choice": [32, 64, 128],
           "use_cer__choice": [false, true],
         },
@@ -2000,10 +2000,10 @@
         "training_epoch": 4,
         "training_frequency": 4,
         "training_start_step": 128,
-        "normalize_state": true
+        "normalize_state": false
       },
       "memory": {
-        "name": "SeqReplay",
+        "name": "Replay",
         "batch_size": 32,
         "max_size": 10000,
         "use_cer": false,
@@ -2094,10 +2094,10 @@
         "training_epoch": 4,
         "training_frequency": 4,
         "training_start_step": 128,
-        "normalize_state": true
+        "normalize_state": false
       },
       "memory": {
-        "name": "SeqReplay",
+        "name": "Replay",
         "batch_size": 32,
         "max_size": 10000,
         "use_cer": false,
@@ -2188,7 +2188,7 @@
         "training_epoch": 4,
         "training_frequency": 8,
         "training_start_step": 32,
-        "normalize_state": true
+        "normalize_state": false
       },
       "memory": {
         "name": "Replay",

--- a/slm_lab/spec/experimental/ddqn.json
+++ b/slm_lab/spec/experimental/ddqn.json
@@ -18,7 +18,7 @@
         "training_epoch": 4,
         "training_frequency": 8,
         "training_start_step": 32,
-        "normalize_state": true
+        "normalize_state": false
       },
       "memory": {
         "name": "Replay",
@@ -101,7 +101,7 @@
         "training_epoch": 4,
         "training_frequency": 32,
         "training_start_step": 10,
-        "normalize_state": true
+        "normalize_state": false
       },
       "memory": {
         "name": "Replay",
@@ -190,10 +190,10 @@
         "training_epoch": 4,
         "training_frequency": 32,
         "training_start_step": 10,
-        "normalize_state": true
+        "normalize_state": false
       },
       "memory": {
-        "name": "SeqReplay",
+        "name": "Replay",
         "batch_size": 32,
         "max_size": 10000,
         "use_cer": true
@@ -283,10 +283,10 @@
         "training_epoch": 4,
         "training_frequency": 32,
         "training_start_step": 10,
-        "normalize_state": true
+        "normalize_state": false
       },
       "memory": {
-        "name": "SeqReplay",
+        "name": "Replay",
         "batch_size": 32,
         "max_size": 10000,
         "use_cer": true
@@ -382,7 +382,6 @@
         "name": "AtariReplay",
         "batch_size": 32,
         "max_size": 250000,
-        "stack_len": 4,
         "use_cer": true
       },
       "net": {
@@ -420,6 +419,8 @@
     }],
     "env": [{
       "name": "BreakoutDeterministic-v4",
+      "frame_op": "concat",
+      "frame_op_len": 4,
       "max_t": null,
       "max_tick": 50000,
     }],
@@ -461,7 +462,6 @@
         "name": "AtariReplay",
         "batch_size": 32,
         "max_size": 250000,
-        "stack_len": 4,
         "use_cer": true
       },
       "net": {
@@ -499,6 +499,8 @@
     }],
     "env": [{
       "name": "BreakoutDeterministic-v4",
+      "frame_op": "concat",
+      "frame_op_len": 4,
       "max_t": null,
       "max_tick": 50000,
     }],

--- a/slm_lab/spec/experimental/ddqn_beamrider.json
+++ b/slm_lab/spec/experimental/ddqn_beamrider.json
@@ -24,7 +24,6 @@
         "name": "AtariReplay",
         "batch_size": 32,
         "max_size": 200000,
-        "stack_len": 4,
         "use_cer": false,
       },
       "net": {
@@ -54,6 +53,8 @@
     }],
     "env": [{
       "name": "BeamRiderNoFrameskip-v4",
+      "frame_op": "concat",
+      "frame_op_len": 4,
       "max_t": null,
       "max_tick": 10000000
     }],

--- a/slm_lab/spec/experimental/ddqn_breakout.json
+++ b/slm_lab/spec/experimental/ddqn_breakout.json
@@ -24,7 +24,6 @@
         "name": "AtariReplay",
         "batch_size": 32,
         "max_size": 200000,
-        "stack_len": 4,
         "use_cer": false
       },
       "net": {
@@ -54,6 +53,8 @@
     }],
     "env": [{
       "name": "BreakoutNoFrameskip-v4",
+      "frame_op": "concat",
+      "frame_op_len": 4,
       "max_t": null,
       "max_tick": 10000000
     }],

--- a/slm_lab/spec/experimental/ddqn_enduro.json
+++ b/slm_lab/spec/experimental/ddqn_enduro.json
@@ -24,7 +24,6 @@
         "name": "AtariReplay",
         "batch_size": 32,
         "max_size": 200000,
-        "stack_len": 4,
         "use_cer": false
       },
       "net": {
@@ -54,6 +53,8 @@
     }],
     "env": [{
       "name": "EnduroNoFrameskip-v4",
+      "frame_op": "concat",
+      "frame_op_len": 4,
       "max_t": null,
       "max_tick": 10000000
     }],

--- a/slm_lab/spec/experimental/ddqn_mspacman.json
+++ b/slm_lab/spec/experimental/ddqn_mspacman.json
@@ -24,7 +24,6 @@
         "name": "AtariReplay",
         "batch_size": 32,
         "max_size": 200000,
-        "stack_len": 4,
         "use_cer": false
       },
       "net": {
@@ -54,6 +53,8 @@
     }],
     "env": [{
       "name": "MsPacmanNoFrameskip-v4",
+      "frame_op": "concat",
+      "frame_op_len": 4,
       "max_t": null,
       "max_tick": 10000000
     }],

--- a/slm_lab/spec/experimental/ddqn_per_beamrider.json
+++ b/slm_lab/spec/experimental/ddqn_per_beamrider.json
@@ -26,7 +26,6 @@
         "epsilon": 0.0001,
         "batch_size": 32,
         "max_size": 200000,
-        "stack_len": 4,
         "use_cer": false,
       },
       "net": {
@@ -56,6 +55,8 @@
     }],
     "env": [{
       "name": "BeamRiderNoFrameskip-v4",
+      "frame_op": "concat",
+      "frame_op_len": 4,
       "max_t": null,
       "max_tick": 10000000
     }],

--- a/slm_lab/spec/experimental/ddqn_per_breakout.json
+++ b/slm_lab/spec/experimental/ddqn_per_breakout.json
@@ -26,7 +26,6 @@
         "epsilon": 0.0001,
         "batch_size": 32,
         "max_size": 200000,
-        "stack_len": 4,
         "use_cer": false
       },
       "net": {
@@ -56,6 +55,8 @@
     }],
     "env": [{
       "name": "BreakoutNoFrameskip-v4",
+      "frame_op": "concat",
+      "frame_op_len": 4,
       "max_t": null,
       "max_tick": 10000000
     }],

--- a/slm_lab/spec/experimental/ddqn_per_enduro.json
+++ b/slm_lab/spec/experimental/ddqn_per_enduro.json
@@ -26,7 +26,6 @@
         "epsilon": 0.0001,
         "batch_size": 32,
         "max_size": 200000,
-        "stack_len": 4,
         "use_cer": false
       },
       "net": {
@@ -56,6 +55,8 @@
     }],
     "env": [{
       "name": "EnduroNoFrameskip-v4",
+      "frame_op": "concat",
+      "frame_op_len": 4,
       "max_t": null,
       "max_tick": 10000000
     }],

--- a/slm_lab/spec/experimental/ddqn_per_mspacman.json
+++ b/slm_lab/spec/experimental/ddqn_per_mspacman.json
@@ -26,7 +26,6 @@
         "epsilon": 0.0001,
         "batch_size": 32,
         "max_size": 200000,
-        "stack_len": 4,
         "use_cer": false
       },
       "net": {
@@ -56,6 +55,8 @@
     }],
     "env": [{
       "name": "MsPacmanNoFrameskip-v4",
+      "frame_op": "concat",
+      "frame_op_len": 4,
       "max_t": null,
       "max_tick": 10000000
     }],

--- a/slm_lab/spec/experimental/ddqn_per_pong.json
+++ b/slm_lab/spec/experimental/ddqn_per_pong.json
@@ -26,7 +26,6 @@
         "epsilon": 0.0001,
         "batch_size": 32,
         "max_size": 200000,
-        "stack_len": 4,
         "use_cer": false
       },
       "net": {
@@ -56,6 +55,8 @@
     }],
     "env": [{
       "name": "PongNoFrameskip-v4",
+      "frame_op": "concat",
+      "frame_op_len": 4,
       "max_t": null,
       "max_tick": 10000000
     }],

--- a/slm_lab/spec/experimental/ddqn_per_qbert.json
+++ b/slm_lab/spec/experimental/ddqn_per_qbert.json
@@ -26,7 +26,6 @@
         "epsilon": 0.0001,
         "batch_size": 32,
         "max_size": 200000,
-        "stack_len": 4,
         "use_cer": false
       },
       "net": {
@@ -56,6 +55,8 @@
     }],
     "env": [{
       "name": "QbertNoFrameskip-v4",
+      "frame_op": "concat",
+      "frame_op_len": 4,
       "max_t": null,
       "max_tick": 10000000
     }],

--- a/slm_lab/spec/experimental/ddqn_per_seaquest.json
+++ b/slm_lab/spec/experimental/ddqn_per_seaquest.json
@@ -26,7 +26,6 @@
         "epsilon": 0.0001,
         "batch_size": 32,
         "max_size": 200000,
-        "stack_len": 4,
         "use_cer": false
       },
       "net": {
@@ -56,6 +55,8 @@
     }],
     "env": [{
       "name": "SeaquestNoFrameskip-v4",
+      "frame_op": "concat",
+      "frame_op_len": 4,
       "max_t": null,
       "max_tick": 10000000
     }],

--- a/slm_lab/spec/experimental/ddqn_per_spaceinvaders.json
+++ b/slm_lab/spec/experimental/ddqn_per_spaceinvaders.json
@@ -26,7 +26,6 @@
         "epsilon": 0.0001,
         "batch_size": 32,
         "max_size": 200000,
-        "stack_len": 4,
         "use_cer": false
       },
       "net": {
@@ -56,6 +55,8 @@
     }],
     "env": [{
       "name": "SpaceInvadersNoFrameskip-v4",
+      "frame_op": "concat",
+      "frame_op_len": 4,
       "max_t": null,
       "max_tick": 10000000
     }],

--- a/slm_lab/spec/experimental/ddqn_pong.json
+++ b/slm_lab/spec/experimental/ddqn_pong.json
@@ -24,7 +24,6 @@
         "name": "AtariReplay",
         "batch_size": 32,
         "max_size": 200000,
-        "stack_len": 4,
         "use_cer": false
       },
       "net": {
@@ -54,6 +53,8 @@
     }],
     "env": [{
       "name": "PongNoFrameskip-v4",
+      "frame_op": "concat",
+      "frame_op_len": 4,
       "max_t": null,
       "max_tick": 10000000
     }],

--- a/slm_lab/spec/experimental/ddqn_qbert.json
+++ b/slm_lab/spec/experimental/ddqn_qbert.json
@@ -24,7 +24,6 @@
         "name": "AtariReplay",
         "batch_size": 32,
         "max_size": 200000,
-        "stack_len": 4,
         "use_cer": false
       },
       "net": {
@@ -54,6 +53,8 @@
     }],
     "env": [{
       "name": "QbertNoFrameskip-v4",
+      "frame_op": "concat",
+      "frame_op_len": 4,
       "max_t": null,
       "max_tick": 10000000
     }],

--- a/slm_lab/spec/experimental/ddqn_seaquest.json
+++ b/slm_lab/spec/experimental/ddqn_seaquest.json
@@ -24,7 +24,6 @@
         "name": "AtariReplay",
         "batch_size": 32,
         "max_size": 200000,
-        "stack_len": 4,
         "use_cer": false
       },
       "net": {
@@ -54,6 +53,8 @@
     }],
     "env": [{
       "name": "SeaquestNoFrameskip-v4",
+      "frame_op": "concat",
+      "frame_op_len": 4,
       "max_t": null,
       "max_tick": 10000000
     }],

--- a/slm_lab/spec/experimental/ddqn_spaceinvaders.json
+++ b/slm_lab/spec/experimental/ddqn_spaceinvaders.json
@@ -24,7 +24,6 @@
         "name": "AtariReplay",
         "batch_size": 32,
         "max_size": 200000,
-        "stack_len": 4,
         "use_cer": false
       },
       "net": {
@@ -54,6 +53,8 @@
     }],
     "env": [{
       "name": "SpaceInvadersNoFrameskip-v4",
+      "frame_op": "concat",
+      "frame_op_len": 4,
       "max_t": null,
       "max_tick": 10000000
     }],

--- a/slm_lab/spec/experimental/dppo.json
+++ b/slm_lab/spec/experimental/dppo.json
@@ -26,7 +26,7 @@
         "val_loss_coef": 0.1,
         "training_frequency": 1,
         "training_epoch": 8,
-        "normalize_state": true
+        "normalize_state": false
       },
       "memory": {
         "name": "OnPolicyReplay"
@@ -118,7 +118,7 @@
         "val_loss_coef": 0.1,
         "training_frequency": 1,
         "training_epoch": 8,
-        "normalize_state": true
+        "normalize_state": false
       },
       "memory": {
         "name": "OnPolicyReplay"
@@ -210,10 +210,10 @@
         "val_loss_coef": 0.1,
         "training_frequency": 1,
         "training_epoch": 8,
-        "normalize_state": true
+        "normalize_state": false
       },
       "memory": {
-        "name": "OnPolicySeqReplay"
+        "name": "OnPolicyReplay"
       },
       "net": {
         "type": "RecurrentNet",
@@ -306,10 +306,10 @@
         "val_loss_coef": 0.1,
         "training_frequency": 1,
         "training_epoch": 8,
-        "normalize_state": true
+        "normalize_state": false
       },
       "memory": {
-        "name": "OnPolicySeqReplay"
+        "name": "OnPolicyReplay"
       },
       "net": {
         "type": "RecurrentNet",
@@ -402,7 +402,7 @@
         "val_loss_coef": 0.1,
         "training_frequency": 1,
         "training_epoch": 8,
-        "normalize_state": true
+        "normalize_state": false
       },
       "memory": {
         "name": "OnPolicyReplay"
@@ -494,7 +494,7 @@
         "val_loss_coef": 0.1,
         "training_frequency": 1,
         "training_epoch": 8,
-        "normalize_state": true
+        "normalize_state": false
       },
       "memory": {
         "name": "OnPolicyReplay"
@@ -586,10 +586,10 @@
         "val_loss_coef": 0.1,
         "training_frequency": 1,
         "training_epoch": 8,
-        "normalize_state": true
+        "normalize_state": false
       },
       "memory": {
-        "name": "OnPolicySeqReplay"
+        "name": "OnPolicyReplay"
       },
       "net": {
         "type": "RecurrentNet",
@@ -682,10 +682,10 @@
         "val_loss_coef": 0.1,
         "training_frequency": 1,
         "training_epoch": 8,
-        "normalize_state": true
+        "normalize_state": false
       },
       "memory": {
-        "name": "OnPolicySeqReplay"
+        "name": "OnPolicyReplay"
       },
       "net": {
         "type": "RecurrentNet",

--- a/slm_lab/spec/experimental/dqn.json
+++ b/slm_lab/spec/experimental/dqn.json
@@ -18,7 +18,7 @@
         "training_epoch": 4,
         "training_frequency": 8,
         "training_start_step": 32,
-        "normalize_state": true
+        "normalize_state": false
       },
       "memory": {
         "name": "Replay",
@@ -104,7 +104,7 @@
         "training_epoch": 4,
         "training_frequency": 8,
         "training_start_step": 32,
-        "normalize_state": true
+        "normalize_state": false
       },
       "memory": {
         "name": "Replay",
@@ -186,7 +186,7 @@
         "training_epoch": 4,
         "training_frequency": 8,
         "training_start_step": 32,
-        "normalize_state": true
+        "normalize_state": false
       },
       "memory": {
         "name": "Replay",
@@ -275,10 +275,10 @@
         "training_epoch": 4,
         "training_frequency": 8,
         "training_start_step": 32,
-        "normalize_state": true
+        "normalize_state": false
       },
       "memory": {
-        "name": "SeqReplay",
+        "name": "Replay",
         "batch_size": 32,
         "max_size": 10000,
         "use_cer": true
@@ -368,10 +368,10 @@
         "training_epoch": 4,
         "training_frequency": 8,
         "training_start_step": 32,
-        "normalize_state": true
+        "normalize_state": false
       },
       "memory": {
-        "name": "SeqReplay",
+        "name": "Replay",
         "batch_size": 32,
         "max_size": 10000,
         "use_cer": true
@@ -461,13 +461,12 @@
         "training_epoch": 5,
         "training_frequency": 50,
         "training_start_step": 100,
-        "normalize_state": true
+        "normalize_state": false
       },
       "memory": {
-        "name": "ConcatReplay",
+        "name": "Replay",
         "batch_size": 32,
         "max_size": 100000,
-        "concat_len": 4,
         "use_cer": true
       },
       "net": {
@@ -495,6 +494,8 @@
     }],
     "env": [{
       "name": "LunarLander-v2",
+      "frame_op": "concat",
+      "frame_op_len": 4,
       "max_t": null,
       "max_tick": 600,
     }],
@@ -536,7 +537,6 @@
         "name": "AtariReplay",
         "batch_size": 32,
         "max_size": 100000,
-        "stack_len": 4,
         "use_cer": false
       },
       "net": {
@@ -566,6 +566,8 @@
     }],
     "env": [{
       "name": "PongNoFrameskip-v4",
+      "frame_op": "concat",
+      "frame_op_len": 4,
       "max_t": null,
       "max_tick": 10000000,
     }],

--- a/slm_lab/spec/experimental/dqn_beamrider.json
+++ b/slm_lab/spec/experimental/dqn_beamrider.json
@@ -24,7 +24,6 @@
         "name": "AtariReplay",
         "batch_size": 32,
         "max_size": 200000,
-        "stack_len": 4,
         "use_cer": false
       },
       "net": {
@@ -54,6 +53,8 @@
     }],
     "env": [{
       "name": "BeamRiderNoFrameskip-v4",
+      "frame_op": "concat",
+      "frame_op_len": 4,
       "max_t": null,
       "max_tick": 10000000
     }],

--- a/slm_lab/spec/experimental/dqn_breakout.json
+++ b/slm_lab/spec/experimental/dqn_breakout.json
@@ -24,7 +24,6 @@
         "name": "AtariReplay",
         "batch_size": 32,
         "max_size": 200000,
-        "stack_len": 4,
         "use_cer": false
       },
       "net": {
@@ -54,6 +53,8 @@
     }],
     "env": [{
       "name": "BreakoutNoFrameskip-v4",
+      "frame_op": "concat",
+      "frame_op_len": 4,
       "max_t": null,
       "max_tick": 10000000
     }],

--- a/slm_lab/spec/experimental/dqn_enduro.json
+++ b/slm_lab/spec/experimental/dqn_enduro.json
@@ -24,7 +24,6 @@
         "name": "AtariReplay",
         "batch_size": 32,
         "max_size": 200000,
-        "stack_len": 4,
         "use_cer": false
       },
       "net": {
@@ -54,6 +53,8 @@
     }],
     "env": [{
       "name": "EnduroNoFrameskip-v4",
+      "frame_op": "concat",
+      "frame_op_len": 4,
       "max_t": null,
       "max_tick": 10000000
     }],

--- a/slm_lab/spec/experimental/dqn_mspacman.json
+++ b/slm_lab/spec/experimental/dqn_mspacman.json
@@ -24,7 +24,6 @@
         "name": "AtariReplay",
         "batch_size": 32,
         "max_size": 200000,
-        "stack_len": 4,
         "use_cer": false
       },
       "net": {
@@ -54,6 +53,8 @@
     }],
     "env": [{
       "name": "MsPacmanNoFrameskip-v4",
+      "frame_op": "concat",
+      "frame_op_len": 4,
       "max_t": null,
       "max_tick": 10000000
     }],

--- a/slm_lab/spec/experimental/dqn_per_beamrider.json
+++ b/slm_lab/spec/experimental/dqn_per_beamrider.json
@@ -26,7 +26,6 @@
         "epsilon": 0.0001,
         "batch_size": 32,
         "max_size": 200000,
-        "stack_len": 4,
         "use_cer": false
       },
       "net": {
@@ -56,6 +55,8 @@
     }],
     "env": [{
       "name": "BeamRiderNoFrameskip-v4",
+      "frame_op": "concat",
+      "frame_op_len": 4,
       "max_t": null,
       "max_tick": 10000000
     }],

--- a/slm_lab/spec/experimental/dqn_per_breakout.json
+++ b/slm_lab/spec/experimental/dqn_per_breakout.json
@@ -26,7 +26,6 @@
         "epsilon": 0.0001,
         "batch_size": 32,
         "max_size": 200000,
-        "stack_len": 4,
         "use_cer": false
       },
       "net": {
@@ -56,6 +55,8 @@
     }],
     "env": [{
       "name": "BreakoutNoFrameskip-v4",
+      "frame_op": "concat",
+      "frame_op_len": 4,
       "max_t": null,
       "max_tick": 10000000
     }],

--- a/slm_lab/spec/experimental/dqn_per_enduro.json
+++ b/slm_lab/spec/experimental/dqn_per_enduro.json
@@ -26,7 +26,6 @@
         "epsilon": 0.0001,
         "batch_size": 32,
         "max_size": 200000,
-        "stack_len": 4,
         "use_cer": false
       },
       "net": {
@@ -56,6 +55,8 @@
     }],
     "env": [{
       "name": "EnduroNoFrameskip-v4",
+      "frame_op": "concat",
+      "frame_op_len": 4,
       "max_t": null,
       "max_tick": 10000000
     }],

--- a/slm_lab/spec/experimental/dqn_per_mspacman.json
+++ b/slm_lab/spec/experimental/dqn_per_mspacman.json
@@ -26,7 +26,6 @@
         "epsilon": 0.0001,
         "batch_size": 32,
         "max_size": 200000,
-        "stack_len": 4,
         "use_cer": false
       },
       "net": {
@@ -56,6 +55,8 @@
     }],
     "env": [{
       "name": "MsPacmanNoFrameskip-v4",
+      "frame_op": "concat",
+      "frame_op_len": 4,
       "max_t": null,
       "max_tick": 10000000
     }],

--- a/slm_lab/spec/experimental/dqn_per_pong.json
+++ b/slm_lab/spec/experimental/dqn_per_pong.json
@@ -26,7 +26,6 @@
         "epsilon": 0.0001,
         "batch_size": 32,
         "max_size": 200000,
-        "stack_len": 4,
         "use_cer": false
       },
       "net": {
@@ -56,6 +55,8 @@
     }],
     "env": [{
       "name": "PongNoFrameskip-v4",
+      "frame_op": "concat",
+      "frame_op_len": 4,
       "num_envs": null,
       "max_t": null,
       "max_tick": 1e7

--- a/slm_lab/spec/experimental/dqn_per_qbert.json
+++ b/slm_lab/spec/experimental/dqn_per_qbert.json
@@ -26,7 +26,6 @@
         "epsilon": 0.0001,
         "batch_size": 32,
         "max_size": 200000,
-        "stack_len": 4,
         "use_cer": false
       },
       "net": {
@@ -56,6 +55,8 @@
     }],
     "env": [{
       "name": "QbertNoFrameskip-v4",
+      "frame_op": "concat",
+      "frame_op_len": 4,
       "max_t": null,
       "max_tick": 10000000
     }],

--- a/slm_lab/spec/experimental/dqn_per_seaquest.json
+++ b/slm_lab/spec/experimental/dqn_per_seaquest.json
@@ -26,7 +26,6 @@
         "epsilon": 0.0001,
         "batch_size": 32,
         "max_size": 200000,
-        "stack_len": 4,
         "use_cer": false
       },
       "net": {
@@ -56,6 +55,8 @@
     }],
     "env": [{
       "name": "SeaquestNoFrameskip-v4",
+      "frame_op": "concat",
+      "frame_op_len": 4,
       "max_t": null,
       "max_tick": 10000000
     }],

--- a/slm_lab/spec/experimental/dqn_per_spaceinvaders.json
+++ b/slm_lab/spec/experimental/dqn_per_spaceinvaders.json
@@ -26,7 +26,6 @@
         "epsilon": 0.0001,
         "batch_size": 32,
         "max_size": 200000,
-        "stack_len": 4,
         "use_cer": false
       },
       "net": {
@@ -56,6 +55,8 @@
     }],
     "env": [{
       "name": "SpaceInvadersNoFrameskip-v4",
+      "frame_op": "concat",
+      "frame_op_len": 4,
       "max_t": null,
       "max_tick": 10000000
     }],

--- a/slm_lab/spec/experimental/dqn_pong.json
+++ b/slm_lab/spec/experimental/dqn_pong.json
@@ -24,7 +24,6 @@
         "name": "AtariReplay",
         "batch_size": 32,
         "max_size": 200000,
-        "stack_len": 4,
         "use_cer": false
       },
       "net": {
@@ -54,6 +53,8 @@
     }],
     "env": [{
       "name": "PongNoFrameskip-v4",
+      "frame_op": "concat",
+      "frame_op_len": 4,
       "num_envs": null,
       "max_t": null,
       "max_tick": 1e7

--- a/slm_lab/spec/experimental/dqn_qbert.json
+++ b/slm_lab/spec/experimental/dqn_qbert.json
@@ -24,7 +24,6 @@
         "name": "AtariReplay",
         "batch_size": 32,
         "max_size": 200000,
-        "stack_len": 4,
         "use_cer": false
       },
       "net": {
@@ -54,6 +53,8 @@
     }],
     "env": [{
       "name": "QbertNoFrameskip-v4",
+      "frame_op": "concat",
+      "frame_op_len": 4,
       "max_t": null,
       "max_tick": 10000000
     }],

--- a/slm_lab/spec/experimental/dqn_seaquest.json
+++ b/slm_lab/spec/experimental/dqn_seaquest.json
@@ -24,7 +24,6 @@
         "name": "AtariReplay",
         "batch_size": 32,
         "max_size": 200000,
-        "stack_len": 4,
         "use_cer": false
       },
       "net": {
@@ -54,6 +53,8 @@
     }],
     "env": [{
       "name": "SeaquestNoFrameskip-v4",
+      "frame_op": "concat",
+      "frame_op_len": 4,
       "max_t": null,
       "max_tick": 10000000
     }],

--- a/slm_lab/spec/experimental/dqn_spaceinvaders.json
+++ b/slm_lab/spec/experimental/dqn_spaceinvaders.json
@@ -24,7 +24,6 @@
         "name": "AtariReplay",
         "batch_size": 32,
         "max_size": 200000,
-        "stack_len": 4,
         "use_cer": false
       },
       "net": {
@@ -54,6 +53,8 @@
     }],
     "env": [{
       "name": "SpaceInvadersNoFrameskip-v4",
+      "frame_op": "concat",
+      "frame_op_len": 4,
       "max_t": null,
       "max_tick": 10000000
     }],

--- a/slm_lab/spec/experimental/dueling_dqn.json
+++ b/slm_lab/spec/experimental/dueling_dqn.json
@@ -18,7 +18,7 @@
         "training_epoch": 4,
         "training_frequency": 8,
         "training_start_step": 32,
-        "normalize_state": true
+        "normalize_state": false
       },
       "memory": {
         "name": "Replay",
@@ -107,7 +107,7 @@
         "training_epoch": 4,
         "training_frequency": 8,
         "training_start_step": 32,
-        "normalize_state": true
+        "normalize_state": false
       },
       "memory": {
         "name": "Replay",
@@ -196,13 +196,12 @@
         "training_epoch": 5,
         "training_frequency": 50,
         "training_start_step": 100,
-        "normalize_state": true
+        "normalize_state": false
       },
       "memory": {
-        "name": "ConcatReplay",
+        "name": "Replay",
         "batch_size": 32,
         "max_size": 100000,
-        "concat_len": 4,
         "use_cer": true
       },
       "net": {
@@ -230,6 +229,8 @@
     }],
     "env": [{
       "name": "LunarLander-v2",
+      "frame_op": "concat",
+      "frame_op_len": 4,
       "max_t": null,
       "max_tick": 600,
     }],
@@ -271,7 +272,6 @@
         "name": "AtariReplay",
         "batch_size": 32,
         "max_size": 250000,
-        "stack_len": 4,
         "use_cer": true
       },
       "net": {
@@ -309,6 +309,8 @@
     }],
     "env": [{
       "name": "BreakoutDeterministic-v4",
+      "frame_op": "concat",
+      "frame_op_len": 4,
       "max_t": null,
       "max_tick": 50000,
     }],

--- a/slm_lab/spec/experimental/gridworld.json
+++ b/slm_lab/spec/experimental/gridworld.json
@@ -15,7 +15,7 @@
         "val_loss_coef": 1.0,
         "training_frequency": 1,
         "training_epoch": 4,
-        "normalize_state": true
+        "normalize_state": false
       },
       "memory": {
         "name": "OnPolicyReplay"
@@ -100,10 +100,10 @@
         "val_loss_coef": 1.0,
         "training_frequency": 1,
         "training_epoch": 4,
-        "normalize_state": true
+        "normalize_state": false
       },
       "memory": {
-        "name": "OnPolicySeqReplay"
+        "name": "OnPolicyReplay"
       },
       "net": {
         "type": "RecurrentNet",
@@ -189,7 +189,7 @@
         "val_loss_coef": 1.0,
         "training_frequency": 1,
         "training_epoch": 4,
-        "normalize_state": true
+        "normalize_state": false
       },
       "memory": {
         "name": "OnPolicyReplay"
@@ -274,10 +274,10 @@
         "val_loss_coef": 1.0,
         "training_frequency": 1,
         "training_epoch": 4,
-        "normalize_state": true
+        "normalize_state": false
       },
       "memory": {
-        "name": "OnPolicySeqReplay"
+        "name": "OnPolicyReplay"
       },
       "net": {
         "type": "RecurrentNet",
@@ -366,14 +366,13 @@
         "training_epoch": 4,
         "training_frequency": 4,
         "training_start_step": 32,
-        "normalize_state": true
+        "normalize_state": false
       },
       "memory": {
         "name": "Replay",
         "batch_size": 32,
         "max_size": 100000,
-        "use_cer": false,
-        "concat_len": 4,
+        "use_cer": false
       },
       "net": {
         "type": "MLPNet",
@@ -400,6 +399,8 @@
     }],
     "env": [{
       "name": "gridworld",
+      "frame_op": "concat",
+      "frame_op_len": 4,
       "max_t": null,
       "max_tick": 1000,
     }],
@@ -458,14 +459,13 @@
         "training_epoch": 4,
         "training_frequency": 4,
         "training_start_step": 32,
-        "normalize_state": true
+        "normalize_state": false
       },
       "memory": {
-        "name": "SeqReplay",
+        "name": "Replay",
         "batch_size": 32,
         "max_size": 100000,
-        "use_cer": false,
-        "concat_len": 4,
+        "use_cer": false
       },
       "net": {
         "type": "RecurrentNet",
@@ -496,6 +496,8 @@
     }],
     "env": [{
       "name": "gridworld",
+      "frame_op": "concat",
+      "frame_op_len": 4,
       "max_t": null,
       "max_tick": 1000,
     }],
@@ -556,14 +558,13 @@
         "training_epoch": 4,
         "training_frequency": 4,
         "training_start_step": 32,
-        "normalize_state": true
+        "normalize_state": false
       },
       "memory": {
         "name": "Replay",
         "batch_size": 32,
         "max_size": 100000,
-        "use_cer": false,
-        "concat_len": 4,
+        "use_cer": false
       },
       "net": {
         "type": "MLPNet",
@@ -590,6 +591,8 @@
     }],
     "env": [{
       "name": "gridworld",
+      "frame_op": "concat",
+      "frame_op_len": 4,
       "max_t": null,
       "max_tick": 1000,
     }],
@@ -648,14 +651,13 @@
         "training_epoch": 4,
         "training_frequency": 4,
         "training_start_step": 32,
-        "normalize_state": true
+        "normalize_state": false
       },
       "memory": {
-        "name": "SeqReplay",
+        "name": "Replay",
         "batch_size": 32,
         "max_size": 100000,
-        "use_cer": false,
-        "concat_len": 4,
+        "use_cer": false
       },
       "net": {
         "type": "RecurrentNet",
@@ -686,6 +688,8 @@
     }],
     "env": [{
       "name": "gridworld",
+      "frame_op": "concat",
+      "frame_op_len": 4,
       "max_t": null,
       "max_tick": 1000,
     }],

--- a/slm_lab/spec/experimental/hydra_dqn.json
+++ b/slm_lab/spec/experimental/hydra_dqn.json
@@ -18,7 +18,7 @@
         "training_epoch": 4,
         "training_frequency": 32,
         "training_start_step": 10,
-        "normalize_state": true
+        "normalize_state": false
       },
       "memory": {
         "name": "Replay",
@@ -115,7 +115,7 @@
         "training_epoch": 4,
         "training_frequency": 32,
         "training_start_step": 10,
-        "normalize_state": true
+        "normalize_state": false
       },
       "memory": {
         "name": "Replay",
@@ -215,7 +215,7 @@
         "training_epoch": 4,
         "training_frequency": 32,
         "training_start_step": 32,
-        "normalize_state": true
+        "normalize_state": false
       },
       "memory": {
         "name": "Replay",
@@ -311,7 +311,7 @@
         "training_epoch": 4,
         "training_frequency": 32,
         "training_start_step": 32,
-        "normalize_state": true
+        "normalize_state": false
       },
       "memory": {
         "name": "Replay",

--- a/slm_lab/spec/experimental/lunar_dqn.json
+++ b/slm_lab/spec/experimental/lunar_dqn.json
@@ -18,14 +18,13 @@
         "training_epoch": 4,
         "training_frequency": 4,
         "training_start_step": 32,
-        "normalize_state": true
+        "normalize_state": false
       },
       "memory": {
         "name": "Replay",
         "batch_size": 32,
         "max_size": 100000,
         "use_cer": false,
-        "concat_len": 4
       },
       "net": {
         "type": "MLPNet",
@@ -51,6 +50,8 @@
     }],
     "env": [{
       "name": "LunarLander-v2",
+      "frame_op": "concat",
+      "frame_op_len": 4,
       "max_t": null,
       "max_tick": 250000,
     }],
@@ -77,9 +78,6 @@
           "explore_var_spec": {
             "end_step__choice": [8000, 10000, 12000, 14000]
           },
-        },
-        "memory": {
-          "name__choice": ["Replay", "ConcatReplay"],
         },
         "net": {
           "polyak_coef__choice": [0, 0.9, 0.95, 0.99, 0.995, 0.999],
@@ -117,14 +115,13 @@
         "training_epoch": 4,
         "training_frequency": 4,
         "training_start_step": 32,
-        "normalize_state": true
+        "normalize_state": false
       },
       "memory": {
         "name": "Replay",
         "batch_size": 32,
         "max_size": 100000,
         "use_cer": false,
-        "concat_len": 4
       },
       "net": {
         "type": "MLPNet",
@@ -150,6 +147,8 @@
     }],
     "env": [{
       "name": "LunarLander-v2",
+      "frame_op": "concat",
+      "frame_op_len": 4,
       "max_t": null,
       "max_tick": 250000,
     }],
@@ -176,9 +175,6 @@
           "explore_var_spec": {
             "end_step__choice": [8000, 10000, 12000, 14000]
           },
-        },
-        "memory": {
-          "name__choice": ["Replay", "ConcatReplay"],
         },
         "net": {
           "polyak_coef__choice": [0, 0.9, 0.95, 0.99, 0.995, 0.999],
@@ -216,14 +212,13 @@
         "training_epoch": 4,
         "training_frequency": 4,
         "training_start_step": 32,
-        "normalize_state": true
+        "normalize_state": false
       },
       "memory": {
         "name": "Replay",
         "batch_size": 32,
         "max_size": 100000,
         "use_cer": false,
-        "concat_len": 4
       },
       "net": {
         "type": "MLPNet",
@@ -249,6 +244,8 @@
     }],
     "env": [{
       "name": "LunarLander-v2",
+      "frame_op": "concat",
+      "frame_op_len": 4,
       "max_t": null,
       "max_tick": 250000,
     }],
@@ -275,9 +272,6 @@
           "explore_var_spec": {
             "end_step__choice": [8000, 10000, 12000, 14000]
           },
-        },
-        "memory": {
-          "name__choice": ["Replay", "ConcatReplay"],
         },
         "net": {
           "update_frequency__choice": [0, 200, 500, 800, 1000, 1500],
@@ -315,14 +309,13 @@
         "training_epoch": 4,
         "training_frequency": 4,
         "training_start_step": 32,
-        "normalize_state": true
+        "normalize_state": false
       },
       "memory": {
         "name": "Replay",
         "batch_size": 32,
         "max_size": 100000,
         "use_cer": false,
-        "concat_len": 4
       },
       "net": {
         "type": "MLPNet",
@@ -348,6 +341,8 @@
     }],
     "env": [{
       "name": "LunarLander-v2",
+      "frame_op": "concat",
+      "frame_op_len": 4,
       "max_t": null,
       "max_tick": 250000,
     }],
@@ -374,9 +369,6 @@
           "explore_var_spec": {
             "end_step__choice": [8000, 10000, 12000, 14000]
           },
-        },
-        "memory": {
-          "name__choice": ["Replay", "ConcatReplay"],
         },
         "net": {
           "update_frequency__choice": [0, 200, 500, 800, 1000, 1500],
@@ -414,14 +406,13 @@
         "training_epoch": 4,
         "training_frequency": 4,
         "training_start_step": 32,
-        "normalize_state": true
+        "normalize_state": false
       },
       "memory": {
         "name": "Replay",
         "batch_size": 32,
         "max_size": 100000,
         "use_cer": false,
-        "concat_len": 4
       },
       "net": {
         "type": "MLPNet",
@@ -447,6 +438,8 @@
     }],
     "env": [{
       "name": "LunarLander-v2",
+      "frame_op": "concat",
+      "frame_op_len": 4,
       "max_t": null,
       "max_tick": 250000,
     }],
@@ -473,9 +466,6 @@
           "explore_var_spec": {
             "end_step__choice": [8000, 10000, 12000, 14000]
           },
-        },
-        "memory": {
-          "name__choice": ["Replay", "ConcatReplay"],
         },
         "net": {
           "polyak_coef__choice": [0, 0.9, 0.95, 0.99, 0.995, 0.999],
@@ -513,14 +503,13 @@
         "training_epoch": 4,
         "training_frequency": 4,
         "training_start_step": 32,
-        "normalize_state": true
+        "normalize_state": false
       },
       "memory": {
         "name": "Replay",
         "batch_size": 32,
         "max_size": 100000,
         "use_cer": false,
-        "concat_len": 4
       },
       "net": {
         "type": "MLPNet",
@@ -546,6 +535,8 @@
     }],
     "env": [{
       "name": "LunarLander-v2",
+      "frame_op": "concat",
+      "frame_op_len": 4,
       "max_t": null,
       "max_tick": 250000,
     }],
@@ -572,9 +563,6 @@
           "explore_var_spec": {
             "end_step__choice": [8000, 10000, 12000, 14000]
           },
-        },
-        "memory": {
-          "name__choice": ["Replay", "ConcatReplay"],
         },
         "net": {
           "polyak_coef__choice": [0, 0.9, 0.95, 0.99, 0.995, 0.999],
@@ -612,14 +600,13 @@
         "training_epoch": 4,
         "training_frequency": 4,
         "training_start_step": 32,
-        "normalize_state": true
+        "normalize_state": false
       },
       "memory": {
         "name": "Replay",
         "batch_size": 32,
         "max_size": 100000,
         "use_cer": false,
-        "concat_len": 4
       },
       "net": {
         "type": "MLPNet",
@@ -645,6 +632,8 @@
     }],
     "env": [{
       "name": "LunarLander-v2",
+      "frame_op": "concat",
+      "frame_op_len": 4,
       "max_t": null,
       "max_tick": 250000,
     }],
@@ -671,9 +660,6 @@
           "explore_var_spec": {
             "end_step__choice": [8000, 10000, 12000, 14000]
           },
-        },
-        "memory": {
-          "name__choice": ["Replay", "ConcatReplay"],
         },
         "net": {
           "update_frequency__choice": [0, 200, 500, 800, 1000, 1500],
@@ -711,14 +697,13 @@
         "training_epoch": 4,
         "training_frequency": 4,
         "training_start_step": 32,
-        "normalize_state": true
+        "normalize_state": false
       },
       "memory": {
         "name": "Replay",
         "batch_size": 32,
         "max_size": 100000,
         "use_cer": false,
-        "concat_len": 4
       },
       "net": {
         "type": "MLPNet",
@@ -744,6 +729,8 @@
     }],
     "env": [{
       "name": "LunarLander-v2",
+      "frame_op": "concat",
+      "frame_op_len": 4,
       "max_t": null,
       "max_tick": 250000,
     }],
@@ -770,9 +757,6 @@
           "explore_var_spec": {
             "end_step__choice": [8000, 10000, 12000, 14000]
           },
-        },
-        "memory": {
-          "name__choice": ["Replay", "ConcatReplay"],
         },
         "net": {
           "update_frequency__choice": [0, 200, 500, 800, 1000, 1500],
@@ -810,10 +794,10 @@
         "training_epoch": 4,
         "training_frequency": 4,
         "training_start_step": 32,
-        "normalize_state": true
+        "normalize_state": false
       },
       "memory": {
-        "name": "SeqReplay",
+        "name": "Replay",
         "batch_size": 32,
         "max_size": 100000,
         "use_cer": false,
@@ -846,6 +830,8 @@
     }],
     "env": [{
       "name": "LunarLander-v2",
+      "frame_op": "concat",
+      "frame_op_len": 4,
       "max_t": null,
       "max_tick": 250000,
     }],
@@ -909,14 +895,13 @@
         "training_epoch": 4,
         "training_frequency": 4,
         "training_start_step": 32,
-        "normalize_state": true
+        "normalize_state": false
       },
       "memory": {
         "name": "Replay",
         "batch_size": 32,
         "max_size": 100000,
         "use_cer": false,
-        "concat_len": 4
       },
       "net": {
         "type": "DuelingMLPNet",
@@ -942,6 +927,8 @@
     }],
     "env": [{
       "name": "LunarLander-v2",
+      "frame_op": "concat",
+      "frame_op_len": 4,
       "max_t": null,
       "max_tick": 250000,
     }],
@@ -968,9 +955,6 @@
           "explore_var_spec": {
             "end_step__choice": [8000, 10000, 12000, 14000]
           },
-        },
-        "memory": {
-          "name__choice": ["Replay", "ConcatReplay"],
         },
         "net": {
           "polyak_coef__choice": [0, 0.9, 0.95, 0.99, 0.995, 0.999],

--- a/slm_lab/spec/experimental/lunar_pg.json
+++ b/slm_lab/spec/experimental/lunar_pg.json
@@ -16,7 +16,7 @@
           "end_step": 40000,
         },
         "training_frequency": 1,
-        "normalize_state": true
+        "normalize_state": false
       },
       "memory": {
         "name": "OnPolicyReplay"
@@ -105,10 +105,10 @@
           "end_step": 40000,
         },
         "training_frequency": 1,
-        "normalize_state": true
+        "normalize_state": false
       },
       "memory": {
-        "name": "OnPolicySeqReplay"
+        "name": "OnPolicyReplay"
       },
       "net": {
         "type": "RecurrentNet",
@@ -205,7 +205,7 @@
         "val_loss_coef": 1.0,
         "training_frequency": 3,
         "training_epoch": 8,
-        "normalize_state": true
+        "normalize_state": false
       },
       "memory": {
         "name": "OnPolicyReplay"
@@ -302,10 +302,10 @@
         "val_loss_coef": 1.0,
         "training_frequency": 3,
         "training_epoch": 8,
-        "normalize_state": true
+        "normalize_state": false
       },
       "memory": {
-        "name": "OnPolicySeqReplay"
+        "name": "OnPolicyReplay"
       },
       "net": {
         "type": "RecurrentNet",
@@ -405,7 +405,7 @@
         "val_loss_coef": 1.0,
         "training_frequency": 1,
         "training_epoch": 4,
-        "normalize_state": true
+        "normalize_state": false
       },
       "memory": {
         "name": "OnPolicyReplay"
@@ -503,10 +503,10 @@
         "val_loss_coef": 0.01,
         "training_frequency": 1,
         "training_epoch": 8,
-        "normalize_state": true
+        "normalize_state": false
       },
       "memory": {
-        "name": "OnPolicySeqReplay"
+        "name": "OnPolicyReplay"
       },
       "net": {
         "type": "RecurrentNet",
@@ -612,7 +612,7 @@
         "val_loss_coef": 0.1,
         "training_frequency": 1,
         "training_epoch": 8,
-        "normalize_state": true
+        "normalize_state": false
       },
       "memory": {
         "name": "OnPolicyReplay"
@@ -708,10 +708,10 @@
         "val_loss_coef": 0.1,
         "training_frequency": 1,
         "training_epoch": 8,
-        "normalize_state": true
+        "normalize_state": false
       },
       "memory": {
-        "name": "OnPolicySeqReplay"
+        "name": "OnPolicyReplay"
       },
       "net": {
         "type": "RecurrentNet",
@@ -894,7 +894,7 @@
         "val_loss_coef": 1.0,
         "training_frequency": 1,
         "training_epoch": 4,
-        "normalize_state": true
+        "normalize_state": false
       },
       "memory": {
         "name": "OnPolicyReplay",
@@ -992,10 +992,10 @@
         "val_loss_coef": 0.01,
         "training_frequency": 1,
         "training_epoch": 8,
-        "normalize_state": true
+        "normalize_state": false
       },
       "memory": {
-        "name": "OnPolicySeqReplay"
+        "name": "OnPolicyReplay"
       },
       "net": {
         "type": "RecurrentNet",
@@ -1175,7 +1175,7 @@
         "val_loss_coef": 1.0,
         "training_frequency": 1,
         "training_epoch": 4,
-        "normalize_state": true
+        "normalize_state": false
       },
       "memory": {
         "name": "OnPolicyReplay",
@@ -1273,10 +1273,10 @@
         "val_loss_coef": 0.01,
         "training_frequency": 1,
         "training_epoch": 8,
-        "normalize_state": true
+        "normalize_state": false
       },
       "memory": {
-        "name": "OnPolicySeqReplay"
+        "name": "OnPolicyReplay"
       },
       "net": {
         "type": "RecurrentNet",
@@ -1371,7 +1371,7 @@
         "val_loss_coef": 0.1,
         "training_frequency": 1,
         "training_epoch": 8,
-        "normalize_state": true
+        "normalize_state": false
       },
       "memory": {
         "name": "OnPolicyReplay"
@@ -1464,10 +1464,10 @@
         "val_loss_coef": 0.1,
         "training_frequency": 1,
         "training_epoch": 8,
-        "normalize_state": true
+        "normalize_state": false
       },
       "memory": {
-        "name": "OnPolicySeqReplay"
+        "name": "OnPolicyReplay"
       },
       "net": {
         "type": "RecurrentNet",
@@ -1560,7 +1560,7 @@
         "training_frequency": 1,
         "training_batch_epoch": 10,
         "training_epoch": 8,
-        "normalize_state": true
+        "normalize_state": false
       },
       "memory": {
         "name": "OnPolicyReplay",
@@ -1656,7 +1656,7 @@
         "training_frequency": 1,
         "training_batch_epoch": 10,
         "training_epoch": 8,
-        "normalize_state": true
+        "normalize_state": false
       },
       "memory": {
         "name": "OnPolicyReplay",
@@ -1755,11 +1755,11 @@
         "training_frequency": 1,
         "training_batch_epoch": 10,
         "training_epoch": 8,
-        "normalize_state": true
+        "normalize_state": false
       },
       "memory": {
-        "name": "OnPolicySeqReplay",
-        "sil_replay_name": "SeqReplay",
+        "name": "OnPolicyReplay",
+        "sil_replay_name": "Replay",
         "batch_size": 64,
         "max_size": 10000,
         "use_cer": true
@@ -1856,11 +1856,11 @@
         "training_frequency": 1,
         "training_batch_epoch": 10,
         "training_epoch": 8,
-        "normalize_state": true
+        "normalize_state": false
       },
       "memory": {
-        "name": "OnPolicySeqReplay",
-        "sil_replay_name": "SeqReplay",
+        "name": "OnPolicyReplay",
+        "sil_replay_name": "Replay",
         "batch_size": 64,
         "max_size": 10000,
         "use_cer": true
@@ -1965,7 +1965,7 @@
         "training_frequency": 1,
         "training_batch_epoch": 10,
         "training_epoch": 8,
-        "normalize_state": true
+        "normalize_state": false
       },
       "memory": {
         "name": "OnPolicyReplay"
@@ -2063,7 +2063,7 @@
         "training_frequency": 1,
         "training_batch_epoch": 10,
         "training_epoch": 8,
-        "normalize_state": true
+        "normalize_state": false
       },
       "memory": {
         "name": "OnPolicyReplay"
@@ -2164,11 +2164,11 @@
         "training_frequency": 1,
         "training_batch_epoch": 10,
         "training_epoch": 8,
-        "normalize_state": true
+        "normalize_state": false
       },
       "memory": {
-        "name": "OnPolicySeqReplay",
-        "sil_replay_name": "SeqReplay",
+        "name": "OnPolicyReplay",
+        "sil_replay_name": "Replay",
         "batch_size": 64,
         "max_size": 10000,
         "use_cer": true
@@ -2271,11 +2271,11 @@
         "training_frequency": 1,
         "training_batch_epoch": 10,
         "training_epoch": 8,
-        "normalize_state": true
+        "normalize_state": false
       },
       "memory": {
-        "name": "OnPolicySeqReplay",
-        "sil_replay_name": "SeqReplay",
+        "name": "OnPolicyReplay",
+        "sil_replay_name": "Replay",
         "batch_size": 64,
         "max_size": 10000,
         "use_cer": true

--- a/slm_lab/spec/experimental/mountain_car.json
+++ b/slm_lab/spec/experimental/mountain_car.json
@@ -21,7 +21,7 @@
         "val_loss_coef": 1.0,
         "training_frequency": 1,
         "training_epoch": 4,
-        "normalize_state": true
+        "normalize_state": false
       },
       "memory": {
         "name": "OnPolicyReplay"
@@ -113,10 +113,10 @@
         "val_loss_coef": 1.0,
         "training_frequency": 1,
         "training_epoch": 4,
-        "normalize_state": true
+        "normalize_state": false
       },
       "memory": {
-        "name": "OnPolicySeqReplay"
+        "name": "OnPolicyReplay"
       },
       "net": {
         "type": "RecurrentNet",
@@ -217,7 +217,7 @@
         "val_loss_coef": 1.0,
         "training_frequency": 1,
         "training_epoch": 4,
-        "normalize_state": true
+        "normalize_state": false
       },
       "memory": {
         "name": "OnPolicyReplay"
@@ -310,10 +310,10 @@
         "val_loss_coef": 1.0,
         "training_frequency": 1,
         "training_epoch": 4,
-        "normalize_state": true
+        "normalize_state": false
       },
       "memory": {
-        "name": "OnPolicySeqReplay"
+        "name": "OnPolicyReplay"
       },
       "net": {
         "type": "RecurrentNet",
@@ -412,8 +412,7 @@
         "name": "Replay",
         "batch_size": 32,
         "max_size": 100000,
-        "use_cer": false,
-        "concat_len": 4,
+        "use_cer": false
       },
       "net": {
         "type": "MLPNet",
@@ -499,14 +498,13 @@
         "training_epoch": 4,
         "training_frequency": 4,
         "training_start_step": 32,
-        "normalize_state": true
+        "normalize_state": false
       },
       "memory": {
-        "name": "SeqReplay",
+        "name": "Replay",
         "batch_size": 32,
         "max_size": 100000,
-        "use_cer": false,
-        "concat_len": 4,
+        "use_cer": false
       },
       "net": {
         "type": "RecurrentNet",
@@ -603,8 +601,7 @@
         "name": "Replay",
         "batch_size": 32,
         "max_size": 100000,
-        "use_cer": false,
-        "concat_len": 4,
+        "use_cer": false
       },
       "net": {
         "type": "MLPNet",
@@ -690,14 +687,13 @@
         "training_epoch": 4,
         "training_frequency": 4,
         "training_start_step": 32,
-        "normalize_state": true
+        "normalize_state": false
       },
       "memory": {
-        "name": "SeqReplay",
+        "name": "Replay",
         "batch_size": 32,
         "max_size": 100000,
-        "use_cer": false,
-        "concat_len": 4,
+        "use_cer": false
       },
       "net": {
         "type": "RecurrentNet",

--- a/slm_lab/spec/experimental/pendulum.json
+++ b/slm_lab/spec/experimental/pendulum.json
@@ -21,7 +21,7 @@
         "val_loss_coef": 0.01,
         "training_frequency": 1,
         "training_epoch": 4,
-        "normalize_state": true
+        "normalize_state": false
       },
       "memory": {
         "name": "OnPolicyReplay"
@@ -114,10 +114,10 @@
         "val_loss_coef": 0.01,
         "training_frequency": 1,
         "training_epoch": 4,
-        "normalize_state": true
+        "normalize_state": false
       },
       "memory": {
-        "name": "OnPolicySeqReplay"
+        "name": "OnPolicyReplay"
       },
       "net": {
         "type": "RecurrentNet",
@@ -212,7 +212,7 @@
         "val_loss_coef": 0.01,
         "training_frequency": 1,
         "training_epoch": 4,
-        "normalize_state": true
+        "normalize_state": false
       },
       "memory": {
         "name": "OnPolicyReplay"
@@ -305,10 +305,10 @@
         "val_loss_coef": 0.01,
         "training_frequency": 1,
         "training_epoch": 4,
-        "normalize_state": true
+        "normalize_state": false
       },
       "memory": {
-        "name": "OnPolicySeqReplay"
+        "name": "OnPolicyReplay"
       },
       "net": {
         "type": "RecurrentNet",
@@ -406,7 +406,7 @@
         "training_frequency": 1,
         "training_batch_epoch": 10,
         "training_epoch": 8,
-        "normalize_state": true
+        "normalize_state": false
       },
       "memory": {
         "name": "OnPolicyReplay",

--- a/slm_lab/spec/experimental/ppo.json
+++ b/slm_lab/spec/experimental/ppo.json
@@ -26,7 +26,7 @@
         "val_loss_coef": 0.1,
         "training_frequency": 1,
         "training_epoch": 8,
-        "normalize_state": true
+        "normalize_state": false
       },
       "memory": {
         "name": "OnPolicyReplay"
@@ -118,7 +118,7 @@
         "val_loss_coef": 0.85,
         "training_frequency": 4,
         "training_epoch": 8,
-        "normalize_state": true
+        "normalize_state": false
       },
       "memory": {
         "name": "OnPolicyReplay"
@@ -210,10 +210,10 @@
         "val_loss_coef": 0.1,
         "training_frequency": 1,
         "training_epoch": 8,
-        "normalize_state": true
+        "normalize_state": false
       },
       "memory": {
-        "name": "OnPolicySeqReplay"
+        "name": "OnPolicyReplay"
       },
       "net": {
         "type": "RecurrentNet",
@@ -306,10 +306,10 @@
         "val_loss_coef": 0.1,
         "training_frequency": 1,
         "training_epoch": 8,
-        "normalize_state": true
+        "normalize_state": false
       },
       "memory": {
-        "name": "OnPolicySeqReplay"
+        "name": "OnPolicyReplay"
       },
       "net": {
         "type": "RecurrentNet",
@@ -402,7 +402,7 @@
         "val_loss_coef": 0.1,
         "training_frequency": 1,
         "training_epoch": 8,
-        "normalize_state": true
+        "normalize_state": false
       },
       "memory": {
         "name": "OnPolicyReplay"
@@ -494,7 +494,7 @@
         "val_loss_coef": 0.1,
         "training_frequency": 1,
         "training_epoch": 8,
-        "normalize_state": true
+        "normalize_state": false
       },
       "memory": {
         "name": "OnPolicyReplay"
@@ -586,10 +586,10 @@
         "val_loss_coef": 0.1,
         "training_frequency": 1,
         "training_epoch": 8,
-        "normalize_state": true
+        "normalize_state": false
       },
       "memory": {
-        "name": "OnPolicySeqReplay"
+        "name": "OnPolicyReplay"
       },
       "net": {
         "type": "RecurrentNet",
@@ -682,10 +682,10 @@
         "val_loss_coef": 0.1,
         "training_frequency": 1,
         "training_epoch": 8,
-        "normalize_state": true
+        "normalize_state": false
       },
       "memory": {
-        "name": "OnPolicySeqReplay"
+        "name": "OnPolicyReplay"
       },
       "net": {
         "type": "RecurrentNet",

--- a/slm_lab/spec/experimental/ppo_beamrider.json
+++ b/slm_lab/spec/experimental/ppo_beamrider.json
@@ -58,6 +58,8 @@
     }],
     "env": [{
       "name": "BeamRiderNoFrameskip-v4",
+      "frame_op": "concat",
+      "frame_op_len": 4,
       "max_t": null,
       "max_tick": 10000000
     }],

--- a/slm_lab/spec/experimental/ppo_breakout.json
+++ b/slm_lab/spec/experimental/ppo_breakout.json
@@ -58,6 +58,8 @@
     }],
     "env": [{
       "name": "BreakoutNoFrameskip-v4",
+      "frame_op": "concat",
+      "frame_op_len": 4,
       "max_t": null,
       "max_tick": 10000000
     }],

--- a/slm_lab/spec/experimental/ppo_enduro.json
+++ b/slm_lab/spec/experimental/ppo_enduro.json
@@ -58,6 +58,8 @@
     }],
     "env": [{
       "name": "EnduroNoFrameskip-v4",
+      "frame_op": "concat",
+      "frame_op_len": 4,
       "max_t": null,
       "max_tick": 10000000
     }],

--- a/slm_lab/spec/experimental/ppo_mspacman.json
+++ b/slm_lab/spec/experimental/ppo_mspacman.json
@@ -58,6 +58,8 @@
     }],
     "env": [{
       "name": "MsPacmanNoFrameskip-v4",
+      "frame_op": "concat",
+      "frame_op_len": 4,
       "max_t": null,
       "max_tick": 10000000
     }],

--- a/slm_lab/spec/experimental/ppo_pong.json
+++ b/slm_lab/spec/experimental/ppo_pong.json
@@ -31,7 +31,6 @@
       },
       "memory": {
         "name": "OnPolicyAtariBatchReplay",
-        "stack_len": 4
       },
       "net": {
         "type": "ConvNet",
@@ -69,6 +68,8 @@
     }],
     "env": [{
       "name": "PongNoFrameskip-v4",
+      "frame_op": "concat",
+      "frame_op_len": 4,
       "num_envs": 8,
       "max_t": null,
       "max_tick": 1e7

--- a/slm_lab/spec/experimental/ppo_qbert.json
+++ b/slm_lab/spec/experimental/ppo_qbert.json
@@ -58,6 +58,8 @@
     }],
     "env": [{
       "name": "QbertNoFrameskip-v4",
+      "frame_op": "concat",
+      "frame_op_len": 4,
       "max_t": null,
       "max_tick": 10000000
     }],

--- a/slm_lab/spec/experimental/ppo_seaquest.json
+++ b/slm_lab/spec/experimental/ppo_seaquest.json
@@ -58,6 +58,8 @@
     }],
     "env": [{
       "name": "SeaquestNoFrameskip-v4",
+      "frame_op": "concat",
+      "frame_op_len": 4,
       "max_t": null,
       "max_tick": 10000000
     }],

--- a/slm_lab/spec/experimental/ppo_sil.json
+++ b/slm_lab/spec/experimental/ppo_sil.json
@@ -29,7 +29,7 @@
         "training_frequency": 1,
         "training_batch_epoch": 4,
         "training_epoch": 8,
-        "normalize_state": true
+        "normalize_state": false
       },
       "memory": {
         "name": "OnPolicyReplay",
@@ -130,7 +130,7 @@
         "training_frequency": 1,
         "training_batch_epoch": 8,
         "training_epoch": 4,
-        "normalize_state": true
+        "normalize_state": false
       },
       "memory": {
         "name": "OnPolicyReplay",
@@ -231,11 +231,11 @@
         "training_frequency": 1,
         "training_batch_epoch": 8,
         "training_epoch": 8,
-        "normalize_state": true
+        "normalize_state": false
       },
       "memory": {
-        "name": "OnPolicySeqReplay",
-        "sil_replay_name": "SeqReplay",
+        "name": "OnPolicyReplay",
+        "sil_replay_name": "Replay",
         "batch_size": 32,
         "max_size": 10000,
         "use_cer": true
@@ -336,11 +336,11 @@
         "training_frequency": 1,
         "training_batch_epoch": 8,
         "training_epoch": 8,
-        "normalize_state": true
+        "normalize_state": false
       },
       "memory": {
-        "name": "OnPolicySeqReplay",
-        "sil_replay_name": "SeqReplay",
+        "name": "OnPolicyReplay",
+        "sil_replay_name": "Replay",
         "batch_size": 32,
         "max_size": 10000,
         "use_cer": true
@@ -441,7 +441,7 @@
         "training_frequency": 1,
         "training_batch_epoch": 4,
         "training_epoch": 8,
-        "normalize_state": true
+        "normalize_state": false
       },
       "memory": {
         "name": "OnPolicyReplay",
@@ -542,7 +542,7 @@
         "training_frequency": 1,
         "training_batch_epoch": 8,
         "training_epoch": 8,
-        "normalize_state": true
+        "normalize_state": false
       },
       "memory": {
         "name": "OnPolicyReplay",
@@ -643,11 +643,11 @@
         "training_frequency": 1,
         "training_batch_epoch": 8,
         "training_epoch": 8,
-        "normalize_state": true
+        "normalize_state": false
       },
       "memory": {
-        "name": "OnPolicySeqReplay",
-        "sil_replay_name": "SeqReplay",
+        "name": "OnPolicyReplay",
+        "sil_replay_name": "Replay",
         "batch_size": 32,
         "max_size": 10000,
         "use_cer": true
@@ -748,11 +748,11 @@
         "training_frequency": 1,
         "training_batch_epoch": 8,
         "training_epoch": 8,
-        "normalize_state": true
+        "normalize_state": false
       },
       "memory": {
-        "name": "OnPolicySeqReplay",
-        "sil_replay_name": "SeqReplay",
+        "name": "OnPolicyReplay",
+        "sil_replay_name": "Replay",
         "batch_size": 32,
         "max_size": 10000,
         "use_cer": true

--- a/slm_lab/spec/experimental/ppo_spaceinvaders.json
+++ b/slm_lab/spec/experimental/ppo_spaceinvaders.json
@@ -58,6 +58,8 @@
     }],
     "env": [{
       "name": "SpaceInvadersNoFrameskip-v4",
+      "frame_op": "concat",
+      "frame_op_len": 4,
       "max_t": null,
       "max_tick": 10000000
     }],

--- a/slm_lab/spec/experimental/reinforce.json
+++ b/slm_lab/spec/experimental/reinforce.json
@@ -16,7 +16,7 @@
           "end_step": 5000,
         },
         "training_frequency": 1,
-        "normalize_state": true
+        "normalize_state": false
       },
       "memory": {
         "name": "OnPolicyReplay"
@@ -89,10 +89,10 @@
           "end_step": 5000,
         },
         "training_frequency": 1,
-        "normalize_state": true
+        "normalize_state": false
       },
       "memory": {
-        "name": "OnPolicySeqReplay"
+        "name": "OnPolicyReplay"
       },
       "net": {
         "type": "RecurrentNet",
@@ -166,7 +166,7 @@
           "end_step": 5000,
         },
         "training_frequency": 1,
-        "normalize_state": true
+        "normalize_state": false
       },
       "memory": {
         "name": "OnPolicyReplay"
@@ -239,10 +239,10 @@
           "end_step": 5000,
         },
         "training_frequency": 1,
-        "normalize_state": true
+        "normalize_state": false
       },
       "memory": {
-        "name": "OnPolicySeqReplay"
+        "name": "OnPolicyReplay"
       },
       "net": {
         "type": "RecurrentNet",
@@ -386,7 +386,6 @@
       },
       "memory": {
         "name": "OnPolicyAtariReplay",
-        "stack_len": 4
       },
       "net": {
         "type": "ConvNet",
@@ -417,6 +416,8 @@
     }],
     "env": [{
       "name": "vizdoom-v0",
+      "frame_op": "concat",
+      "frame_op_len": 4,
       "cfg_name": "basic",
       "max_t": 400000,
       "max_tick": 100

--- a/slm_lab/spec/experimental/sarsa.json
+++ b/slm_lab/spec/experimental/sarsa.json
@@ -15,7 +15,7 @@
         },
         "gamma": 0.99,
         "training_frequency": 20,
-        "normalize_state": true
+        "normalize_state": false
       },
       "memory": {
         "name": "OnPolicyBatchReplay"
@@ -95,7 +95,7 @@
         },
         "gamma": 0.99,
         "training_frequency": 20,
-        "normalize_state": true
+        "normalize_state": false
       },
       "memory": {
         "name": "OnPolicyBatchReplay"
@@ -175,10 +175,10 @@
         },
         "gamma": 0.99,
         "training_frequency": 20,
-        "normalize_state": true
+        "normalize_state": false
       },
       "memory": {
-        "name": "OnPolicySeqBatchReplay"
+        "name": "OnPolicyBatchReplay"
       },
       "net": {
         "type": "RecurrentNet",
@@ -259,10 +259,10 @@
         },
         "gamma": 0.99,
         "training_frequency": 20,
-        "normalize_state": true
+        "normalize_state": false
       },
       "memory": {
-        "name": "OnPolicySeqBatchReplay"
+        "name": "OnPolicyBatchReplay"
       },
       "net": {
         "type": "RecurrentNet",

--- a/slm_lab/spec/experimental/sil.json
+++ b/slm_lab/spec/experimental/sil.json
@@ -120,7 +120,7 @@
         "training_frequency": 1,
         "training_batch_epoch": 8,
         "training_epoch": 4,
-        "normalize_state": true
+        "normalize_state": false
       },
       "memory": {
         "name": "OnPolicyReplay",
@@ -216,11 +216,11 @@
         "training_frequency": 1,
         "training_batch_epoch": 8,
         "training_epoch": 4,
-        "normalize_state": true
+        "normalize_state": false
       },
       "memory": {
-        "name": "OnPolicySeqReplay",
-        "sil_replay_name": "SeqReplay",
+        "name": "OnPolicyReplay",
+        "sil_replay_name": "Replay",
         "batch_size": 32,
         "max_size": 10000,
         "use_cer": true
@@ -316,11 +316,11 @@
         "training_frequency": 1,
         "training_batch_epoch": 8,
         "training_epoch": 4,
-        "normalize_state": true
+        "normalize_state": false
       },
       "memory": {
-        "name": "OnPolicySeqReplay",
-        "sil_replay_name": "SeqReplay",
+        "name": "OnPolicyReplay",
+        "sil_replay_name": "Replay",
         "batch_size": 32,
         "max_size": 10000,
         "use_cer": true
@@ -416,7 +416,7 @@
         "training_frequency": 1,
         "training_batch_epoch": 4,
         "training_epoch": 4,
-        "normalize_state": true
+        "normalize_state": false
       },
       "memory": {
         "name": "OnPolicyReplay",
@@ -512,7 +512,7 @@
         "training_frequency": 1,
         "training_batch_epoch": 8,
         "training_epoch": 4,
-        "normalize_state": true
+        "normalize_state": false
       },
       "memory": {
         "name": "OnPolicyReplay",
@@ -608,11 +608,11 @@
         "training_frequency": 1,
         "training_batch_epoch": 8,
         "training_epoch": 4,
-        "normalize_state": true
+        "normalize_state": false
       },
       "memory": {
-        "name": "OnPolicySeqReplay",
-        "sil_replay_name": "SeqReplay",
+        "name": "OnPolicyReplay",
+        "sil_replay_name": "Replay",
         "batch_size": 32,
         "max_size": 10000,
         "use_cer": true
@@ -708,11 +708,11 @@
         "training_frequency": 1,
         "training_batch_epoch": 8,
         "training_epoch": 4,
-        "normalize_state": true
+        "normalize_state": false
       },
       "memory": {
-        "name": "OnPolicySeqReplay",
-        "sil_replay_name": "SeqReplay",
+        "name": "OnPolicyReplay",
+        "sil_replay_name": "Replay",
         "batch_size": 32,
         "max_size": 10000,
         "use_cer": true

--- a/test/agent/net/test_recurrent.py
+++ b/test/agent/net/test_recurrent.py
@@ -32,12 +32,13 @@ net_spec = {
     },
     "gpu": True
 }
-in_dim = 10
+state_dim = 10
 out_dim = 3
 batch_size = 16
 seq_len = net_spec['seq_len']
+in_dim = (seq_len, state_dim)
 net = RecurrentNet(net_spec, in_dim, out_dim)
-x = torch.rand((batch_size, seq_len, in_dim))
+x = torch.rand((batch_size, seq_len, state_dim))
 
 
 def test_init():

--- a/test/env/test_vec_env.py
+++ b/test/env/test_vec_env.py
@@ -9,20 +9,17 @@ import pytest
     ('CartPole-v0', (4,)),
 ])
 @pytest.mark.parametrize('num_envs', (1, 4))
-def test_make_gym_venv(name, state_shape, num_envs):
+def test_make_gym_venv_nostack(name, state_shape, num_envs):
     seed = 0
-    stack_len = 4
-    venv = make_gym_venv(name, seed, stack_len, num_envs)
+    frame_op = None
+    frame_op_len = None
+    venv = make_gym_venv(name, seed, frame_op, frame_op_len, num_envs)
     venv.reset()
     for i in range(5):
         state, reward, done, info = venv.step([venv.action_space.sample()] * num_envs)
 
     assert isinstance(state, np.ndarray)
-    if len(state_shape) == 1:
-        stack_shape = (num_envs, stack_len * state_shape[0],)
-    else:
-        stack_shape = (num_envs, stack_len,) + state_shape[1:]
-    assert state.shape == stack_shape
+    assert state.shape == (num_envs,) + state_shape
     assert isinstance(reward, np.ndarray)
     assert reward.shape == (num_envs,)
     assert isinstance(done, np.ndarray)
@@ -37,16 +34,44 @@ def test_make_gym_venv(name, state_shape, num_envs):
     ('CartPole-v0', (4,)),
 ])
 @pytest.mark.parametrize('num_envs', (1, 4))
-def test_make_gym_venv_nostack(name, state_shape, num_envs):
+def test_make_gym_concat(name, state_shape, num_envs):
     seed = 0
-    stack_len = None
-    venv = make_gym_venv(name, seed, stack_len, num_envs)
+    frame_op = 'concat'  # used for image, or for concat vector
+    frame_op_len = 4
+    venv = make_gym_venv(name, seed, frame_op, frame_op_len, num_envs)
     venv.reset()
     for i in range(5):
         state, reward, done, info = venv.step([venv.action_space.sample()] * num_envs)
 
     assert isinstance(state, np.ndarray)
-    assert state.shape == (num_envs,) + state_shape
+    stack_shape = (num_envs, frame_op_len * state_shape[0],) + state_shape[1:]
+    assert state.shape == stack_shape
+    assert isinstance(reward, np.ndarray)
+    assert reward.shape == (num_envs,)
+    assert isinstance(done, np.ndarray)
+    assert done.shape == (num_envs,)
+    assert len(info) == num_envs
+    venv.close()
+
+
+@pytest.mark.skip(reason='Not implemented yet')
+@pytest.mark.parametrize('name,state_shape', [
+    ('LunarLander-v2', (8,)),
+    ('CartPole-v0', (4,)),
+])
+@pytest.mark.parametrize('num_envs', (1, 4))
+def test_make_gym_stack(name, state_shape, num_envs):
+    seed = 0
+    frame_op = 'stack'  # used for rnn
+    frame_op_len = 4
+    venv = make_gym_venv(name, seed, frame_op, frame_op_len, num_envs)
+    venv.reset()
+    for i in range(5):
+        state, reward, done, info = venv.step([venv.action_space.sample()] * num_envs)
+
+    assert isinstance(state, np.ndarray)
+    stack_shape = (num_envs, frame_op_len,) + state_shape
+    assert state.shape == stack_shape
     assert isinstance(reward, np.ndarray)
     assert reward.shape == (num_envs,)
     assert isinstance(done, np.ndarray)

--- a/test/env/test_wrapper.py
+++ b/test/env/test_wrapper.py
@@ -5,22 +5,20 @@ import pytest
 
 @pytest.mark.parametrize('name,state_shape', [
     ('PongNoFrameskip-v4', (1, 84, 84)),
-    ('LunarLander-v2', (1, 8,)),
-    ('CartPole-v0', (1, 4,)),
+    ('LunarLander-v2', (8,)),
+    ('CartPole-v0', (4,)),
 ])
-def test_make_gym_env(name, state_shape):
+def test_make_gym_env_nostack(name, state_shape):
     seed = 0
-    stack_len = 4
-    env = make_gym_env(name, seed, stack_len)
+    frame_op = None
+    frame_op_len = None
+    env = make_gym_env(name, seed, frame_op, frame_op_len)
     env.reset()
     for i in range(5):
         state, reward, done, info = env.step(env.action_space.sample())
 
-    assert isinstance(state, LazyFrames)
-    state = state.__array__()  # realize data
     assert isinstance(state, np.ndarray)
-    stack_shape = (stack_len,) + state_shape[1:]
-    assert state.shape == stack_shape
+    assert state.shape == state_shape
     assert state.shape == env.observation_space.shape
     assert isinstance(reward, float)
     assert isinstance(done, bool)
@@ -33,16 +31,47 @@ def test_make_gym_env(name, state_shape):
     ('LunarLander-v2', (8,)),
     ('CartPole-v0', (4,)),
 ])
-def test_make_gym_env_nostack(name, state_shape):
+def test_make_gym_env_concat(name, state_shape):
     seed = 0
-    stack_len = None
-    env = make_gym_env(name, seed, stack_len)
+    frame_op = 'concat'  # used for image, or for concat vector
+    frame_op_len = 4
+    env = make_gym_env(name, seed, frame_op, frame_op_len)
     env.reset()
     for i in range(5):
         state, reward, done, info = env.step(env.action_space.sample())
 
+    assert isinstance(state, LazyFrames)
+    state = state.__array__()  # realize data
     assert isinstance(state, np.ndarray)
-    assert state.shape == state_shape
+    # concat multiplies first dim
+    stack_shape = (frame_op_len * state_shape[0],) + state_shape[1:]
+    assert state.shape == stack_shape
+    assert state.shape == env.observation_space.shape
+    assert isinstance(reward, float)
+    assert isinstance(done, bool)
+    assert isinstance(info, dict)
+    env.close()
+
+
+@pytest.mark.parametrize('name,state_shape', [
+    ('LunarLander-v2', (8,)),
+    ('CartPole-v0', (4,)),
+])
+def test_make_gym_env_stack(name, state_shape):
+    seed = 0
+    frame_op = 'stack'  # used for rnn
+    frame_op_len = 4
+    env = make_gym_env(name, seed, frame_op, frame_op_len)
+    env.reset()
+    for i in range(5):
+        state, reward, done, info = env.step(env.action_space.sample())
+
+    assert isinstance(state, LazyFrames)
+    state = state.__array__()  # realize data
+    assert isinstance(state, np.ndarray)
+    # stack creates new dim
+    stack_shape = (frame_op_len, ) + state_shape
+    assert state.shape == stack_shape
     assert state.shape == env.observation_space.shape
     assert isinstance(reward, float)
     assert isinstance(done, bool)

--- a/test/spec/test_spec.py
+++ b/test/spec/test_spec.py
@@ -190,7 +190,7 @@ def test_hydra_dqn(spec_file, spec_name):
 @flaky
 @pytest.mark.parametrize('spec_file,spec_name', [
     ('experimental/dqn.json', 'dqn_pong'),
-    # ('experimental/a2c.json', 'a2c_pong'),
+    ('experimental/a2c.json', 'a2c_pong'),
 ])
 def test_atari(spec_file, spec_name):
     run_trial_test(spec_file, spec_name)


### PR DESCRIPTION
## Feature / Fix
- generalize FrameStack to do concat and stack for all state shapes
- retire custom memories using `concat_len, stack_len`. Move specs to env.
- infer `seq_len` spec from net and use stack preprocessing
- remove extraneous methods: `preprocess_state, state_buffer, preprocess_append, epi_reset, try_preprocess`
- mute `normalize_state`: breaks when combined with vec env, also slower. better to default to disabled.
- retire these memory classes as no longer needed:
  * OnPolicySeqReplay
  * OnPolicySeqBatchReplay
  * OnPolicyConcatReplay
  * SeqReplay
  * ConcatReplay
  * OnPolicyImageReplay
  * ImageReplay

## Bug fix
- fix A2C shape error

## Migration guide
- see example spec changes here for migration guide. mainly, `stack_len` now are env spec `frame_op` and `frame_op_len`