### PR TITLE
update benchmark envs, analysis, benchmark runner

### DIFF
--- a/job/a2c_nstep_benchmark.json
+++ b/job/a2c_nstep_benchmark.json
@@ -1,8 +1,8 @@
 {
-  "benchmark/a2c/a2c_atari.json": {
-    "a2c_atari": "train"
+  "benchmark/a2c/a2c_nstep_atari.json": {
+    "a2c_nstep_atari": "train"
   },
-  "experimental/a2c/a2c_cont.json": {
-    "a2c_cont": "train"
+  "experimental/a2c/a2c_nstep_cont.json": {
+    "a2c_nstep_cont": "train"
   },
 }

--- a/job/atari_benchmark.json
+++ b/job/atari_benchmark.json
@@ -1,0 +1,11 @@
+{
+  "benchmark/a2c/a2c_gae_atari.json": {
+    "a2c_gae_atari": "train"
+  },
+  "benchmark/a2c/a2c_nstep_atari.json": {
+    "a2c_nstep_atari": "train"
+  },
+  "benchmark/ppo/ppo_atari.json": {
+    "ppo_atari": "train"
+  },
+}

--- a/run_lab.py
+++ b/run_lab.py
@@ -57,7 +57,17 @@ def read_spec_and_run(spec_file, spec_name, lab_mode):
         run_spec(spec, lab_mode)
     else:  # spec is parametrized; run them in parallel using ray
         param_specs = spec_util.get_param_specs(spec)
-        search.run_param_specs(param_specs)
+        device_count = torch.cuda.device_count() or util.NUM_CPUS
+        num_pro = int(device_count/spec['meta']['max_session'])
+        # can't use Pool since it cannot spawn nested Process, which is needed for VecEnv and parallel sessions. So these will run and wait by chunks
+        workers = [mp.Process(target=run_spec, args=(spec, lab_mode)) for spec in param_specs]
+        for chunk_w in ps.chunk(workers, num_pro):
+            for w in chunk_w:
+                w.start()
+            for w in chunk_w:
+                w.join()
+        # param_specs = spec_util.get_param_specs(spec)
+        # search.run_param_specs(param_specs)
 
 
 def main():

--- a/slm_lab/experiment/analysis.py
+++ b/slm_lab/experiment/analysis.py
@@ -10,7 +10,7 @@ import torch
 
 NUM_EVAL = 4
 METRICS_COLS = [
-    'mean_return',
+    'final_return_ma',
     'strength', 'max_strength', 'final_strength',
     'sample_efficiency', 'training_efficiency',
     'stability', 'consistency',
@@ -119,7 +119,7 @@ def calc_session_metrics(session_df, env_name, info_prepath=None, df_mode=None):
     frames = session_df['frame']
     opt_steps = session_df['opt_step']
 
-    mean_return = mean_returns.mean()
+    final_return_ma = mean_returns[-viz.PLOT_MA_WINDOW:].mean()
     str_, local_strs = calc_strength(mean_returns, mean_rand_returns)
     max_str, final_str = local_strs.max(), local_strs.iloc[-1]
     sample_eff, local_sample_effs = calc_efficiency(local_strs, frames)
@@ -128,7 +128,7 @@ def calc_session_metrics(session_df, env_name, info_prepath=None, df_mode=None):
 
     # all the scalar session metrics
     scalar = {
-        'mean_return': mean_return,
+        'final_return_ma': final_return_ma,
         'strength': str_,
         'max_strength': max_str,
         'final_strength': final_str,
@@ -181,7 +181,7 @@ def calc_trial_metrics(session_metrics_list, info_prepath=None):
 
     # all the scalar trial metrics
     scalar = {
-        'mean_return': mean_scalar['mean_return'],
+        'final_return_ma': mean_scalar['final_return_ma'],
         'strength': mean_scalar['strength'],
         'max_strength': mean_scalar['max_strength'],
         'final_strength': mean_scalar['final_strength'],

--- a/slm_lab/experiment/control.py
+++ b/slm_lab/experiment/control.py
@@ -7,6 +7,7 @@ from slm_lab.env import make_env
 from slm_lab.experiment import analysis, search
 from slm_lab.lib import logger, util
 from slm_lab.spec import spec_util
+import torch
 import torch.multiprocessing as mp
 
 
@@ -107,6 +108,7 @@ class Session:
         self.agent.close()
         self.env.close()
         self.eval_env.close()
+        torch.cuda.empty_cache()
         logger.info(f'Session {self.index} done')
 
     def run(self):

--- a/slm_lab/lib/util.py
+++ b/slm_lab/lib/util.py
@@ -490,7 +490,7 @@ def set_cuda_id(spec):
     job_idx = trial_idx * meta_spec['max_session'] + session_idx
     job_idx += meta_spec['cuda_offset']
     device_count = torch.cuda.device_count()
-    cuda_id = job_idx % device_count if device_count else None
+    cuda_id = job_idx % device_count if torch.cuda.is_available() else None
 
     for agent_spec in spec['agent']:
         agent_spec['net']['cuda_id'] = cuda_id

--- a/slm_lab/spec/benchmark/a2c/a2c_gae_atari.json
+++ b/slm_lab/spec/benchmark/a2c/a2c_gae_atari.json
@@ -79,7 +79,7 @@
     },
     "spec_params": {
       "env": [
-        "BeamRiderNoFrameskip-v4", "BreakoutNoFrameskip-v4", "MsPacmanNoFrameskip-v4", "PongNoFrameskip-v4", "QbertNoFrameskip-v4", "SeaquestNoFrameskip-v4", "SpaceInvadersNoFrameskip-v4"
+        "BreakoutNoFrameskip-v4", "MsPacmanNoFrameskip-v4", "PongNoFrameskip-v4", "QbertNoFrameskip-v4", "SeaquestNoFrameskip-v4", "SpaceInvadersNoFrameskip-v4"
       ]
     }
   },

--- a/slm_lab/spec/benchmark/a2c/a2c_gae_atari.json
+++ b/slm_lab/spec/benchmark/a2c/a2c_gae_atari.json
@@ -79,7 +79,7 @@
     },
     "spec_params": {
       "env": [
-        "BreakoutNoFrameskip-v4", "MsPacmanNoFrameskip-v4", "PongNoFrameskip-v4", "QbertNoFrameskip-v4", "SeaquestNoFrameskip-v4", "SpaceInvadersNoFrameskip-v4"
+        "BeamRiderNoFrameskip-v4", "BreakoutNoFrameskip-v4", "PongNoFrameskip-v4", "QbertNoFrameskip-v4", "SeaquestNoFrameskip-v4", "SpaceInvadersNoFrameskip-v4"
       ]
     }
   },

--- a/slm_lab/spec/benchmark/a2c/a2c_nstep_atari.json
+++ b/slm_lab/spec/benchmark/a2c/a2c_nstep_atari.json
@@ -79,7 +79,7 @@
     },
     "spec_params": {
       "env": [
-        "BeamRiderNoFrameskip-v4", "BreakoutNoFrameskip-v4", "MsPacmanNoFrameskip-v4", "PongNoFrameskip-v4", "QbertNoFrameskip-v4", "SeaquestNoFrameskip-v4", "SpaceInvadersNoFrameskip-v4"
+        "BreakoutNoFrameskip-v4", "MsPacmanNoFrameskip-v4", "PongNoFrameskip-v4", "QbertNoFrameskip-v4", "SeaquestNoFrameskip-v4", "SpaceInvadersNoFrameskip-v4"
       ]
     }
   },

