### PR TITLE
Refactor net interface and optim

### DIFF
--- a/bin/setup_arch_extra
+++ b/bin/setup_arch_extra
@@ -24,3 +24,6 @@ echo "--- Installing Unity ML agents ---"
 conda activate lab
 pip install unityagents==0.2.0
 pip uninstall -y tensorflow tensorboard
+
+echo "--- Installing VizDoom ---"
+pip install vizdoom==1.1.6

--- a/bin/setup_macOS_extra
+++ b/bin/setup_macOS_extra
@@ -24,3 +24,6 @@ echo "--- Installing Unity ML agents ---"
 conda activate lab
 pip install unityagents==0.2.0
 pip uninstall -y tensorflow tensorboard
+
+echo "--- Installing VizDoom ---"
+pip install vizdoom==1.1.6

--- a/bin/setup_ubuntu_extra
+++ b/bin/setup_ubuntu_extra
@@ -25,3 +25,6 @@ echo "--- Installing Unity ML agents ---"
 conda activate lab
 pip install unityagents==0.2.0
 pip uninstall -y tensorflow tensorboard
+
+echo "--- Installing VizDoom ---"
+pip install vizdoom==1.1.6

--- a/environment.yml
+++ b/environment.yml
@@ -57,4 +57,3 @@ dependencies:
     - gym[classic_control]
     - roboschool==1.0.46
     - atari-py
-    - vizdoom==1.1.6

--- a/slm_lab/agent/algorithm/actor_critic.py
+++ b/slm_lab/agent/algorithm/actor_critic.py
@@ -161,6 +161,12 @@ class ActorCritic(Reinforce):
         else:
             util.set_attr(self, global_nets)
             self.net_names = list(global_nets.keys())
+        # init net optimizer and its lr scheduler
+        self.optim = net_util.get_optim(self.net, self.net.optim_spec)
+        self.lr_scheduler = net_util.get_lr_scheduler(self.optim, self.net.lr_scheduler_spec)
+        if not self.shared:
+            self.critic_optim = net_util.get_optim(self.critic, self.critic.optim_spec)
+            self.critic_lr_scheduler = net_util.get_lr_scheduler(self.critic_optim, self.critic.lr_scheduler_spec)
         self.post_init_nets()
 
     @lab_api

--- a/slm_lab/agent/algorithm/actor_critic.py
+++ b/slm_lab/agent/algorithm/actor_critic.py
@@ -294,10 +294,10 @@ class ActorCritic(Reinforce):
             val_loss = self.calc_val_loss(v_preds, v_targets)  # from critic
             if self.shared:  # shared network
                 loss = policy_loss + val_loss
-                self.net.training_step(loss=loss, lr_clock=clock)
+                self.net.training_step(loss, self.optim, self.lr_scheduler, lr_clock=clock)
             else:
-                self.net.training_step(loss=policy_loss, lr_clock=clock)
-                self.critic.training_step(loss=val_loss, lr_clock=clock)
+                self.net.training_step(policy_loss, self.optim, self.lr_scheduler, lr_clock=clock)
+                self.critic.training_step(val_loss, self.critic_optim, self.critic_lr_scheduler, lr_clock=clock)
                 loss = policy_loss + val_loss
             # reset
             self.to_train = 0

--- a/slm_lab/agent/algorithm/dqn.py
+++ b/slm_lab/agent/algorithm/dqn.py
@@ -145,7 +145,7 @@ class VanillaDQN(SARSA):
                 batch = self.sample()
                 for _ in range(self.training_batch_epoch):
                     loss = self.calc_q_loss(batch)
-                    self.net.training_step(loss=loss, lr_clock=clock)
+                    self.net.training_step(loss, self.optim, self.lr_scheduler, lr_clock=clock)
                     total_loss += loss
             loss = total_loss / (self.training_epoch * self.training_batch_epoch)
             # reset

--- a/slm_lab/agent/algorithm/dqn.py
+++ b/slm_lab/agent/algorithm/dqn.py
@@ -88,6 +88,9 @@ class VanillaDQN(SARSA):
         else:
             util.set_attr(self, global_nets)
             self.net_names = list(global_nets.keys())
+        # init net optimizer and its lr scheduler
+        self.optim = net_util.get_optim(self.net, self.net.optim_spec)
+        self.lr_scheduler = net_util.get_lr_scheduler(self.optim, self.net.lr_scheduler_spec)
         self.post_init_nets()
 
     def calc_q_loss(self, batch):
@@ -189,6 +192,9 @@ class DQNBase(VanillaDQN):
         else:
             util.set_attr(self, global_nets)
             self.net_names = list(global_nets.keys())
