### PR TITLE
Analysis plotting methods

### DIFF
--- a/slm_lab/experiment/analysis.py
+++ b/slm_lab/experiment/analysis.py
@@ -267,6 +267,7 @@ def analyze_experiment(spec, trial_data_dict):
     experiment_df = calc_experiment_df(trial_data_dict, info_prepath)
     # plot graph
     viz.plot_experiment(spec, experiment_df, METRICS_COLS)
+    viz.plot_experiment_trials(spec)
     # zip files
     predir, _, _, _, _, _ = util.prepath_split(info_prepath)
     shutil.make_archive(predir, 'zip', predir)

--- a/slm_lab/experiment/analysis.py
+++ b/slm_lab/experiment/analysis.py
@@ -10,6 +10,7 @@ import torch
 
 NUM_EVAL = 4
 METRICS_COLS = [
+    'mean_return',
     'strength', 'max_strength', 'final_strength',
     'sample_efficiency', 'training_efficiency',
     'stability', 'consistency',
@@ -116,6 +117,7 @@ def calc_session_metrics(session_df, env_name, info_prepath=None, df_mode=None):
     frames = session_df['frame']
     opt_steps = session_df['opt_step']
 
+    mean_return = mean_returns.mean()
     str_, local_strs = calc_strength(mean_returns, mean_rand_returns)
     max_str, final_str = local_strs.max(), local_strs.iloc[-1]
     sample_eff, local_sample_effs = calc_efficiency(local_strs, frames)
@@ -124,6 +126,7 @@ def calc_session_metrics(session_df, env_name, info_prepath=None, df_mode=None):
 
     # all the scalar session metrics
     scalar = {
+        'mean_return': mean_return,
         'strength': str_,
         'max_strength': max_str,
         'final_strength': final_str,
@@ -133,11 +136,11 @@ def calc_session_metrics(session_df, env_name, info_prepath=None, df_mode=None):
     }
     # all the session local metrics
     local = {
+        'mean_returns': mean_returns,
         'strengths': local_strs,
         'sample_efficiencies': local_sample_effs,
         'training_efficiencies': local_train_effs,
         'stabilities': local_stas,
-        'mean_returns': mean_returns,
         'frames': frames,
         'opt_steps': opt_steps,
     }
@@ -164,11 +167,11 @@ def calc_trial_metrics(session_metrics_list, info_prepath=None):
     scalar_list = [sm['scalar'] for sm in session_metrics_list]
     mean_scalar = pd.DataFrame(scalar_list).mean().to_dict()
 
+    mean_returns_list = [sm['local']['mean_returns'] for sm in session_metrics_list]
     local_strs_list = [sm['local']['strengths'] for sm in session_metrics_list]
     local_se_list = [sm['local']['sample_efficiencies'] for sm in session_metrics_list]
     local_te_list = [sm['local']['training_efficiencies'] for sm in session_metrics_list]
     local_sta_list = [sm['local']['stabilities'] for sm in session_metrics_list]
-    mean_returns_list = [sm['local']['mean_returns'] for sm in session_metrics_list]
     frames = session_metrics_list[0]['local']['frames']
     opt_steps = session_metrics_list[0]['local']['opt_steps']
     # calculate consistency
@@ -176,6 +179,7 @@ def calc_trial_metrics(session_metrics_list, info_prepath=None):
 
     # all the scalar trial metrics
     scalar = {
+        'mean_return': mean_scalar['mean_return'],
         'strength': mean_scalar['strength'],
         'max_strength': mean_scalar['max_strength'],
         'final_strength': mean_scalar['final_strength'],
@@ -187,12 +191,12 @@ def calc_trial_metrics(session_metrics_list, info_prepath=None):
     assert set(scalar.keys()) == set(METRICS_COLS)
     # for plotting: gather all local series of sessions
     local = {
+        'mean_returns': mean_returns_list,
         'strengths': local_strs_list,
         'sample_efficiencies': local_se_list,
         'training_efficiencies': local_te_list,
         'stabilities': local_sta_list,
         'consistencies': local_cons,  # this is a list
-        'mean_returns': mean_returns_list,
         'frames': frames,
         'opt_steps': opt_steps,
     }

--- a/slm_lab/experiment/analysis.py
+++ b/slm_lab/experiment/analysis.py
@@ -220,6 +220,8 @@ def calc_experiment_df(trial_data_dict, info_prepath=None):
     sorted_cols = config_cols + cols
     experiment_df = experiment_df.reindex(sorted_cols, axis=1)
     experiment_df.sort_values(by=['strength'], ascending=False, inplace=True)
+    # insert trial index
+    experiment_df.insert(0, 'trial', experiment_df.index)
     if info_prepath is not None:
         util.write(experiment_df, f'{info_prepath}_experiment_df.csv')
         # save important metrics in info_prepath directly

--- a/slm_lab/experiment/analysis.py
+++ b/slm_lab/experiment/analysis.py
@@ -67,8 +67,10 @@ def calc_efficiency(local_strs, ts):
     @param Series:ts A series of times units (frame or opt_steps)
     @returns float:eff, Series:local_effs
     '''
-    eff = (local_strs / ts).sum() / local_strs.sum()
-    local_effs = (local_strs / ts).cumsum() / local_strs.cumsum()
+    # drop inf from when first t is 0
+    str_t_ratios = (local_strs / ts).replace([np.inf, -np.inf], np.nan).dropna()
+    eff = str_t_ratios.sum() / local_strs.sum()
+    local_effs = str_t_ratios.cumsum() / local_strs.cumsum()
     return eff, local_effs
 
 

--- a/slm_lab/experiment/analysis.py
+++ b/slm_lab/experiment/analysis.py
@@ -243,6 +243,7 @@ def analyze_session(session_spec, session_df, df_mode):
     session_metrics = calc_session_metrics(session_df, ps.get(session_spec, 'env.0.name'), info_prepath, df_mode)
     # plot graph
     viz.plot_session(session_spec, session_metrics, session_df, df_mode)
+    viz.plot_session(session_spec, session_metrics, session_df, df_mode, ma=True)
     return session_metrics
 
 
@@ -253,6 +254,7 @@ def analyze_trial(trial_spec, session_metrics_list):
     trial_metrics = calc_trial_metrics(session_metrics_list, info_prepath)
     # plot graphs
     viz.plot_trial(trial_spec, trial_metrics)
+    viz.plot_trial(trial_spec, trial_metrics, ma=True)
     # zip files
     if util.get_lab_mode() == 'train':
         predir, _, _, _, _, _ = util.prepath_split(info_prepath)

--- a/slm_lab/experiment/control.py
+++ b/slm_lab/experiment/control.py
@@ -66,6 +66,7 @@ class Session:
             body.log_summary('train')
 
         if self.to_ckpt(env, 'eval'):
+            logger.info('Running eval ckpt')
             avg_return = analysis.gen_avg_return(agent, self.eval_env)
             body.eval_ckpt(self.eval_env, avg_return)
             body.log_summary('eval')

--- a/slm_lab/experiment/control.py
+++ b/slm_lab/experiment/control.py
@@ -52,9 +52,7 @@ class Session:
         clock = env.clock
         frame = clock.get()
         frequency = env.eval_frequency if mode == 'eval' else env.log_frequency
-        if frame == 0 or clock.get('opt_step') == 0:  # avoid ckpt at init
-            to_ckpt = False
-        elif frequency is None:  # default episodic
+        if frequency is None:  # default episodic
             to_ckpt = env.done
         else:  # normal ckpt condition by mod remainder (general for venv)
             to_ckpt = util.frame_mod(frame, frequency, env.num_envs) or frame == clock.max_frame

--- a/slm_lab/experiment/control.py
+++ b/slm_lab/experiment/control.py
@@ -134,9 +134,10 @@ class Trial:
     def parallelize_sessions(self, global_nets=None):
         mp_dict = mp.Manager().dict()
         workers = []
-        for _s in range(self.spec['meta']['max_session']):
-            spec_util.tick(self.spec, 'session')
-            w = mp.Process(target=mp_run_session, args=(deepcopy(self.spec), global_nets, mp_dict))
+        spec = deepcopy(self.spec)
+        for _s in range(spec['meta']['max_session']):
+            spec_util.tick(spec, 'session')
+            w = mp.Process(target=mp_run_session, args=(spec, global_nets, mp_dict))
             w.start()
             workers.append(w)
         for w in workers:
@@ -147,8 +148,9 @@ class Trial:
     def run_sessions(self):
         logger.info('Running sessions')
         if self.spec['meta']['max_session'] == 1:
-            spec_util.tick(self.spec, 'session')
-            session_metrics_list = [Session(deepcopy(self.spec)).run()]
+            spec = deepcopy(self.spec)
+            spec_util.tick(spec, 'session')
+            session_metrics_list = [Session(spec).run()]
         else:
             session_metrics_list = self.parallelize_sessions()
         return session_metrics_list

--- a/slm_lab/lib/util.py
+++ b/slm_lab/lib/util.py
@@ -334,20 +334,10 @@ def prepath_split(prepath):
 
 def prepath_to_idxs(prepath):
     '''Extract trial index and session index from prepath if available'''
-    _, _, prename, spec_name, _, _ = prepath_split(prepath)
-    idxs_tail = prename.replace(spec_name, '').strip('_')
-    idxs_strs = ps.compact(idxs_tail.split('_')[:2])
-    if ps.is_empty(idxs_strs):
-        return None, None
-    tidx = idxs_strs[0]
-    assert tidx.startswith('t')
-    trial_index = int(tidx.strip('t'))
-    if len(idxs_strs) == 1:  # has session
-        session_index = None
-    else:
-        sidx = idxs_strs[1]
-        assert sidx.startswith('s')
-        session_index = int(sidx.strip('s'))
+    tidxs = re.findall('_t(\d+)', prepath)
+    trial_index = int(tidxs[0]) if tidxs else None
+    sidxs = re.findall('_s(\d+)', prepath)
+    session_index = int(sidxs[0]) if sidxs else None
     return trial_index, session_index
 
 
@@ -357,7 +347,7 @@ def prepath_to_spec(prepath):
     example: data/a2c_cartpole_2018_06_13_220436/a2c_cartpole_t0_s0
     '''
     predir, _, prename, _, experiment_ts, ckpt = prepath_split(prepath)
-    sidx_res = re.search('_s\d+', prename)
+    sidx_res = re.findall('_s\d+', prename)
     if sidx_res:  # replace the _s0 if any
         prename = prename.replace(sidx_res[0], '')
     spec_path = f'{predir}/{prename}_spec.json'

--- a/slm_lab/lib/viz.py
+++ b/slm_lab/lib/viz.py
@@ -126,7 +126,7 @@ def save_image(figure, filepath):
 
 # analysis plot methods
 
-def plot_session(session_spec, session_metrics, session_df, df_mode='eval'):
+def plot_session(session_spec, session_metrics, session_df, df_mode='eval', ma=False):
     '''
     Plot the session graphs:
     - mean_returns, strengths, sample_efficiencies, training_efficiencies, stabilities (with error bar)
@@ -146,13 +146,17 @@ def plot_session(session_spec, session_metrics, session_df, df_mode='eval'):
         ('stabilities', 'frames')
     ]
     for name, time in name_time_pairs:
+        sr = local_metrics[name]
+        if ma:
+            sr = calc_sr_ma(sr)
+            name = f'{name}_ma'  # for labeling
         fig = plot_sr(
-            local_metrics[name], local_metrics[time], title, name, time)
+            sr, local_metrics[time], title, name, time)
         save_image(fig, f'{graph_prepath}_session_graph_{df_mode}_{name}_vs_{time}.png')
-        if name in ('mean_returns',):  # save important graphs in prepath directly
+        if name in ('mean_returns', 'mean_returns_ma'):  # save important graphs in prepath directly
             save_image(fig, f'{prepath}_session_graph_{df_mode}_{name}_vs_{time}.png')
 
-    if df_mode == 'eval':
+    if df_mode == 'eval' or ma:
         return
     # training plots from session_df
     name_time_pairs = [
@@ -166,7 +170,7 @@ def plot_session(session_spec, session_metrics, session_df, df_mode='eval'):
         save_image(fig, f'{graph_prepath}_session_graph_{df_mode}_{name}_vs_{time}.png')
 
 
-def plot_trial(trial_spec, trial_metrics):
+def plot_trial(trial_spec, trial_metrics, ma=False):
     '''
     Plot the trial graphs:
     - mean_returns, strengths, sample_efficiencies, training_efficiencies, stabilities (with error bar)
@@ -188,13 +192,21 @@ def plot_trial(trial_spec, trial_metrics):
     ]
     for name, time in name_time_pairs:
         if name == 'consistencies':
+            sr = local_metrics[name]
+            if ma:
+                sr = calc_sr_ma(sr)
+                name = f'{name}_ma'  # for labeling
             fig = plot_sr(
-                local_metrics[name], local_metrics[time], title, name, time)
+                sr, local_metrics[time], title, name, time)
         else:
