### PR TITLE
Retro analyze fail gracefully when no experiment data

### DIFF
--- a/slm_lab/experiment/retro_analysis.py
+++ b/slm_lab/experiment/retro_analysis.py
@@ -52,8 +52,9 @@ def retro_analyze_experiment(predir):
     experiment_spec_paths = ps.difference(glob(f'{predir}/*_spec.json'), trial_spec_paths)
     experiment_spec_path = experiment_spec_paths[0]
     spec = util.read(experiment_spec_path)
-    info_prepath = spec['meta']['info_prepath']
+    info_prepath = spec['meta'].get('info_prepath')
     if not os.path.exists(f'{info_prepath}_trial_data_dict.json'):
+        logger.info('No experiment data available. This is expected if no search was ran.')
         return  # only run analysis if experiment had been ran
     trial_data_dict = util.read(f'{info_prepath}_trial_data_dict.json')
     analysis.analyze_experiment(spec, trial_data_dict)

--- a/slm_lab/experiment/retro_analysis.py
+++ b/slm_lab/experiment/retro_analysis.py
@@ -54,7 +54,7 @@ def retro_analyze_experiment(predir):
     spec = util.read(experiment_spec_path)
     info_prepath = spec['meta'].get('info_prepath')
     if not os.path.exists(f'{info_prepath}_trial_data_dict.json'):
-        logger.info('No experiment data available. This is expected if no search was ran.')
+        logger.info('Skipping retro_analyze_experiment since no experiment was ran.')
         return  # only run analysis if experiment had been ran
     trial_data_dict = util.read(f'{info_prepath}_trial_data_dict.json')
     analysis.analyze_experiment(spec, trial_data_dict)


### PR DESCRIPTION
##  Fix
- guard the info_prepath look up in retro_analyze_experiment and log an appropriate message if none is found. It is misleading for the program to crash when an experiment wasn't run but the session and trial analyses succeeded.