+        # init net optimizer and its lr scheduler
+        self.optim = net_util.get_optim(self.net, self.net.optim_spec)
+        self.lr_scheduler = net_util.get_lr_scheduler(self.optim, self.net.lr_scheduler_spec)
         self.post_init_nets()
         self.online_net = self.target_net
         self.eval_net = self.target_net

--- a/slm_lab/agent/algorithm/hydra_dqn.py
+++ b/slm_lab/agent/algorithm/hydra_dqn.py
@@ -1,7 +1,7 @@
 from slm_lab.agent import net
 from slm_lab.agent.algorithm import policy_util
-from slm_lab.agent.algorithm.sarsa import SARSA
 from slm_lab.agent.algorithm.dqn import DQN
+from slm_lab.agent.net import net_util
 from slm_lab.lib import logger, util
 from slm_lab.lib.decorator import lab_api
 import numpy as np
@@ -27,17 +27,12 @@ class HydraDQN(DQN):
         else:
             util.set_attr(self, global_nets)
             self.net_names = list(global_nets.keys())
+        # init net optimizer and its lr scheduler
+        self.optim = net_util.get_optim(self.net, self.net.optim_spec)
+        self.lr_scheduler = net_util.get_lr_scheduler(self.optim, self.net.lr_scheduler_spec)
         self.post_init_nets()
         self.online_net = self.target_net
         self.eval_net = self.target_net
-
-    @lab_api
-    def calc_pdparam(self, xs, net=None):
-        '''
-        Calculate pdparams for multi-action by chunking the network logits output
-        '''
-        pdparam = SARSA.calc_pdparam(self, xs, net=net)
-        return pdparam
 
     @lab_api
     def space_act(self, state_a):

--- a/slm_lab/agent/algorithm/hydra_dqn.py
+++ b/slm_lab/agent/algorithm/hydra_dqn.py
@@ -100,7 +100,7 @@ class HydraDQN(DQN):
                 batch = self.space_sample()
                 for _ in range(self.training_batch_epoch):
                     loss = self.calc_q_loss(batch)
-                    self.net.training_step(loss=loss, lr_clock=clock)
+                    self.net.training_step(loss, self.optim, self.lr_scheduler, lr_clock=clock)
                     total_loss += loss
             loss = total_loss / (self.training_epoch * self.training_batch_epoch)
             # reset

--- a/slm_lab/agent/algorithm/ppo.py
+++ b/slm_lab/agent/algorithm/ppo.py
@@ -189,10 +189,10 @@ class PPO(ActorCritic):
                     val_loss = self.calc_val_loss(v_preds, v_targets)  # from critic
                     if self.shared:  # shared network
                         loss = policy_loss + val_loss
-                        self.net.training_step(loss=loss, lr_clock=clock)
+                        self.net.training_step(loss, self.optim, self.lr_scheduler, lr_clock=clock)
                     else:
-                        self.net.training_step(loss=policy_loss, lr_clock=clock)
-                        self.critic.training_step(loss=val_loss, lr_clock=clock)
+                        self.net.training_step(policy_loss, self.optim, self.lr_scheduler, lr_clock=clock)
+                        self.critic.training_step(val_loss, self.critic_optim, self.critic_lr_scheduler, lr_clock=clock)
                         loss = policy_loss + val_loss
                     total_loss += loss
             loss = total_loss / self.training_epoch / len(minibatches)

--- a/slm_lab/agent/algorithm/reinforce.py
+++ b/slm_lab/agent/algorithm/reinforce.py
@@ -88,6 +88,9 @@ class Reinforce(Algorithm):
         else:
             util.set_attr(self, global_nets)
             self.net_names = list(global_nets.keys())
+        # init net optimizer and its lr scheduler
+        self.optim = net_util.get_optim(self.net, self.net.optim_spec)
+        self.lr_scheduler = net_util.get_lr_scheduler(self.optim, self.net.lr_scheduler_spec)
         self.post_init_nets()
 
     @lab_api

--- a/slm_lab/agent/algorithm/reinforce.py
+++ b/slm_lab/agent/algorithm/reinforce.py
@@ -161,7 +161,7 @@ class Reinforce(Algorithm):
             pdparams = self.calc_pdparam_batch(batch)
             advs = self.calc_ret_advs(batch)
             loss = self.calc_policy_loss(batch, pdparams, advs)
-            self.net.training_step(loss=loss, lr_clock=clock)
+            self.net.training_step(loss, self.optim, self.lr_scheduler, lr_clock=clock)
             # reset
             self.to_train = 0
             logger.debug(f'Trained {self.name} at epi: {clock.epi}, total_t: {clock.total_t}, t: {clock.t}, total_reward so far: {self.body.total_reward}, loss: {loss:g}')

