### PR TITLE
guard hogwild distributed spec

### DIFF
--- a/slm_lab/experiment/control.py
+++ b/slm_lab/experiment/control.py
@@ -275,6 +275,7 @@ class Trial:
 
     def run_distributed_sessions(self):
         logger.info('Running distributed sessions')
+        assert ps.get(self.spec, 'agent.0.net.gpu') != True, f'Hogwild lock-free does not work with GPU locked CUDA tensors. Set gpu: false.'
         global_nets = self.init_global_nets()
         session_datas = self.parallelize_sessions(global_nets)
         return session_datas

--- a/slm_lab/experiment/control.py
+++ b/slm_lab/experiment/control.py
@@ -275,7 +275,6 @@ class Trial:
 
     def run_distributed_sessions(self):
         logger.info('Running distributed sessions')
-        assert ps.get(self.spec, 'agent.0.net.gpu') != True, f'Hogwild lock-free does not work with GPU locked CUDA tensors. Set gpu: false.'
         global_nets = self.init_global_nets()
         session_datas = self.parallelize_sessions(global_nets)
         return session_datas

--- a/slm_lab/lib/viz.py
+++ b/slm_lab/lib/viz.py
@@ -20,6 +20,8 @@ os.makedirs(PLOT_FILEDIR, exist_ok=True)
 if util.is_jupyter():
     py.init_notebook_mode(connected=True)
 logger = logger.get_logger(__name__)
+# warn orca failure only once
+orca_warn_once = ps.once(lambda e: logger.warn(f'Failed to generate graph. Run retro-analysis to generate graphs later.'))
 
 
 def create_label(
@@ -218,8 +220,7 @@ def save_image(figure, filepath=None):
     try:
         pio.write_image(figure, filepath)
     except Exception as e:
-        logger.warn(
-            f'Failed to generate graph. Run retro-analysis to generate graphs later.')
+        orca_warn_once(e)
 
 
 def stack_cumsum(df, y_col):

--- a/slm_lab/spec/experimental/a3c/a3c_gae_atari.json
+++ b/slm_lab/spec/experimental/a3c/a3c_gae_atari.json
@@ -55,7 +55,7 @@
           "eps": 1e-5
         },
         "lr_scheduler_spec": null,
-        "gpu": true
+        "gpu": false
       }
     }],
     "env": [{

--- a/slm_lab/spec/experimental/a3c/a3c_gae_pong.json
+++ b/slm_lab/spec/experimental/a3c/a3c_gae_pong.json
@@ -63,7 +63,7 @@
       "frame_op": "concat",
       "frame_op_len": 4,
       "reward_scale": "sign",
-      "num_envs": 8,
+      "num_envs": 1,
       "max_t": null,
       "max_tick": 1e7
     }],
@@ -76,7 +76,7 @@
       "log_frequency": 50000,
       "eval_frequency": 50000,
       "max_tick_unit": "total_t",
-      "max_session": 8,
+      "max_session": 16,
       "max_trial": 1,
     }
   }

--- a/slm_lab/spec/experimental/a3c/a3c_gae_pong.json
+++ b/slm_lab/spec/experimental/a3c/a3c_gae_pong.json
@@ -55,7 +55,7 @@
           "eps": 1e-5
         },
         "lr_scheduler_spec": null,
-        "gpu": true
+        "gpu": false
       }
     }],
     "env": [{

--- a/slm_lab/spec/spec_util.py
+++ b/slm_lab/spec/spec_util.py
@@ -77,6 +77,13 @@ def check_body_spec(spec):
         assert ps.is_list(body_num)
 
 
+def check_compatibility(spec):
+    '''Check compatibility among spec setups'''
+    # TODO expand to be more comprehensive
+    if spec['meta'].get('distributed'):
+        assert ps.get(spec, 'agent.0.net.gpu') != True, f'Hogwild lock-free does not work with GPU locked CUDA tensors. Set gpu: false.'
+
+
 def check(spec):
     '''Check a single spec for validity'''
     try:
@@ -89,6 +96,7 @@ def check(spec):
         check_comp_spec(spec['body'], SPEC_FORMAT['body'])
         check_comp_spec(spec['meta'], SPEC_FORMAT['meta'])
         check_body_spec(spec)
+        check_compatibility(spec)
     except Exception as e:
         logger.exception(f'spec {spec_name} fails spec check')
         raise e


### PR DESCRIPTION
## Feature / Fix
Hogwild does not work with GPU: Hogwild is lock-free, while CUDA tensors are not necessarily so, and may result in corruption. Add guard to ensure when hogwild (distributed) is enabled, GPU is disabled in spec.
See more details from https://discuss.pytorch.org/t/mnist-hogwild-with-cuda-not-working-with-model-net-cuda/4547/2