--- a/slm_lab/spec/benchmark/a2c/a2c_nstep_atari.json
+++ b/slm_lab/spec/benchmark/a2c/a2c_nstep_atari.json
@@ -79,7 +79,7 @@
     },
     "spec_params": {
       "env": [
-        "BreakoutNoFrameskip-v4", "MsPacmanNoFrameskip-v4", "PongNoFrameskip-v4", "QbertNoFrameskip-v4", "SeaquestNoFrameskip-v4", "SpaceInvadersNoFrameskip-v4"
+        "BeamRiderNoFrameskip-v4", "BreakoutNoFrameskip-v4", "PongNoFrameskip-v4", "QbertNoFrameskip-v4", "SeaquestNoFrameskip-v4", "SpaceInvadersNoFrameskip-v4"
       ]
     }
   },

--- a/slm_lab/spec/benchmark/a3c/a3c_gae_atari.json
+++ b/slm_lab/spec/benchmark/a3c/a3c_gae_atari.json
@@ -75,7 +75,7 @@
     },
     "spec_params": {
       "env": [
-        "BeamRiderNoFrameskip-v4", "BreakoutNoFrameskip-v4", "MsPacmanNoFrameskip-v4", "PongNoFrameskip-v4", "QbertNoFrameskip-v4", "SeaquestNoFrameskip-v4", "SpaceInvadersNoFrameskip-v4"
+        "BeamRiderNoFrameskip-v4", "BreakoutNoFrameskip-v4", "PongNoFrameskip-v4", "QbertNoFrameskip-v4", "SeaquestNoFrameskip-v4", "SpaceInvadersNoFrameskip-v4"
       ]
     }
   },

--- a/slm_lab/spec/benchmark/a3c/a3c_nstep_atari.json
+++ b/slm_lab/spec/benchmark/a3c/a3c_nstep_atari.json
@@ -75,7 +75,7 @@
     },
     "spec_params": {
       "env": [
-        "BeamRiderNoFrameskip-v4", "BreakoutNoFrameskip-v4", "MsPacmanNoFrameskip-v4", "PongNoFrameskip-v4", "QbertNoFrameskip-v4", "SeaquestNoFrameskip-v4", "SpaceInvadersNoFrameskip-v4"
+        "BeamRiderNoFrameskip-v4", "BreakoutNoFrameskip-v4", "PongNoFrameskip-v4", "QbertNoFrameskip-v4", "SeaquestNoFrameskip-v4", "SpaceInvadersNoFrameskip-v4"
       ]
     }
   },