--- a/slm_lab/agent/algorithm/sarsa.py
+++ b/slm_lab/agent/algorithm/sarsa.py
@@ -149,7 +149,7 @@ class SARSA(Algorithm):
         if self.to_train == 1:
             batch = self.sample()
             loss = self.calc_q_loss(batch)
-            self.net.training_step(loss=loss, lr_clock=clock)
+            self.net.training_step(loss, self.optim, self.lr_scheduler, lr_clock=clock)
             # reset
             self.to_train = 0
             logger.debug(f'Trained {self.name} at epi: {clock.epi}, total_t: {clock.total_t}, t: {clock.t}, total_reward so far: {self.body.total_reward}, loss: {loss:g}')

--- a/slm_lab/agent/algorithm/sarsa.py
+++ b/slm_lab/agent/algorithm/sarsa.py
@@ -81,6 +81,9 @@ class SARSA(Algorithm):
         else:
             util.set_attr(self, global_nets)
             self.net_names = list(global_nets.keys())
+        # init net optimizer and its lr scheduler
+        self.optim = net_util.get_optim(self.net, self.net.optim_spec)
+        self.lr_scheduler = net_util.get_lr_scheduler(self.optim, self.net.lr_scheduler_spec)
         self.post_init_nets()
 
     @lab_api

--- a/slm_lab/agent/algorithm/sil.py
+++ b/slm_lab/agent/algorithm/sil.py
@@ -147,7 +147,7 @@ class SIL(ActorCritic):
                     pdparams, _v_preds = self.calc_pdparam_v(batch)
                     sil_policy_loss, sil_val_loss = self.calc_sil_policy_val_loss(batch, pdparams)
                     sil_loss = sil_policy_loss + sil_val_loss
-                    self.net.training_step(loss=sil_loss, lr_clock=clock)
+                    self.net.training_step(sil_loss, self.optim, self.lr_scheduler, lr_clock=clock)
                     total_sil_loss += sil_loss
             sil_loss = total_sil_loss / self.training_epoch
             loss = super_loss + sil_loss

--- a/slm_lab/agent/net/conv.py
+++ b/slm_lab/agent/net/conv.py
@@ -203,7 +203,6 @@ class ConvNet(Net, nn.Module):
         if loss is None:
             out = self(x)
             loss = self.loss_fn(out, y)
-        assert not torch.isnan(loss).any(), loss
         loss.backward(retain_graph=retain_graph)
         if self.clip_grad_val is not None:
             nn.utils.clip_grad_norm_(self.parameters(), self.clip_grad_val)

--- a/slm_lab/agent/net/conv.py
+++ b/slm_lab/agent/net/conv.py
@@ -140,13 +140,8 @@ class ConvNet(Net, nn.Module):
 
         net_util.init_layers(self, self.init_fn)
         self.loss_fn = net_util.get_loss_fn(self, self.loss_spec)
-        self.optim = net_util.get_optim(self, self.optim_spec)
-        self.lr_scheduler = net_util.get_lr_scheduler(self.optim, self.lr_scheduler_spec)
         self.to(self.device)
         self.train()
-
-    def __str__(self):
-        return super().__str__() + f'\noptim: {self.optim}'
 
     def get_conv_output_size(self):
         '''Helper function to calculate the size of the flattened features after the final convolutional layer'''
@@ -195,14 +190,14 @@ class ConvNet(Net, nn.Module):
             return self.model_tail(x)
 
     @net_util.dev_check_training_step
-    def training_step(self, loss, lr_clock=None):
+    def training_step(self, loss, optim, lr_scheduler, lr_clock=None):
         '''Takes a single training step: one forward and one backwards pass'''
-        self.lr_scheduler.step(epoch=ps.get(lr_clock, 'total_t'))
-        self.optim.zero_grad()
+        lr_scheduler.step(epoch=ps.get(lr_clock, 'total_t'))
+        optim.zero_grad()
         loss.backward()
         if self.clip_grad_val is not None:
             nn.utils.clip_grad_norm_(self.parameters(), self.clip_grad_val)
-        self.optim.step()
+        optim.step()
         lr_clock.tick('grad_step')
         return loss
 
@@ -310,8 +305,6 @@ class DuelingConvNet(ConvNet):
 
         net_util.init_layers(self, self.init_fn)
         self.loss_fn = net_util.get_loss_fn(self, self.loss_spec)
-        self.optim = net_util.get_optim(self, self.optim_spec)
-        self.lr_scheduler = net_util.get_lr_scheduler(self.optim, self.lr_scheduler_spec)
         self.to(self.device)
         self.train()
 