+            sr_list = local_metrics[name]
+            if ma:
+                sr_list = [calc_sr_ma(sr) for sr in sr_list]
+                name = f'{name}_ma'  # for labeling
             fig = plot_mean_sr(
-                local_metrics[name], local_metrics[time], title, name, time)
+                sr_list, local_metrics[time], title, name, time)
         save_image(fig, f'{graph_prepath}_trial_graph_{name}_vs_{time}.png')
-        if name in ('mean_returns',):  # save important graphs in prepath directly
+        if name in ('mean_returns', 'mean_returns_ma'):  # save important graphs in prepath directly
             save_image(fig, f'{prepath}_trial_graph_{name}_vs_{time}.png')
 
 

--- a/slm_lab/lib/viz.py
+++ b/slm_lab/lib/viz.py
@@ -296,6 +296,9 @@ def plot_multi_trial(trial_metrics_path_list, legend_list, title, graph_prepath,
             name = f'{name}_ma'  # for labeling
         fig = plot_multi_local_metrics(local_metrics_list, legend_list, name, time, title)
         save_image(fig, f'{graph_prepath}_multi_trial_graph_{name}_vs_{time}.png')
+        if name in ('mean_returns', 'mean_returns_ma'):  # save important graphs in prepath directly
+            prepath = graph_prepath.replace('/graph/', '/')
+            save_image(fig, f'{prepath}_multi_trial_graph_{name}_vs_{time}.png')
 
 
 def plot_experiment_trials(experiment_spec):

--- a/slm_lab/lib/viz.py
+++ b/slm_lab/lib/viz.py
@@ -261,7 +261,7 @@ def plot_multi_local_metrics(local_metrics_list, legend_list, name, time, title)
     return fig
 
 
-def plot_multi_trial(trial_metrics_path_list, legend_list, title, graph_prepath):
+def plot_multi_trial(trial_metrics_path_list, legend_list, title, graph_prepath, ma=False):
     '''
     Plot multiple trial graphs together
     This method can be used in analysis and also custom plotting by specifying the arguments manually
@@ -288,6 +288,12 @@ def plot_multi_trial(trial_metrics_path_list, legend_list, title, graph_prepath)
         ('stabilities', 'frames')
     ]
     for name, time in name_time_pairs:
+        if ma:
+            for local_metrics in local_metrics_list:
+                sr_list = local_metrics[name]
+                sr_list = [calc_sr_ma(sr) for sr in sr_list]
+                local_metrics[f'{name}_ma'] = sr_list
+            name = f'{name}_ma'  # for labeling
         fig = plot_multi_local_metrics(local_metrics_list, legend_list, name, time, title)
         save_image(fig, f'{graph_prepath}_multi_trial_graph_{name}_vs_{time}.png')
 
@@ -301,3 +307,4 @@ def plot_experiment_trials(experiment_spec):
     legend_list = [util.prepath_to_idxs(prepath)[0] for prepath in trial_metrics_path_list]
     graph_prepath = meta_spec['graph_prepath']
     plot_multi_trial(trial_metrics_path_list, legend_list, title, graph_prepath)
+    plot_multi_trial(trial_metrics_path_list, legend_list, title, graph_prepath, ma=True)

--- a/slm_lab/lib/viz.py
+++ b/slm_lab/lib/viz.py
@@ -198,9 +198,6 @@ def plot_experiment(experiment_spec, experiment_df, metrics_cols):
     y_cols = metrics_cols
     x_cols = ps.difference(experiment_df.columns.tolist(), y_cols)
     fig = tools.make_subplots(rows=len(y_cols), cols=len(x_cols), shared_xaxes=True, shared_yaxes=True, print_grid=False)
-    strength_sr = experiment_df['strength']
-    min_strength = strength_sr.values.min()
-    max_strength = strength_sr.values.max()
     for row_idx, y in enumerate(y_cols):
         for col_idx, x in enumerate(x_cols):
             x_sr = experiment_df[x]
@@ -211,8 +208,6 @@ def plot_experiment(experiment_spec, experiment_df, metrics_cols):
                 showlegend=False, mode='markers',
                 marker={
                     'symbol': 'circle-open-dot', 'color': experiment_df['strength'], 'opacity': 0.5,
-                    # dump first quarter of colorscale that is too bright
-                    'cmin': min_strength - 0.50 * (max_strength - min_strength), 'cmax': max_strength,
                     'colorscale': 'YlGnBu', 'reversescale': True
                 },
             )

--- a/slm_lab/lib/viz.py
+++ b/slm_lab/lib/viz.py
@@ -10,10 +10,17 @@ import pydash as ps
 
 logger = logger.get_logger(__name__)
 
+# moving-average window size for plotting
+PLOT_MA_WINDOW = 100
 # warn orca failure only once
 orca_warn_once = ps.once(lambda e: logger.warning(f'Failed to generate graph. Run retro-analysis to generate graphs later.'))
 if util.is_jupyter():
     init_notebook_mode(connected=True)
+
+
+def calc_sr_ma(sr):
+    '''Calculate the moving-average of a series to be plotted'''
+    return sr.rolling(PLOT_MA_WINDOW, min_periods=1).mean()
 
 
 def create_label(y_col, x_col, title=None, y_title=None, x_title=None, legend_name=None):


### PR DESCRIPTION
## Feature / Fix
- add `mean_returns` as part of implemented metrics, to plot as graph
- add `trial` index to `experiment_df`
- add methods to plot multiple trials as part of experiment analysis, also can be used manually
- evaluate from 0. guard breakage
- add moving-average as additional side plots