--- a/slm_lab/spec/benchmark/dqn/ddqn_atari.json
+++ b/slm_lab/spec/benchmark/dqn/ddqn_atari.json
@@ -70,7 +70,7 @@
     },
     "spec_params": {
       "env": [
-        "BeamRiderNoFrameskip-v4", "BreakoutNoFrameskip-v4", "MsPacmanNoFrameskip-v4", "PongNoFrameskip-v4", "QbertNoFrameskip-v4", "SeaquestNoFrameskip-v4", "SpaceInvadersNoFrameskip-v4"
+        "BeamRiderNoFrameskip-v4", "BreakoutNoFrameskip-v4", "PongNoFrameskip-v4", "QbertNoFrameskip-v4", "SeaquestNoFrameskip-v4", "SpaceInvadersNoFrameskip-v4"
       ]
     }
   },

--- a/slm_lab/spec/benchmark/dqn/ddqn_per_atari.json
+++ b/slm_lab/spec/benchmark/dqn/ddqn_per_atari.json
@@ -72,7 +72,7 @@
     },
     "spec_params": {
       "env": [
-        "BeamRiderNoFrameskip-v4", "BreakoutNoFrameskip-v4", "MsPacmanNoFrameskip-v4", "PongNoFrameskip-v4", "QbertNoFrameskip-v4", "SeaquestNoFrameskip-v4", "SpaceInvadersNoFrameskip-v4"
+        "BeamRiderNoFrameskip-v4", "BreakoutNoFrameskip-v4", "PongNoFrameskip-v4", "QbertNoFrameskip-v4", "SeaquestNoFrameskip-v4", "SpaceInvadersNoFrameskip-v4"
       ]
     }
   },

--- a/slm_lab/spec/benchmark/dqn/dqn_atari.json
+++ b/slm_lab/spec/benchmark/dqn/dqn_atari.json
@@ -70,7 +70,7 @@
     },
     "spec_params": {
       "env": [
-        "BeamRiderNoFrameskip-v4", "BreakoutNoFrameskip-v4", "MsPacmanNoFrameskip-v4", "PongNoFrameskip-v4", "QbertNoFrameskip-v4", "SeaquestNoFrameskip-v4", "SpaceInvadersNoFrameskip-v4"
+        "BeamRiderNoFrameskip-v4", "BreakoutNoFrameskip-v4", "PongNoFrameskip-v4", "QbertNoFrameskip-v4", "SeaquestNoFrameskip-v4", "SpaceInvadersNoFrameskip-v4"
       ]
     }
   },

--- a/slm_lab/spec/benchmark/dqn/dqn_per_atari.json
+++ b/slm_lab/spec/benchmark/dqn/dqn_per_atari.json
@@ -72,7 +72,7 @@
     },
     "spec_params": {
       "env": [
-        "BeamRiderNoFrameskip-v4", "BreakoutNoFrameskip-v4", "MsPacmanNoFrameskip-v4", "PongNoFrameskip-v4", "QbertNoFrameskip-v4", "SeaquestNoFrameskip-v4", "SpaceInvadersNoFrameskip-v4"
+        "BeamRiderNoFrameskip-v4", "BreakoutNoFrameskip-v4", "PongNoFrameskip-v4", "QbertNoFrameskip-v4", "SeaquestNoFrameskip-v4", "SpaceInvadersNoFrameskip-v4"
       ]
     }
   },

--- a/slm_lab/spec/benchmark/ppo/ppo_atari.json
+++ b/slm_lab/spec/benchmark/ppo/ppo_atari.json
@@ -86,7 +86,7 @@
     },
     "spec_params": {
       "env": [
-        "BreakoutNoFrameskip-v4", "MsPacmanNoFrameskip-v4", "PongNoFrameskip-v4", "QbertNoFrameskip-v4", "SeaquestNoFrameskip-v4", "SpaceInvadersNoFrameskip-v4"
+        "BeamRiderNoFrameskip-v4", "BreakoutNoFrameskip-v4", "PongNoFrameskip-v4", "QbertNoFrameskip-v4", "SeaquestNoFrameskip-v4", "SpaceInvadersNoFrameskip-v4"
       ]
     }
   },

--- a/slm_lab/spec/benchmark/ppo/ppo_atari.json
+++ b/slm_lab/spec/benchmark/ppo/ppo_atari.json
@@ -86,7 +86,7 @@
     },
     "spec_params": {
       "env": [
-        "BeamRiderNoFrameskip-v4", "BreakoutNoFrameskip-v4", "MsPacmanNoFrameskip-v4", "PongNoFrameskip-v4", "QbertNoFrameskip-v4", "SeaquestNoFrameskip-v4", "SpaceInvadersNoFrameskip-v4"
+        "BreakoutNoFrameskip-v4", "MsPacmanNoFrameskip-v4", "PongNoFrameskip-v4", "QbertNoFrameskip-v4", "SeaquestNoFrameskip-v4", "SpaceInvadersNoFrameskip-v4"
       ]
     }
   },


### PR DESCRIPTION
## Feature / Fix
- update benchmark envs to use only 6
- update analysis to include `final_reward_ma`
- update benchmark runner to use mp as original instead of ray