--- a/slm_lab/agent/net/conv.py
+++ b/slm_lab/agent/net/conv.py
@@ -141,7 +141,7 @@ class ConvNet(Net, nn.Module):
         net_util.init_layers(self, self.init_fn)
         self.loss_fn = net_util.get_loss_fn(self, self.loss_spec)
         self.optim = net_util.get_optim(self, self.optim_spec)
-        self.lr_scheduler = net_util.get_lr_scheduler(self, self.lr_scheduler_spec)
+        self.lr_scheduler = net_util.get_lr_scheduler(self.optim, self.lr_scheduler_spec)
         self.to(self.device)
         self.train()
 
@@ -316,7 +316,7 @@ class DuelingConvNet(ConvNet):
         net_util.init_layers(self, self.init_fn)
         self.loss_fn = net_util.get_loss_fn(self, self.loss_spec)
         self.optim = net_util.get_optim(self, self.optim_spec)
-        self.lr_scheduler = net_util.get_lr_scheduler(self, self.lr_scheduler_spec)
+        self.lr_scheduler = net_util.get_lr_scheduler(self.optim, self.lr_scheduler_spec)
         self.to(self.device)
         self.train()
 

--- a/slm_lab/agent/net/conv.py
+++ b/slm_lab/agent/net/conv.py
@@ -195,15 +195,10 @@ class ConvNet(Net, nn.Module):
             return self.model_tail(x)
 
     @net_util.dev_check_training_step
-    def training_step(self, x=None, y=None, loss=None, retain_graph=False, lr_clock=None):
+    def training_step(self, loss, retain_graph=False, lr_clock=None):
         '''Takes a single training step: one forward and one backwards pass'''
-        if hasattr(self, 'model_tails') and x is not None:
-            raise ValueError('Loss computation from x,y not supported for multitails')
         self.lr_scheduler.step(epoch=ps.get(lr_clock, 'total_t'))
         self.optim.zero_grad()
-        if loss is None:
-            out = self(x)
-            loss = self.loss_fn(out, y)
         loss.backward(retain_graph=retain_graph)
         if self.clip_grad_val is not None:
             nn.utils.clip_grad_norm_(self.parameters(), self.clip_grad_val)

--- a/slm_lab/agent/net/conv.py
+++ b/slm_lab/agent/net/conv.py
@@ -165,7 +165,8 @@ class ConvNet(Net, nn.Module):
             hid_layer = [tuple(e) if ps.is_list(e) else e for e in hid_layer]  # guard list-to-tuple
             # hid_layer = out_d, kernel, stride, padding, dilation
             conv_layers.append(nn.Conv2d(in_d, *hid_layer))
-            conv_layers.append(net_util.get_activation_fn(self.hid_layers_activation))
+            if self.hid_layers_activation is not None:
+                conv_layers.append(net_util.get_activation_fn(self.hid_layers_activation))
             # Don't include batch norm in the first layer
             if self.batch_norm and i != 0:
                 conv_layers.append(nn.BatchNorm2d(in_d))

--- a/slm_lab/agent/net/conv.py
+++ b/slm_lab/agent/net/conv.py
@@ -195,11 +195,11 @@ class ConvNet(Net, nn.Module):
             return self.model_tail(x)
 
     @net_util.dev_check_training_step
-    def training_step(self, loss, retain_graph=False, lr_clock=None):
+    def training_step(self, loss, lr_clock=None):
         '''Takes a single training step: one forward and one backwards pass'''
         self.lr_scheduler.step(epoch=ps.get(lr_clock, 'total_t'))
         self.optim.zero_grad()
-        loss.backward(retain_graph=retain_graph)
+        loss.backward()
         if self.clip_grad_val is not None:
             nn.utils.clip_grad_norm_(self.parameters(), self.clip_grad_val)
         self.optim.step()

--- a/slm_lab/agent/net/mlp.py
+++ b/slm_lab/agent/net/mlp.py
@@ -138,7 +138,6 @@ class MLPNet(Net, nn.Module):
         if loss is None:
             out = self(x)
             loss = self.loss_fn(out, y)
-        assert not torch.isnan(loss).any(), loss
         loss.backward(retain_graph=retain_graph)
         if self.clip_grad_val is not None:
             nn.utils.clip_grad_norm_(self.parameters(), self.clip_grad_val)
@@ -317,7 +316,6 @@ class HydraMLPNet(Net, nn.Module):
                 loss = self.loss_fn(out, y)
                 total_loss += loss
             loss = total_loss
