### PR TITLE
REINFORCE center mean returns; remove a, e idx from Agent, Env

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Modular Deep Reinforcement Learning framework in PyTorch.
 
 ## Features
 
-### [Algorithms](#algorithms)
+### Algorithms
 
 SLM Lab implements a number of canonical RL [algorithms](https://github.com/kengz/SLM-Lab/tree/master/slm_lab/agent/algorithm) with reusable **modular components** and *class-inheritance*, with commitment to code quality and performance.
 
@@ -39,7 +39,7 @@ Below shows the latest benchmark status. See [benchmark results here](https://gi
 | PPO, distributed-PPO    | :white_check_mark: |            |
 | SIL (A2C, PPO)          |       |            |
 
-### [Environments](#environments)
+### Environments
 
 SLM Lab integrates with multiple environment offerings:
   - [OpenAI gym](https://github.com/openai/gym)
@@ -49,7 +49,7 @@ SLM Lab integrates with multiple environment offerings:
 
 *Contributions are welcome to integrate more environments!*
 
-### [Metrics and Experimentation](#experimentation-framework)
+### Metrics and Experimentation
 
 To facilitate better RL development, SLM Lab also comes with prebuilt *metrics* and *experimentation framework*:
 - every run generates metrics, graphs and data for analysis, as well as spec for reproducibility

--- a/bin/setup_macOS
+++ b/bin/setup_macOS
@@ -38,9 +38,7 @@ echo "--- Installing Conda environment ---"
 if conda env list | grep "^lab " >/dev/null; then
   echo "conda env lab is already installed"
 else
-  conda create -n lab python=3.7.3 ipykernel -y
-  conda activate lab
-  python -m ipykernel install --user --name lab
+  conda create -n lab python=3.7.3 -y
 fi
 
 # remove for reset:

--- a/slm_lab/agent/__init__.py
+++ b/slm_lab/agent/__init__.py
@@ -19,10 +19,9 @@ class Agent:
     Contains algorithm, memory, body
     '''
 
-    def __init__(self, spec, body, a=None, global_nets=None):
+    def __init__(self, spec, body, global_nets=None):
         self.spec = spec
-        self.a = a or 0  # for multi-agent
-        self.agent_spec = spec['agent'][self.a]
+        self.agent_spec = spec['agent'][0]  # idx 0 for single-agent
         self.name = self.agent_spec['name']
         assert not ps.is_list(global_nets), f'single agent global_nets must be a dict, got {global_nets}'
         # set components
@@ -80,8 +79,8 @@ class Body:
         # essential reference variables
         self.agent = None  # set later
         self.env = env
-        self.aeb = aeb
-        self.a, self.e, self.b = aeb
+        # agent, env, body index for multi-agent-env
+        self.a, self.e, self.b = self.aeb = aeb
 
         # variables set during init_algorithm_params
         self.explore_var = np.nan  # action exploration: epsilon or tau

--- a/slm_lab/agent/algorithm/reinforce.py
+++ b/slm_lab/agent/algorithm/reinforce.py
@@ -47,6 +47,7 @@ class Reinforce(Algorithm):
         util.set_attr(self, dict(
             action_pdtype='default',
             action_policy='default',
+            center_return=False,
             explore_var_spec=None,
             entropy_coef_spec=None,
             policy_loss_coef=1.0,
@@ -54,7 +55,7 @@ class Reinforce(Algorithm):
         util.set_attr(self, self.algorithm_spec, [
             'action_pdtype',
             'action_policy',
-            # theoretically, REINFORCE does not have policy update; but in this implementation we have such option
+            'center_return',  # center by the mean
             'explore_var_spec',
             'gamma',  # the discount factor
             'entropy_coef_spec',
@@ -121,6 +122,8 @@ class Reinforce(Algorithm):
     def calc_ret_advs(self, batch):
         '''Calculate plain returns; which is generalized to advantage in ActorCritic'''
         rets = math_util.calc_returns(batch['rewards'], batch['dones'], self.gamma)
+        if self.center_return:
+            rets = math_util.center_mean(rets)
         advs = rets
         if self.body.env.is_venv:
             advs = math_util.venv_unpack(advs)

--- a/slm_lab/agent/net/base.py
+++ b/slm_lab/agent/net/base.py
@@ -27,7 +27,7 @@ class Net(ABC):
             self.device = 'cpu'
 
     @net_util.dev_check_train_step
-    def train_step(self, loss, optim, lr_scheduler, clock=None, global_net=None):
+    def train_step(self, loss, optim, lr_scheduler, clock, global_net=None):
         lr_scheduler.step(epoch=ps.get(clock, 'frame'))
         optim.zero_grad()
         loss.backward()

--- a/slm_lab/env/__init__.py
+++ b/slm_lab/env/__init__.py
@@ -1,11 +1,11 @@
 # the environment module
 
 
-def make_env(spec, e=None):
+def make_env(spec):
     try:
         from slm_lab.env.openai import OpenAIEnv
-        env = OpenAIEnv(spec, e)
+        env = OpenAIEnv(spec)
     except Exception:
         from slm_lab.env.unity import UnityEnv
-        env = UnityEnv(spec, e)
+        env = UnityEnv(spec)
     return env

--- a/slm_lab/env/base.py
+++ b/slm_lab/env/base.py
@@ -85,10 +85,9 @@ class BaseEnv(ABC):
     }],
     '''
 
-    def __init__(self, spec, e=None):
-        self.e = e or 0  # for multi-env
+    def __init__(self, spec):
         self.done = False
-        self.env_spec = spec['env'][self.e]
+        self.env_spec = spec['env'][0]  # idx 0 for single-env
         # set default
         util.set_attr(self, dict(
             log_frequency=None,  # default to log at epi done

--- a/slm_lab/env/openai.py
+++ b/slm_lab/env/openai.py
@@ -30,8 +30,8 @@ class OpenAIEnv(BaseEnv):
     }],
     '''
 
-    def __init__(self, spec, e=None):
-        super().__init__(spec, e)
+    def __init__(self, spec):
+        super().__init__(spec)
         try_register_env(spec)  # register if it's a custom gym env
         seed = ps.get(spec, 'meta.random_seed')
         if self.is_venv:  # make vector environment

--- a/slm_lab/env/unity.py
+++ b/slm_lab/env/unity.py
@@ -59,8 +59,8 @@ class UnityEnv(BaseEnv):
     }],
     '''
 
-    def __init__(self, spec, e=None):
-        super().__init__(spec, e)
+    def __init__(self, spec):
+        super().__init__(spec)
         util.set_attr(self, self.env_spec, ['unity'])
         worker_id = int(f'{os.getpid()}{self.e+int(ps.unique_id())}'[-4:])
         seed = ps.get(spec, 'meta.random_seed')

--- a/slm_lab/lib/math_util.py
+++ b/slm_lab/lib/math_util.py
@@ -5,6 +5,11 @@ import torch
 
 # general math methods
 
+def center_mean(v):
+    '''Center an array by its mean'''
+    return v - v.mean()
+
+
 def normalize(v):
     '''Method to normalize a rank-1 np array'''
     v_min = v.min()


### PR DESCRIPTION
## Minor improvements
- add `center_return` as REINFORCE baseline
- API: ensure clock is not optional in `train_step`
- remove ipykernel in macOS install
- API cleanup: remove extraneous `a, e` idx from Agent, Env