-        assert not torch.isnan(loss).any(), loss
         loss.backward(retain_graph=retain_graph)
         if self.clip_grad_val is not None:
             nn.utils.clip_grad_norm_(self.parameters(), self.clip_grad_val)

--- a/slm_lab/agent/net/mlp.py
+++ b/slm_lab/agent/net/mlp.py
@@ -108,7 +108,7 @@ class MLPNet(Net, nn.Module):
         net_util.init_layers(self, self.init_fn)
         self.loss_fn = net_util.get_loss_fn(self, self.loss_spec)
         self.optim = net_util.get_optim(self, self.optim_spec)
-        self.lr_scheduler = net_util.get_lr_scheduler(self, self.lr_scheduler_spec)
+        self.lr_scheduler = net_util.get_lr_scheduler(self.optim, self.lr_scheduler_spec)
         self.to(self.device)
 
     def __str__(self):
@@ -255,7 +255,7 @@ class HydraMLPNet(Net, nn.Module):
         net_util.init_layers(self, self.init_fn)
         self.loss_fn = net_util.get_loss_fn(self, self.loss_spec)
         self.optim = net_util.get_optim(self, self.optim_spec)
-        self.lr_scheduler = net_util.get_lr_scheduler(self, self.lr_scheduler_spec)
+        self.lr_scheduler = net_util.get_lr_scheduler(self.optim, self.lr_scheduler_spec)
         self.to(self.device)
 
     def __str__(self):
@@ -396,7 +396,7 @@ class DuelingMLPNet(MLPNet):
         net_util.init_layers(self, self.init_fn)
         self.loss_fn = net_util.get_loss_fn(self, self.loss_spec)
         self.optim = net_util.get_optim(self, self.optim_spec)
-        self.lr_scheduler = net_util.get_lr_scheduler(self, self.lr_scheduler_spec)
+        self.lr_scheduler = net_util.get_lr_scheduler(self.optim, self.lr_scheduler_spec)
         self.to(self.device)
 
     def forward(self, x):

--- a/slm_lab/agent/net/mlp.py
+++ b/slm_lab/agent/net/mlp.py
@@ -126,13 +126,13 @@ class MLPNet(Net, nn.Module):
             return self.model_tail(x)
 
     @net_util.dev_check_training_step
-    def training_step(self, loss, retain_graph=False, lr_clock=None):
+    def training_step(self, loss, lr_clock=None):
         '''
         Train a network given a computed loss
         '''
         self.lr_scheduler.step(epoch=ps.get(lr_clock, 'total_t'))
         self.optim.zero_grad()
-        loss.backward(retain_graph=retain_graph)
+        loss.backward()
         if self.clip_grad_val is not None:
             nn.utils.clip_grad_norm_(self.parameters(), self.clip_grad_val)
         self.optim.step()
@@ -297,10 +297,10 @@ class HydraMLPNet(Net, nn.Module):
         return outs
 
     @net_util.dev_check_training_step
-    def training_step(self, loss, retain_graph=False, lr_clock=None):
+    def training_step(self, loss, lr_clock=None):
         self.lr_scheduler.step(epoch=ps.get(lr_clock, 'total_t'))
         self.optim.zero_grad()
-        loss.backward(retain_graph=retain_graph)
+        loss.backward()
         if self.clip_grad_val is not None:
             nn.utils.clip_grad_norm_(self.parameters(), self.clip_grad_val)
         self.optim.step()

--- a/slm_lab/agent/net/net_util.py
+++ b/slm_lab/agent/net/net_util.py
@@ -76,11 +76,11 @@ def get_lr_scheduler(optim, lr_scheduler_spec):
     return lr_scheduler
 
 
-def get_optim(cls, optim_spec):
+def get_optim(net, optim_spec):
     '''Helper to parse optim param and construct optim for net'''
     OptimClass = getattr(torch.optim, optim_spec['name'])
     optim_spec = ps.omit(optim_spec, 'name')
-    optim = OptimClass(cls.parameters(), **optim_spec)
+    optim = OptimClass(net.parameters(), **optim_spec)
     return optim
 
 

--- a/slm_lab/agent/net/net_util.py
+++ b/slm_lab/agent/net/net_util.py
@@ -249,6 +249,7 @@ def dev_check_training_step(fn):
 
         # run training_step, get loss
         loss = fn(*args, **kwargs)
+        assert not torch.isnan(loss).any(), loss
 
         # get post-update parameters to compare
         post_params = [param.clone() for param in net.parameters()]

--- a/slm_lab/agent/net/net_util.py
+++ b/slm_lab/agent/net/net_util.py
@@ -49,7 +49,6 @@ def get_nn_name(uncased_name):
 
 def get_activation_fn(activation):
     '''Helper to generate activation function layers for net'''
-    activation = activation or 'relu'
     ActivationClass = getattr(nn, get_nn_name(activation))
     return ActivationClass()
 

--- a/slm_lab/agent/net/net_util.py
+++ b/slm_lab/agent/net/net_util.py
@@ -179,8 +179,10 @@ def save_algorithm(algorithm, ckpt=None):
         net = getattr(algorithm, net_name)
         model_path = f'{prepath}_{net_name}_model.pth'
         save(net, model_path)
-        optim_path = f'{prepath}_{net_name}_optim.pth'
-        save(net.optim, optim_path)
+        optim = getattr(algorithm, net_name.replace('net', 'optim'), None)
+        if optim is not None:  # only trainable net has optim
+            optim_path = f'{prepath}_{net_name}_optim.pth'
+            save(optim, optim_path)
     logger.debug(f'Saved algorithm {util.get_class_name(algorithm)} nets {net_names} to {prepath}_*.pth')
 
 
@@ -204,8 +206,10 @@ def load_algorithm(algorithm):
         net = getattr(algorithm, net_name)
         model_path = f'{prepath}_{net_name}_model.pth'
         load(net, model_path)
-        optim_path = f'{prepath}_{net_name}_optim.pth'
-        load(net.optim, optim_path)
+        optim = getattr(algorithm, net_name.replace('net', 'optim'), None)
+        if optim is not None:  # only trainable net has optim
+            optim_path = f'{prepath}_{net_name}_optim.pth'
+            load(optim, optim_path)
 
 
 def copy(src_net, tar_net):

--- a/slm_lab/agent/net/net_util.py
+++ b/slm_lab/agent/net/net_util.py
@@ -61,18 +61,18 @@ def get_loss_fn(cls, loss_spec):
     return loss_fn
 
 
-def get_lr_scheduler(cls, lr_scheduler_spec):
+def get_lr_scheduler(optim, lr_scheduler_spec):
     '''Helper to parse lr_scheduler param and construct Pytorch optim.lr_scheduler'''
     if ps.is_empty(lr_scheduler_spec):
-        lr_scheduler = NoOpLRScheduler(cls.optim)
+        lr_scheduler = NoOpLRScheduler(optim)
     elif lr_scheduler_spec['name'] == 'LinearToZero':
         LRSchedulerClass = getattr(torch.optim.lr_scheduler, 'LambdaLR')
         total_t = float(lr_scheduler_spec['total_t'])
-        lr_scheduler = LRSchedulerClass(cls.optim, lr_lambda=lambda x: 1 - x / total_t)
+        lr_scheduler = LRSchedulerClass(optim, lr_lambda=lambda x: 1 - x / total_t)
     else:
         LRSchedulerClass = getattr(torch.optim.lr_scheduler, lr_scheduler_spec['name'])
         lr_scheduler_spec = ps.omit(lr_scheduler_spec, 'name')
-        lr_scheduler = LRSchedulerClass(cls.optim, **lr_scheduler_spec)
+        lr_scheduler = LRSchedulerClass(optim, **lr_scheduler_spec)
     return lr_scheduler
 
 

--- a/slm_lab/agent/net/recurrent.py
+++ b/slm_lab/agent/net/recurrent.py
@@ -184,7 +184,6 @@ class RecurrentNet(Net, nn.Module):
         if loss is None:
             out = self(x)
             loss = self.loss_fn(out, y)
-        assert not torch.isnan(loss).any(), loss
         loss.backward(retain_graph=retain_graph)
         if self.clip_grad_val is not None:
             nn.utils.clip_grad_norm_(self.parameters(), self.clip_grad_val)

--- a/slm_lab/agent/net/recurrent.py
+++ b/slm_lab/agent/net/recurrent.py
@@ -175,15 +175,9 @@ class RecurrentNet(Net, nn.Module):
             return self.model_tail(hid_x)
 
     @net_util.dev_check_training_step
-    def training_step(self, x=None, y=None, loss=None, retain_graph=False, lr_clock=None):
-        '''Takes a single training step: one forward and one backwards pass'''
-        if hasattr(self, 'model_tails') and x is not None:
-            raise ValueError('Loss computation from x,y not supported for multitails')
+    def training_step(self, loss, retain_graph=False, lr_clock=None):
         self.lr_scheduler.step(epoch=ps.get(lr_clock, 'total_t'))
         self.optim.zero_grad()
-        if loss is None:
-            out = self(x)
-            loss = self.loss_fn(out, y)
         loss.backward(retain_graph=retain_graph)
         if self.clip_grad_val is not None:
             nn.utils.clip_grad_norm_(self.parameters(), self.clip_grad_val)

--- a/slm_lab/agent/net/recurrent.py
+++ b/slm_lab/agent/net/recurrent.py
@@ -175,10 +175,10 @@ class RecurrentNet(Net, nn.Module):
             return self.model_tail(hid_x)
 
     @net_util.dev_check_training_step
-    def training_step(self, loss, retain_graph=False, lr_clock=None):
+    def training_step(self, loss, lr_clock=None):
         self.lr_scheduler.step(epoch=ps.get(lr_clock, 'total_t'))
         self.optim.zero_grad()
-        loss.backward(retain_graph=retain_graph)
+        loss.backward()
         if self.clip_grad_val is not None:
             nn.utils.clip_grad_norm_(self.parameters(), self.clip_grad_val)
         self.optim.step()

--- a/slm_lab/agent/net/recurrent.py
+++ b/slm_lab/agent/net/recurrent.py
@@ -144,7 +144,7 @@ class RecurrentNet(Net, nn.Module):
         net_util.init_layers(self, self.init_fn)
         self.loss_fn = net_util.get_loss_fn(self, self.loss_spec)
         self.optim = net_util.get_optim(self, self.optim_spec)
-        self.lr_scheduler = net_util.get_lr_scheduler(self, self.lr_scheduler_spec)
+        self.lr_scheduler = net_util.get_lr_scheduler(self.optim, self.lr_scheduler_spec)
         self.to(self.device)
         self.train()
 

--- a/slm_lab/experiment/monitor.py
+++ b/slm_lab/experiment/monitor.py
@@ -197,12 +197,9 @@ class Body:
         if not hasattr(self.agent.algorithm, 'net_names'):
             return np.nan
         lrs = []
-        for net_name in self.agent.algorithm.net_names:
-            # we are only interested in directly trainable network, so exclude target net
-            if net_name is 'target_net':
-                continue
-            net = getattr(self.agent.algorithm, net_name)
-            lrs.append(net.lr_scheduler.get_lr())
+        for k, attr in self.agent.algorithm.__dict__.items():
+            if k.endswith('lr_scheduler'):
+                lrs.append(attr.get_lr())
         return np.mean(lrs)
 
     def get_log_prefix(self):

--- a/slm_lab/lib/logger.py
+++ b/slm_lab/lib/logger.py
@@ -24,6 +24,7 @@ lab_logger.handlers = FixedList([sh])
 # this will trigger from Experiment init on reload(logger)
 if os.environ.get('PREPATH') is not None:
     warnings.filterwarnings('ignore', category=pd.io.pytables.PerformanceWarning)
+    warnings.filterwarnings('ignore', category=ImportError)
 
     log_filepath = os.environ['PREPATH'] + '.log'
     os.makedirs(os.path.dirname(log_filepath), exist_ok=True)

--- a/slm_lab/lib/logger.py
+++ b/slm_lab/lib/logger.py
@@ -24,7 +24,7 @@ lab_logger.handlers = FixedList([sh])
 # this will trigger from Experiment init on reload(logger)
 if os.environ.get('PREPATH') is not None:
     warnings.filterwarnings('ignore', category=pd.io.pytables.PerformanceWarning)
-    warnings.filterwarnings('ignore', category=ImportError)
+    logging.getLogger('ray.tune').setLevel('INFO')
 
     log_filepath = os.environ['PREPATH'] + '.log'
     os.makedirs(os.path.dirname(log_filepath), exist_ok=True)

--- a/slm_lab/lib/logger.py
+++ b/slm_lab/lib/logger.py
@@ -20,11 +20,11 @@ sh = logging.StreamHandler(sys.stdout)
 sh.setFormatter(color_formatter)
 lab_logger = logging.getLogger()
 lab_logger.handlers = FixedList([sh])
+logging.getLogger('ray').propagate = False  # hack to mute poorly designed ray TF warning log
 
 # this will trigger from Experiment init on reload(logger)
 if os.environ.get('PREPATH') is not None:
     warnings.filterwarnings('ignore', category=pd.io.pytables.PerformanceWarning)
-    logging.getLogger('ray.tune').setLevel('INFO')
 
     log_filepath = os.environ['PREPATH'] + '.log'
     os.makedirs(os.path.dirname(log_filepath), exist_ok=True)

--- a/test/agent/net/test_conv.py
+++ b/test/agent/net/test_conv.py
@@ -56,7 +56,8 @@ def test_forward():
 def test_training_step():
     y = torch.rand((batch_size, out_dim))
     clock = Clock(100, 'total_t', 1)
-    loss = net.training_step(x=x, y=y, lr_clock=clock)
+    loss = net.loss_fn(net.forward(x), y)
+    net.training_step(loss, lr_clock=clock)
     assert loss != 0.0
 
 

--- a/test/agent/net/test_conv.py
+++ b/test/agent/net/test_conv.py
@@ -36,6 +36,9 @@ in_dim = (4, 84, 84)
 out_dim = 3
 batch_size = 16
 net = ConvNet(net_spec, in_dim, out_dim)
+# init net optimizer and its lr scheduler
+optim = net_util.get_optim(net, net.optim_spec)
+lr_scheduler = net_util.get_lr_scheduler(optim, net.lr_scheduler_spec)
 x = torch.rand((batch_size,) + in_dim)
 
 
@@ -57,7 +60,7 @@ def test_training_step():
     y = torch.rand((batch_size, out_dim))
     clock = Clock(100, 'total_t', 1)
     loss = net.loss_fn(net.forward(x), y)
-    net.training_step(loss, lr_clock=clock)
+    net.training_step(loss, optim, lr_scheduler, lr_clock=clock)
     assert loss != 0.0
 
 

--- a/test/agent/net/test_mlp.py
+++ b/test/agent/net/test_mlp.py
@@ -52,7 +52,8 @@ def test_forward():
 def test_training_step():
     y = torch.rand((batch_size, out_dim))
     clock = Clock(100, 'total_t', 1)
-    loss = net.training_step(x=x, y=y, lr_clock=clock)
+    loss = net.loss_fn(net.forward(x), y)
+    net.training_step(loss, lr_clock=clock)
     assert loss != 0.0
 
 

--- a/test/agent/net/test_mlp.py
+++ b/test/agent/net/test_mlp.py
@@ -33,6 +33,9 @@ in_dim = 10
 out_dim = 3
 batch_size = 16
 net = MLPNet(net_spec, in_dim, out_dim)
+# init net optimizer and its lr scheduler
+optim = net_util.get_optim(net, net.optim_spec)
+lr_scheduler = net_util.get_lr_scheduler(optim, net.lr_scheduler_spec)
 x = torch.rand((batch_size, in_dim))
 
 
@@ -53,7 +56,7 @@ def test_training_step():
     y = torch.rand((batch_size, out_dim))
     clock = Clock(100, 'total_t', 1)
     loss = net.loss_fn(net.forward(x), y)
-    net.training_step(loss, lr_clock=clock)
+    net.training_step(loss, optim, lr_scheduler, lr_clock=clock)
     assert loss != 0.0
 
 
@@ -65,7 +68,6 @@ def test_no_lr_scheduler():
     assert hasattr(net, 'model')
     assert hasattr(net, 'model_tail')
     assert not hasattr(net, 'model_tails')
-    assert isinstance(net.lr_scheduler, net_util.NoOpLRScheduler)
 
     y = net.forward(x)
     assert y.shape == (batch_size, out_dim)

--- a/test/agent/net/test_recurrent.py
+++ b/test/agent/net/test_recurrent.py
@@ -38,6 +38,9 @@ batch_size = 16
 seq_len = net_spec['seq_len']
 in_dim = (seq_len, state_dim)
 net = RecurrentNet(net_spec, in_dim, out_dim)
+# init net optimizer and its lr scheduler
+optim = net_util.get_optim(net, net.optim_spec)
+lr_scheduler = net_util.get_lr_scheduler(optim, net.lr_scheduler_spec)
 x = torch.rand((batch_size, seq_len, state_dim))
 
 
@@ -60,7 +63,7 @@ def test_training_step():
     y = torch.rand((batch_size, out_dim))
     clock = Clock(100, 'total_t', 1)
     loss = net.loss_fn(net.forward(x), y)
-    net.training_step(loss, lr_clock=clock)
+    net.training_step(loss, optim, lr_scheduler, lr_clock=clock)
     assert loss != 0.0
 
 

--- a/test/agent/net/test_recurrent.py
+++ b/test/agent/net/test_recurrent.py
@@ -59,7 +59,8 @@ def test_forward():
 def test_training_step():
     y = torch.rand((batch_size, out_dim))
     clock = Clock(100, 'total_t', 1)
-    loss = net.training_step(x=x, y=y, lr_clock=clock)
+    loss = net.loss_fn(net.forward(x), y)
+    net.training_step(loss, lr_clock=clock)
     assert loss != 0.0
 
 


### PR DESCRIPTION
## Feature / Fix
- refactor network interface: remove `x, y, retain_graph`
- move optim and lr_scheduler out of net for generality (Hogwild)
- interface is now `training_step(loss, optim, lr_scheduler, lr_clock)`

## Misc
- fix installation
- mute badly designed Ray warning log