### PR TITLE
Fast eval option

### DIFF
--- a/slm_lab/agent/__init__.py
+++ b/slm_lab/agent/__init__.py
@@ -91,8 +91,6 @@ class Body:
         self.mean_entropy = np.nan
         self.mean_grad_norm = np.nan
 
-        self.epi_start = True
-        self.ckpt_total_reward = np.nan
         self.total_reward = 0  # init to 0, but dont ckpt before end of an epi
         self.total_reward_ma = np.nan
         # store current and best reward_ma for model checkpointing and early termination if all the environments are solved
@@ -123,9 +121,7 @@ class Body:
 
     def update(self, state, action, reward, next_state, done):
         '''Interface update method for body at agent.update()'''
-        if hasattr(self.env.u_env, 'raw_reward'):  # use raw_reward if reward is preprocessed
-            reward = self.env.u_env.raw_reward
-        self.ckpt_total_reward, self.total_reward, self.epi_start = util.update_total_reward(self.ckpt_total_reward, self.total_reward, self.epi_start, reward, done)
+        self.total_reward = self.env.total_reward
 
     def __str__(self):
         return f'body: {util.to_json(util.get_class_attr(self))}'

--- a/slm_lab/agent/__init__.py
+++ b/slm_lab/agent/__init__.py
@@ -167,10 +167,9 @@ class Body:
         self.total_reward_ma = self.train_df[-viz.PLOT_MA_WINDOW:]['total_reward'].mean()
         self.train_df.iloc[-1]['total_reward_ma'] = self.total_reward_ma
 
-    def eval_ckpt(self, eval_env, total_reward):
+    def eval_ckpt(self, eval_env):
         '''Checkpoint to update body.eval_df data'''
         row = self.calc_df_row(eval_env)
-        row['total_reward'] = total_reward
         # append efficiently to df
         self.eval_df.loc[len(self.eval_df)] = row
         # update current reward_ma

--- a/slm_lab/agent/__init__.py
+++ b/slm_lab/agent/__init__.py
@@ -129,6 +129,8 @@ class Body:
         frame = self.env.clock.get('frame')
         wall_t = env.clock.get_elapsed_wall_t()
         fps = 0 if wall_t == 0 else frame / wall_t
+        with np.errstate(all='ignore'):
+            total_reward = np.nanmean(env.total_reward)  # guard for vec env
 
         # update debugging variables
         if net_util.to_check_train_step():
@@ -144,7 +146,7 @@ class Body:
             'opt_step': self.env.clock.get('opt_step'),
             'frame': frame,
             'fps': fps,
-            'total_reward': np.nanmean(env.total_reward),  # guard for vec env
+            'total_reward': total_reward,
             'total_reward_ma': np.nan,  # update outside
             'loss': self.loss,
             'lr': self.get_mean_lr(),

--- a/slm_lab/agent/__init__.py
+++ b/slm_lab/agent/__init__.py
@@ -91,11 +91,9 @@ class Body:
         self.mean_entropy = np.nan
         self.mean_grad_norm = np.nan
 
-        self.total_reward = 0  # init to 0, but dont ckpt before end of an epi
+        # total_reward_ma from eval for model checkpoint saves
+        self.best_total_reward_ma = -np.inf
         self.total_reward_ma = np.nan
-        # store current and best reward_ma for model checkpointing and early termination if all the environments are solved
-        self.best_reward_ma = -np.inf
-        self.eval_reward_ma = np.nan
 
         # dataframes to track data for analysis.analyze_session
         # track training data per episode
@@ -121,7 +119,7 @@ class Body:
 
     def update(self, state, action, reward, next_state, done):
         '''Interface update method for body at agent.update()'''
-        self.total_reward = self.env.total_reward
+        pass
 
     def __str__(self):
         return f'body: {util.to_json(util.get_class_attr(self))}'
@@ -158,23 +156,18 @@ class Body:
         assert all(col in self.train_df.columns for col in row.index), f'Mismatched row keys: {row.index} vs df columns {self.train_df.columns}'
         return row
 
-    def train_ckpt(self):
-        '''Checkpoint to update body.train_df data'''
-        row = self.calc_df_row(self.env)
-        # append efficiently to df
-        self.train_df.loc[len(self.train_df)] = row
-        # update current reward_ma
-        self.total_reward_ma = self.train_df[-viz.PLOT_MA_WINDOW:]['total_reward'].mean()
-        self.train_df.iloc[-1]['total_reward_ma'] = self.total_reward_ma
-
-    def eval_ckpt(self, eval_env):
-        '''Checkpoint to update body.eval_df data'''
-        row = self.calc_df_row(eval_env)
-        # append efficiently to df
-        self.eval_df.loc[len(self.eval_df)] = row
-        # update current reward_ma
-        self.eval_reward_ma = self.eval_df[-viz.PLOT_MA_WINDOW:]['total_reward'].mean()
-        self.eval_df.iloc[-1]['total_reward_ma'] = self.eval_reward_ma
+    def ckpt(self, env, df_mode):
+        '''
+        Checkpoint to update body.train_df or eval_df data
+        @param OpenAIEnv|UnityEnv:env self.env or self.eval_env
+        @param str:df_mode 'train' or 'eval'
+        '''
+        row = self.calc_df_row(env)
+        df = getattr(self, f'{df_mode}_df')
+        df.loc[len(df)] = row  # append efficiently to df
+        df.iloc[-1]['total_reward_ma'] = total_reward_ma = df[-viz.PLOT_MA_WINDOW:]['total_reward'].mean()
+        if df_mode == 'eval':
+            self.total_reward_ma = total_reward_ma
 
     def get_mean_lr(self):
         '''Gets the average current learning rate of the algorithm's nets.'''

--- a/slm_lab/agent/__init__.py
+++ b/slm_lab/agent/__init__.py
@@ -8,6 +8,7 @@ import numpy as np
 import pandas as pd
 import pydash as ps
 import torch
+import warnings
 
 
 logger = logger.get_logger(__name__)
@@ -129,7 +130,8 @@ class Body:
         frame = self.env.clock.get('frame')
         wall_t = env.clock.get_elapsed_wall_t()
         fps = 0 if wall_t == 0 else frame / wall_t
-        with np.errstate(all='ignore'):
+        with warnings.catch_warnings():  # mute np.nanmean warning
+            warnings.filterwarnings('ignore')
             total_reward = np.nanmean(env.total_reward)  # guard for vec env
 
         # update debugging variables

--- a/slm_lab/agent/__init__.py
+++ b/slm_lab/agent/__init__.py
@@ -146,7 +146,7 @@ class Body:
             'opt_step': self.env.clock.get('opt_step'),
             'frame': frame,
             'fps': fps,
-            'total_reward': np.nanmean(self.total_reward),  # guard for vec env
+            'total_reward': np.nanmean(env.total_reward),  # guard for vec env
             'total_reward_ma': np.nan,  # update outside
             'loss': self.loss,
             'lr': self.get_mean_lr(),

--- a/slm_lab/agent/algorithm/actor_critic.py
+++ b/slm_lab/agent/algorithm/actor_critic.py
@@ -297,7 +297,7 @@ class ActorCritic(Reinforce):
                 loss = policy_loss + val_loss
             # reset
             self.to_train = 0
-            logger.debug(f'Trained {self.name} at epi: {clock.epi}, frame: {clock.frame}, t: {clock.t}, total_reward so far: {self.body.total_reward}, loss: {loss:g}')
+            logger.debug(f'Trained {self.name} at epi: {clock.epi}, frame: {clock.frame}, t: {clock.t}, total_reward so far: {self.body.env.total_reward}, loss: {loss:g}')
             return loss.item()
         else:
             return np.nan

--- a/slm_lab/agent/algorithm/dqn.py
+++ b/slm_lab/agent/algorithm/dqn.py
@@ -144,7 +144,7 @@ class VanillaDQN(SARSA):
             loss = total_loss / (self.training_iter * self.training_batch_iter)
             # reset
             self.to_train = 0
-            logger.debug(f'Trained {self.name} at epi: {clock.epi}, frame: {clock.frame}, t: {clock.t}, total_reward so far: {self.body.total_reward}, loss: {loss:g}')
+            logger.debug(f'Trained {self.name} at epi: {clock.epi}, frame: {clock.frame}, t: {clock.t}, total_reward so far: {self.body.env.total_reward}, loss: {loss:g}')
             return loss.item()
         else:
             return np.nan

--- a/slm_lab/agent/algorithm/ppo.py
+++ b/slm_lab/agent/algorithm/ppo.py
@@ -199,7 +199,7 @@ class PPO(ActorCritic):
             loss = total_loss / self.training_epoch / len(minibatches)
             # reset
             self.to_train = 0
-            logger.debug(f'Trained {self.name} at epi: {clock.epi}, frame: {clock.frame}, t: {clock.t}, total_reward so far: {self.body.total_reward}, loss: {loss:g}')
+            logger.debug(f'Trained {self.name} at epi: {clock.epi}, frame: {clock.frame}, t: {clock.t}, total_reward so far: {self.body.env.total_reward}, loss: {loss:g}')
             return loss.item()
         else:
             return np.nan

--- a/slm_lab/agent/algorithm/reinforce.py
+++ b/slm_lab/agent/algorithm/reinforce.py
@@ -159,7 +159,7 @@ class Reinforce(Algorithm):
             self.net.train_step(loss, self.optim, self.lr_scheduler, clock=clock, global_net=self.global_net)
             # reset
             self.to_train = 0
-            logger.debug(f'Trained {self.name} at epi: {clock.epi}, frame: {clock.frame}, t: {clock.t}, total_reward so far: {self.body.total_reward}, loss: {loss:g}')
+            logger.debug(f'Trained {self.name} at epi: {clock.epi}, frame: {clock.frame}, t: {clock.t}, total_reward so far: {self.body.env.total_reward}, loss: {loss:g}')
             return loss.item()
         else:
             return np.nan

--- a/slm_lab/agent/algorithm/sarsa.py
+++ b/slm_lab/agent/algorithm/sarsa.py
@@ -144,7 +144,7 @@ class SARSA(Algorithm):
             self.net.train_step(loss, self.optim, self.lr_scheduler, clock=clock, global_net=self.global_net)
             # reset
             self.to_train = 0
-            logger.debug(f'Trained {self.name} at epi: {clock.epi}, frame: {clock.frame}, t: {clock.t}, total_reward so far: {self.body.total_reward}, loss: {loss:g}')
+            logger.debug(f'Trained {self.name} at epi: {clock.epi}, frame: {clock.frame}, t: {clock.t}, total_reward so far: {self.body.env.total_reward}, loss: {loss:g}')
             return loss.item()
         else:
             return np.nan

--- a/slm_lab/agent/algorithm/sil.py
+++ b/slm_lab/agent/algorithm/sil.py
@@ -145,7 +145,7 @@ class SIL(ActorCritic):
                     total_sil_loss += sil_loss
             sil_loss = total_sil_loss / self.training_iter
             loss = super_loss + sil_loss
-            logger.debug(f'Trained {self.name} at epi: {clock.epi}, frame: {clock.frame}, t: {clock.t}, total_reward so far: {self.body.total_reward}, loss: {loss:g}')
+            logger.debug(f'Trained {self.name} at epi: {clock.epi}, frame: {clock.frame}, t: {clock.t}, total_reward so far: {self.body.env.total_reward}, loss: {loss:g}')
             return loss.item()
         else:
             return np.nan

--- a/slm_lab/env/base.py
+++ b/slm_lab/env/base.py
@@ -146,7 +146,7 @@ class BaseEnv(ABC):
         self.total_reward_buffer = np.nan
         self.total_reward = 0  # init to 0, but dont ckpt before end of an epi
 
-    def _track_total_reward(self, reward, done):
+    def _track_total_reward(self, reward, done, info):
         '''
         Track the total reward given reward and done signal
         This accounts for whether env is in eval mode and has multiple lives (eval)

--- a/slm_lab/env/base.py
+++ b/slm_lab/env/base.py
@@ -90,7 +90,8 @@ class BaseEnv(ABC):
         self.env_spec = spec['env'][0]  # idx 0 for single-env
         # set default
         util.set_attr(self, dict(
-            log_frequency=None,  # default to log at epi done
+            eval_frequency=10000,
+            log_frequency=10000,
             frame_op=None,
             frame_op_len=None,
             normalize_state=False,
@@ -98,8 +99,8 @@ class BaseEnv(ABC):
             num_envs=1,
         ))
         util.set_attr(self, spec['meta'], [
-            'log_frequency',
             'eval_frequency',
+            'log_frequency',
         ])
         util.set_attr(self, self.env_spec, [
             'name',
@@ -161,9 +162,6 @@ class BaseEnv(ABC):
     def _infer_venv_attr(self):
         '''Infer vectorized env attributes'''
         self.is_venv = (self.num_envs is not None and self.num_envs > 1)
-        if self.is_venv and self.log_frequency is None:
-            self.log_frequency = 10000
-            logger.info(f'Defaulted unspecified vec env.log_frequency to {self.log_frequency}')
 
     def _is_discrete(self, action_space):
         '''Check if an action space is discrete'''

--- a/slm_lab/env/base.py
+++ b/slm_lab/env/base.py
@@ -6,7 +6,6 @@ import numpy as np
 import pydash as ps
 import time
 
-NUM_EVAL = 8
 logger = logger.get_logger(__name__)
 
 
@@ -114,7 +113,7 @@ class BaseEnv(ABC):
         ])
         # override if env is for eval
         if util.in_eval_lab_modes():
-            self.num_envs = NUM_EVAL
+            self.num_envs = ps.get(spec, 'meta.rigorous_eval')
         self.to_render = util.to_render()
         self._infer_frame_attr(spec)
         self._infer_venv_attr()

--- a/slm_lab/env/base.py
+++ b/slm_lab/env/base.py
@@ -115,20 +115,20 @@ class BaseEnv(ABC):
         if util.in_eval_lab_modes():
             self.num_envs = NUM_EVAL
         self.to_render = util.to_render()
-        self._infer_frame_attr()
+        self._infer_frame_attr(spec)
         self._infer_venv_attr()
         self._set_clock()
 
         self.done = False
 
-    def _infer_frame_attr(self):
+    def _infer_frame_attr(self, spec):
         '''Infer frame attributes'''
-        seq_len = ps.get(self.spec, 'agent.0.net.seq_len')
+        seq_len = ps.get(spec, 'agent.0.net.seq_len')
         if seq_len is not None:  # infer if using RNN
             self.frame_op = 'stack'
             self.frame_op_len = seq_len
-        if self.spec['meta']['distributed'] != False:  # divide max_frame for distributed
-            self.max_frame = int(self.max_frame / self.spec['meta']['max_session'])
+        if spec['meta']['distributed'] != False:  # divide max_frame for distributed
+            self.max_frame = int(self.max_frame / spec['meta']['max_session'])
 
     def _infer_venv_attr(self):
         '''Infer vectorized env attributes'''

--- a/slm_lab/env/base.py
+++ b/slm_lab/env/base.py
@@ -143,7 +143,7 @@ class BaseEnv(ABC):
     def _set_tracking_attr(self):
         self.done = False
         self.epi_start = True
-        self.ckpt_total_reward = np.nan
+        self.total_reward_buffer = np.nan
         self.total_reward = 0  # init to 0, but dont ckpt before end of an epi
 
     def _track_total_reward(self, reward, done):
@@ -155,7 +155,19 @@ class BaseEnv(ABC):
         # TODO track both total_reward and episodic total reward
         if hasattr(self.u_env, 'raw_reward'):  # use raw_reward if reward is preprocessed
             reward = self.u_env.raw_reward
-        self.ckpt_total_reward, self.total_reward, self.epi_start = util.update_total_reward(self.ckpt_total_reward, self.total_reward, self.epi_start, reward, done)
+        self._update_total_reward(reward, done)
+
+    def _update_total_reward(self, reward, done):
+        '''
+        Method to increment total_reward from reward or env.u_env.raw_reward.
+        Generalized to single and vec env, and only update total_reward for an individual env on reaching done = True
+        '''
+        if self.total_reward_buffer is np.nan:  # init
+            self.total_reward_buffer = reward
+        else:  # reset on epi_start, else keep adding. generalized for vec env
+            self.total_reward_buffer = self.total_reward_buffer * (1 - self.epi_start) + reward
+        self.total_reward = done * self.total_reward_buffer + (1 - done) * self.total_reward
+        self.epi_start = done
 
     def _set_attr_from_u_env(self, u_env):
         '''Set the observation, action dimensions and action type from u_env'''

--- a/slm_lab/env/openai.py
+++ b/slm_lab/env/openai.py
@@ -60,7 +60,7 @@ class OpenAIEnv(BaseEnv):
         if not self.is_discrete and self.action_dim == 1:  # guard for continuous with action_dim 1, make array
             action = np.expand_dims(action, axis=-1)
         state, reward, done, info = self.u_env.step(action)
-        self._track_total_reward(reward, done)
+        self._track_total_reward(reward, done, info)
         if self.to_render:
             self.u_env.render()
         if not self.is_venv and self.clock.t > self.max_t:

--- a/slm_lab/env/openai.py
+++ b/slm_lab/env/openai.py
@@ -60,6 +60,7 @@ class OpenAIEnv(BaseEnv):
         if not self.is_discrete and self.action_dim == 1:  # guard for continuous with action_dim 1, make array
             action = np.expand_dims(action, axis=-1)
         state, reward, done, info = self.u_env.step(action)
+        self._track_total_reward(reward, done)
         if self.to_render:
             self.u_env.render()
         if not self.is_venv and self.clock.t > self.max_t:

--- a/slm_lab/env/openai.py
+++ b/slm_lab/env/openai.py
@@ -60,7 +60,7 @@ class OpenAIEnv(BaseEnv):
         if not self.is_discrete and self.action_dim == 1:  # guard for continuous with action_dim 1, make array
             action = np.expand_dims(action, axis=-1)
         state, reward, done, info = self.u_env.step(action)
-        self._track_total_reward(reward, done, info)
+        self._update_total_reward(info)
         if self.to_render:
             self.u_env.render()
         if not self.is_venv and self.clock.t > self.max_t:

--- a/slm_lab/env/unity.py
+++ b/slm_lab/env/unity.py
@@ -142,7 +142,7 @@ class UnityEnv(BaseEnv):
         reward = env_info_a.rewards[b]
         reward = try_scale_reward(self, reward)
         done = env_info_a.local_done[b]
-        self._track_total_reward(reward, done)
+        self._track_total_reward(reward, done, env_info_a)
         if not self.is_venv and self.clock.t > self.max_t:
             done = True
         self.done = done

--- a/slm_lab/env/unity.py
+++ b/slm_lab/env/unity.py
@@ -142,6 +142,7 @@ class UnityEnv(BaseEnv):
         reward = env_info_a.rewards[b]
         reward = try_scale_reward(self, reward)
         done = env_info_a.local_done[b]
+        self._track_total_reward(reward, done)
         if not self.is_venv and self.clock.t > self.max_t:
             done = True
         self.done = done

--- a/slm_lab/env/unity.py
+++ b/slm_lab/env/unity.py
@@ -69,6 +69,8 @@ class UnityEnv(BaseEnv):
         self.patch_gym_spaces(self.u_env)
         self._set_attr_from_u_env(self.u_env)
         assert self.max_t is not None
+        self.tracked_reward = 0
+        self.total_reward = 0
         logger.info(util.self_desc(self))
 
     def patch_gym_spaces(self, u_env):
@@ -142,11 +144,17 @@ class UnityEnv(BaseEnv):
         reward = env_info_a.rewards[b]
         reward = try_scale_reward(self, reward)
         done = env_info_a.local_done[b]
-        self._track_total_reward(reward, done, env_info_a)
         if not self.is_venv and self.clock.t > self.max_t:
             done = True
         self.done = done
-        return state, reward, done, env_info_a
+        info = {'env_info': env_info_a}
+        # track total_reward
+        self.tracked_reward += reward
+        if done:
+            self.total_reward = self.tracked_reward
+            self.tracked_reward = 0  # reset
+        info.update({'total_reward': self.total_reward})
+        return state, reward, done, info
 
     @lab_api
     def close(self):

--- a/slm_lab/env/vec_env.py
+++ b/slm_lab/env/vec_env.py
@@ -4,7 +4,7 @@ from abc import ABC, abstractmethod
 from collections import OrderedDict
 from functools import partial
 from gym import spaces
-from slm_lab.env.wrapper import make_gym_env, try_scale_reward
+from slm_lab.env.wrapper import make_gym_env
 from slm_lab.lib import logger
 import contextlib
 import ctypes
@@ -24,7 +24,6 @@ _NP_TO_CT = {
 
 
 # helper methods
-
 
 @contextlib.contextmanager
 def clear_mpi_env_vars():

--- a/slm_lab/env/vec_env.py
+++ b/slm_lab/env/vec_env.py
@@ -450,13 +450,11 @@ class ShmemVecEnv(VecEnv):
 class VecFrameStack(VecEnvWrapper):
     '''Frame stack wrapper for vector environment'''
 
-    def __init__(self, venv, frame_op, frame_op_len, reward_scale=None):
+    def __init__(self, venv, frame_op, frame_op_len):
         self.venv = venv
         assert frame_op in ('concat', 'stack'), 'Invalid frame_op mode'
         self.is_stack = frame_op == 'stack'
         self.frame_op_len = frame_op_len
-        self.reward_scale = reward_scale
-        self.sign_reward = self.reward_scale == 'sign'
         self.spec = venv.spec
         wos = venv.observation_space  # wrapped ob space
         if self.is_stack:
@@ -495,7 +493,7 @@ def make_gym_venv(name, num_envs=4, seed=0, frame_op=None, frame_op_len=None, re
     '''General method to create any parallel vectorized Gym env; auto wraps Atari'''
     venv = [
         # don't concat frame or clip reward on individual env; do that at vector level
-        partial(make_gym_env, name, seed + i, frame_op=None, frame_op_len=None, reward_scale=None, normalize_state=normalize_state, episode_life=episode_life)
+        partial(make_gym_env, name, seed + i, frame_op=None, frame_op_len=None, reward_scale=reward_scale, normalize_state=normalize_state, episode_life=episode_life)
         for i in range(num_envs)
     ]
     if len(venv) > 1:
@@ -503,5 +501,5 @@ def make_gym_venv(name, num_envs=4, seed=0, frame_op=None, frame_op_len=None, re
     else:
         venv = DummyVecEnv(venv)
     if frame_op is not None:
-        venv = VecFrameStack(venv, frame_op, frame_op_len, reward_scale)
+        venv = VecFrameStack(venv, frame_op, frame_op_len)
     return venv

--- a/slm_lab/env/vec_env.py
+++ b/slm_lab/env/vec_env.py
@@ -480,7 +480,6 @@ class VecFrameStack(VecEnvWrapper):
         if self.is_stack:
             obs = np.expand_dims(obs, axis=1)
         self.stackedobs[:, -self.shape_dim0:] = obs
-        rews = try_scale_reward(self, rews)
         return self.stackedobs.copy(), rews, news, infos
 
     def reset(self):

--- a/slm_lab/env/wrapper.py
+++ b/slm_lab/env/wrapper.py
@@ -9,11 +9,10 @@ import numpy as np
 
 
 def try_scale_reward(cls, reward):
-    '''Env class to scale reward and set raw_reward'''
+    '''Env class to scale reward'''
     if util.in_eval_lab_modes():  # only trigger on training
         return reward
     if cls.reward_scale is not None:
-        cls.raw_reward = reward
         if cls.sign_reward:
             reward = np.sign(reward)
         else:
@@ -276,7 +275,6 @@ class ScaleRewardEnv(gym.RewardWrapper):
         self.sign_reward = self.reward_scale == 'sign'
 
     def reward(self, reward):
-        '''Set self.raw_reward for retrieving the original reward'''
         return try_scale_reward(self, reward)
 
 

--- a/slm_lab/env/wrapper.py
+++ b/slm_lab/env/wrapper.py
@@ -170,7 +170,7 @@ class NormalizeStateEnv(gym.ObservationWrapper):
         self.alpha = 0.9999
         self.num_steps = 0
 
-    def _observation(self, observation):
+    def observation(self, observation):
         self.num_steps += 1
         self.state_mean = self.state_mean * self.alpha + \
             observation.mean() * (1 - self.alpha)

--- a/slm_lab/env/wrapper.py
+++ b/slm_lab/env/wrapper.py
@@ -288,7 +288,7 @@ class TrackReward(gym.Wrapper):
         '''
         gym.Wrapper.__init__(self, env)
         self.tracked_reward = 0
-        self.total_reward = 0
+        self.total_reward = np.nan
 
     def step(self, action):
         obs, reward, done, info = self.env.step(action)

--- a/slm_lab/experiment/analysis.py
+++ b/slm_lab/experiment/analysis.py
@@ -22,20 +22,17 @@ logger = logger.get_logger(__name__)
 
 def gen_return(agent, env):
     '''Generate return for an agent and an env in eval mode. eval_env should be a vec env with NUM_EVAL instances'''
-    # stats variables
-    vec_dones = False
+    vec_dones = False  # done check for single and vec env
     # swap ref to allow inference based on body.env
-    main_env = agent.body.env
+    body_env = agent.body.env
     agent.body.env = env
     # start eval loop
     state = env.reset()
-    done = False
     while not np.all(vec_dones):
         action = agent.act(state)
         state, reward, done, info = env.step(action)
         vec_dones = np.logical_or(vec_dones, done)  # wait till every vec slot done turns True
-    # restore swapped ref
-    agent.body.env = main_env
+    agent.body.env = body_env  # restore swapped ref
     return np.mean(env.total_reward)
 
 

--- a/slm_lab/experiment/analysis.py
+++ b/slm_lab/experiment/analysis.py
@@ -23,9 +23,6 @@ logger = logger.get_logger(__name__)
 def gen_return(agent, env):
     '''Generate return for an agent and an env in eval mode. eval_env should be a vec env with NUM_EVAL instances'''
     # stats variables
-    epi_start = True
-    ckpt_total_reward = np.nan
-    total_reward = 0
     vec_dones = False
     # swap ref to allow inference based on body.env
     main_env = agent.body.env
@@ -36,13 +33,10 @@ def gen_return(agent, env):
     while not np.all(vec_dones):
         action = agent.act(state)
         state, reward, done, info = env.step(action)
-        if hasattr(env.u_env, 'raw_reward'):  # use raw_reward if reward is preprocessed
-            reward = env.u_env.raw_reward
-        ckpt_total_reward, total_reward, epi_start = util.update_total_reward(ckpt_total_reward, total_reward, epi_start, reward, done)
         vec_dones = np.logical_or(vec_dones, done)  # wait till every vec slot done turns True
     # restore swapped ref
     agent.body.env = main_env
-    return np.mean(total_reward)
+    return np.mean(env.total_reward)
 
 
 def gen_avg_return(agent, env):

--- a/slm_lab/experiment/control.py
+++ b/slm_lab/experiment/control.py
@@ -68,8 +68,8 @@ class Session:
 
         if self.to_ckpt(env, 'eval'):
             logger.info('Running eval ckpt')
-            avg_return = analysis.gen_avg_return(agent, self.eval_env)
-            body.eval_ckpt(self.eval_env, avg_return)
+            analysis.gen_avg_return(agent, self.eval_env)
+            body.eval_ckpt(self.eval_env)
             body.log_summary('eval')
             if body.eval_reward_ma >= body.best_reward_ma:
                 body.best_reward_ma = body.eval_reward_ma

--- a/slm_lab/experiment/control.py
+++ b/slm_lab/experiment/control.py
@@ -63,20 +63,20 @@ class Session:
         '''Check then run checkpoint log/eval'''
         body = agent.body
         if self.to_ckpt(env, 'log'):
-            body.train_ckpt()
+            body.ckpt(self.env, 'train')
             body.log_summary('train')
+            if len(body.train_df) > 1:  # need > 1 row to calculate stability
+                metrics = analysis.analyze_session(self.spec, body.train_df, 'train', plot=False)
+                body.log_metrics(metrics['scalar'], 'train')
 
         if self.to_ckpt(env, 'eval'):
             logger.info('Running eval ckpt')
             analysis.gen_avg_return(agent, self.eval_env)
-            body.eval_ckpt(self.eval_env)
+            body.ckpt(self.eval_env, 'eval')
             body.log_summary('eval')
-            if body.eval_reward_ma >= body.best_reward_ma:
-                body.best_reward_ma = body.eval_reward_ma
+            if body.total_reward_ma >= body.best_total_reward_ma:
+                body.best_total_reward_ma = body.total_reward_ma
                 agent.save(ckpt='best')
-            if len(body.train_df) > 1:  # need > 1 row to calculate stability
-                metrics = analysis.analyze_session(self.spec, body.train_df, 'train', plot=False)
-                body.log_metrics(metrics['scalar'], 'train')
             if len(body.eval_df) > 1:  # need > 1 row to calculate stability
                 metrics = analysis.analyze_session(self.spec, body.eval_df, 'eval', plot=False)
                 body.log_metrics(metrics['scalar'], 'eval')

--- a/slm_lab/experiment/control.py
+++ b/slm_lab/experiment/control.py
@@ -66,7 +66,7 @@ class Session:
         if self.to_ckpt(env, 'log'):
             body.ckpt(self.env, 'train')
             body.log_summary('train')
-            if len(body.train_df) > 1:  # need > 1 row to calculate stability
+            if len(body.train_df) > 2:  # need more rows to calculate metrics
                 metrics = analysis.analyze_session(self.spec, body.train_df, 'train', plot=False)
                 body.log_metrics(metrics['scalar'], 'train')
 
@@ -79,7 +79,7 @@ class Session:
             if body.total_reward_ma >= body.best_total_reward_ma:
                 body.best_total_reward_ma = body.total_reward_ma
                 agent.save(ckpt='best')
-            if len(body.eval_df) > 1:  # need > 1 row to calculate stability
+            if len(body.eval_df) > 2:  # need more rows to calculate metrics
                 metrics = analysis.analyze_session(self.spec, body.eval_df, 'eval', plot=False)
                 body.log_metrics(metrics['scalar'], 'eval')
 

--- a/slm_lab/experiment/control.py
+++ b/slm_lab/experiment/control.py
@@ -53,10 +53,7 @@ class Session:
         clock = env.clock
         frame = clock.get()
         frequency = env.eval_frequency if mode == 'eval' else env.log_frequency
-        if frequency is None:  # default episodic
-            to_ckpt = env.done
-        else:  # normal ckpt condition by mod remainder (general for venv)
-            to_ckpt = util.frame_mod(frame, frequency, env.num_envs) or frame == clock.max_frame
+        to_ckpt = util.frame_mod(frame, frequency, env.num_envs) or frame == clock.max_frame
         return to_ckpt
 
     def try_ckpt(self, agent, env):

--- a/slm_lab/lib/util.py
+++ b/slm_lab/lib/util.py
@@ -610,7 +610,10 @@ def to_torch_batch(batch, device, is_episodic):
 
 
 def update_total_reward(ckpt_total_reward, total_reward, epi_start, reward, done):
-    '''Method to increment total_reward generalized to scalar and vec env. Only update total_reward for an env on reaching done = True'''
+    '''
+    Method to increment total_reward from reward or env.u_env.raw_reward.
+    Generalized to single and vec env, and only update total_reward for an individual env on reaching done = True
+    '''
     if ckpt_total_reward is np.nan:  # init
         ckpt_total_reward = reward
     else:  # reset on epi_start, else keep adding. generalized for vec env

--- a/slm_lab/lib/util.py
+++ b/slm_lab/lib/util.py
@@ -609,20 +609,6 @@ def to_torch_batch(batch, device, is_episodic):
     return batch
 
 
-def update_total_reward(ckpt_total_reward, total_reward, epi_start, reward, done):
-    '''
-    Method to increment total_reward from reward or env.u_env.raw_reward.
-    Generalized to single and vec env, and only update total_reward for an individual env on reaching done = True
-    '''
-    if ckpt_total_reward is np.nan:  # init
-        ckpt_total_reward = reward
-    else:  # reset on epi_start, else keep adding. generalized for vec env
-        ckpt_total_reward = ckpt_total_reward * (1 - epi_start) + reward
-    total_reward = done * ckpt_total_reward + (1 - done) * total_reward
-    epi_start = done
-    return ckpt_total_reward, total_reward, epi_start
-
-
 def write(data, data_path):
     '''
     Universal data writing method with smart data parsing

--- a/slm_lab/spec/benchmark/a2c/a2c_gae_atari.json
+++ b/slm_lab/spec/benchmark/a2c/a2c_gae_atari.json
@@ -72,8 +72,9 @@
     },
     "meta": {
       "distributed": false,
-      "log_frequency": 10000,
       "eval_frequency": 10000,
+      "log_frequency": 10000,
+      "rigorous_eval": 0,
       "max_session": 4,
       "max_trial": 1
     },

--- a/slm_lab/spec/benchmark/a2c/a2c_gae_qbert.json
+++ b/slm_lab/spec/benchmark/a2c/a2c_gae_qbert.json
@@ -1,0 +1,82 @@
+{
+  "a2c_gae_qbert": {
+    "agent": [{
+      "name": "A2C",
+      "algorithm": {
+        "name": "ActorCritic",
+        "action_pdtype": "default",
+        "action_policy": "default",
+        "explore_var_spec": null,
+        "gamma": 0.99,
+        "lam": 0.95,
+        "num_step_returns": null,
+        "entropy_coef_spec": {
+          "name": "no_decay",
+          "start_val": 0.01,
+          "end_val": 0.01,
+          "start_step": 0,
+          "end_step": 0
+        },
+        "val_loss_coef": 0.5,
+        "training_frequency": 32
+      },
+      "memory": {
+        "name": "OnPolicyBatchReplay",
+      },
+      "net": {
+        "type": "ConvNet",
+        "shared": true,
+        "conv_hid_layers": [
+          [32, 8, 4, 0, 1],
+          [64, 4, 2, 0, 1],
+          [32, 3, 1, 0, 1]
+        ],
+        "fc_hid_layers": [512],
+        "hid_layers_activation": "relu",
+        "init_fn": "orthogonal_",
+        "normalize": true,
+        "batch_norm": false,
+        "clip_grad_val": 0.5,
+        "use_same_optim": false,
+        "loss_spec": {
+          "name": "MSELoss"
+        },
+        "actor_optim_spec": {
+          "name": "RMSprop",
+          "lr": 7e-4,
+          "alpha": 0.99,
+          "eps": 1e-5
+        },
+        "critic_optim_spec": {
+          "name": "RMSprop",
+          "lr": 7e-4,
+          "alpha": 0.99,
+          "eps": 1e-5
+        },
+        "lr_scheduler_spec": null,
+        "gpu": true
+      }
+    }],
+    "env": [{
+      "name": "QbertNoFrameskip-v4",
+      "frame_op": "concat",
+      "frame_op_len": 4,
+      "reward_scale": "sign",
+      "num_envs": 16,
+      "max_t": null,
+      "max_frame": 1e7
+    }],
+    "body": {
+      "product": "outer",
+      "num": 1
+    },
+    "meta": {
+      "distributed": false,
+      "log_frequency": 10000,
+      "eval_frequency": 10000,
+      "rigorous_eval": 0,
+      "max_session": 4,
+      "max_trial": 1,
+    }
+  }
+}

--- a/slm_lab/spec/benchmark/a2c/a2c_nstep_atari.json
+++ b/slm_lab/spec/benchmark/a2c/a2c_nstep_atari.json
@@ -72,8 +72,9 @@
     },
     "meta": {
       "distributed": false,
-      "log_frequency": 10000,
       "eval_frequency": 10000,
+      "log_frequency": 10000,
+      "rigorous_eval": 0,
       "max_session": 4,
       "max_trial": 1
     },

--- a/slm_lab/spec/benchmark/a2c/a2c_nstep_qbert.json
+++ b/slm_lab/spec/benchmark/a2c/a2c_nstep_qbert.json
@@ -1,0 +1,82 @@
+{
+  "a2c_nstep_qbert": {
+    "agent": [{
+      "name": "A2C",
+      "algorithm": {
+        "name": "ActorCritic",
+        "action_pdtype": "default",
+        "action_policy": "default",
+        "explore_var_spec": null,
+        "gamma": 0.99,
+        "lam": null,
+        "num_step_returns": 11,
+        "entropy_coef_spec": {
+          "name": "no_decay",
+          "start_val": 0.01,
+          "end_val": 0.01,
+          "start_step": 0,
+          "end_step": 0
+        },
+        "val_loss_coef": 0.5,
+        "training_frequency": 5
+      },
+      "memory": {
+        "name": "OnPolicyBatchReplay"
+      },
+      "net": {
+        "type": "ConvNet",
+        "shared": true,
+        "conv_hid_layers": [
+          [32, 8, 4, 0, 1],
+          [64, 4, 2, 0, 1],
+          [32, 3, 1, 0, 1]
+        ],
+        "fc_hid_layers": [512],
+        "hid_layers_activation": "relu",
+        "init_fn": "orthogonal_",
+        "normalize": true,
+        "batch_norm": false,
+        "clip_grad_val": 0.5,
+        "use_same_optim": false,
+        "loss_spec": {
+          "name": "MSELoss"
+        },
+        "actor_optim_spec": {
+          "name": "RMSprop",
+          "lr": 7e-4,
+          "alpha": 0.99,
+          "eps": 1e-5
+        },
+        "critic_optim_spec": {
+          "name": "RMSprop",
+          "lr": 7e-4,
+          "alpha": 0.99,
+          "eps": 1e-5
+        },
+        "lr_scheduler_spec": null,
+        "gpu": true
+      }
+    }],
+    "env": [{
+      "name": "QbertNoFrameskip-v4",
+      "frame_op": "concat",
+      "frame_op_len": 4,
+      "reward_scale": "sign",
+      "num_envs": 16,
+      "max_t": null,
+      "max_frame": 1e7
+    }],
+    "body": {
+      "product": "outer",
+      "num": 1,
+    },
+    "meta": {
+      "distributed": false,
+      "log_frequency": 10000,
+      "eval_frequency": 10000,
+      "rigorous_eval": 0,
+      "max_session": 4,
+      "max_trial": 1
+    }
+  }
+}

--- a/slm_lab/spec/benchmark/a3c/a3c_gae_atari.json
+++ b/slm_lab/spec/benchmark/a3c/a3c_gae_atari.json
@@ -148,8 +148,9 @@
     },
     "meta": {
       "distributed": "shared",
-      "log_frequency": 10000,
       "eval_frequency": 10000,
+      "log_frequency": 10000,
+      "rigorous_eval": 0,
       "max_session": 16,
       "max_trial": 1
     },

--- a/slm_lab/spec/benchmark/a3c/a3c_gae_qbert.json
+++ b/slm_lab/spec/benchmark/a3c/a3c_gae_qbert.json
@@ -1,0 +1,153 @@
+{
+  "a3c_gae_qbert": {
+    "agent": [{
+      "name": "A3C",
+      "algorithm": {
+        "name": "ActorCritic",
+        "action_pdtype": "default",
+        "action_policy": "default",
+        "explore_var_spec": null,
+        "gamma": 0.99,
+        "lam": 0.95,
+        "num_step_returns": null,
+        "entropy_coef_spec": {
+          "name": "no_decay",
+          "start_val": 0.01,
+          "end_val": 0.01,
+          "start_step": 0,
+          "end_step": 0
+        },
+        "val_loss_coef": 0.5,
+        "training_frequency": 32
+      },
+      "memory": {
+        "name": "OnPolicyBatchReplay",
+      },
+      "net": {
+        "type": "ConvNet",
+        "shared": true,
+        "conv_hid_layers": [
+          [32, 8, 4, 0, 1],
+          [64, 4, 2, 0, 1],
+          [32, 3, 1, 0, 1]
+        ],
+        "fc_hid_layers": [512],
+        "hid_layers_activation": "relu",
+        "init_fn": "orthogonal_",
+        "normalize": true,
+        "batch_norm": false,
+        "clip_grad_val": 0.5,
+        "use_same_optim": false,
+        "loss_spec": {
+          "name": "MSELoss"
+        },
+        "actor_optim_spec": {
+          "name": "GlobalAdam",
+          "lr": 7e-4
+        },
+        "critic_optim_spec": {
+          "name": "GlobalAdam",
+          "lr": 7e-4
+        },
+        "lr_scheduler_spec": null,
+        "gpu": false
+      }
+    }],
+    "env": [{
+      "name": "PongNoFrameskip-v4",
+      "frame_op": "concat",
+      "frame_op_len": 4,
+      "reward_scale": "sign",
+      "num_envs": 8,
+      "max_t": null,
+      "max_frame": 1e7
+    }],
+    "body": {
+      "product": "outer",
+      "num": 1
+    },
+    "meta": {
+      "distributed": "synced",
+      "log_frequency": 10000,
+      "eval_frequency": 10000,
+      "max_session": 16,
+      "max_trial": 1,
+    }
+  },
+  "gpu_a3c_gae_pong": {
+    "agent": [{
+      "name": "A3C",
+      "algorithm": {
+        "name": "ActorCritic",
+        "action_pdtype": "default",
+        "action_policy": "default",
+        "explore_var_spec": null,
+        "gamma": 0.99,
+        "lam": 0.95,
+        "num_step_returns": null,
+        "entropy_coef_spec": {
+          "name": "no_decay",
+          "start_val": 0.01,
+          "end_val": 0.01,
+          "start_step": 0,
+          "end_step": 0
+        },
+        "val_loss_coef": 0.5,
+        "training_frequency": 32
+      },
+      "memory": {
+        "name": "OnPolicyBatchReplay",
+      },
+      "net": {
+        "type": "ConvNet",
+        "shared": true,
+        "conv_hid_layers": [
+          [32, 8, 4, 0, 1],
+          [64, 4, 2, 0, 1],
+          [32, 3, 1, 0, 1]
+        ],
+        "fc_hid_layers": [512],
+        "hid_layers_activation": "relu",
+        "init_fn": "orthogonal_",
+        "normalize": true,
+        "batch_norm": false,
+        "clip_grad_val": 0.5,
+        "use_same_optim": false,
+        "loss_spec": {
+          "name": "MSELoss"
+        },
+        "actor_optim_spec": {
+          "name": "GlobalAdam",
+          "lr": 1e-4
+        },
+        "critic_optim_spec": {
+          "name": "GlobalAdam",
+          "lr": 1e-4
+        },
+        "lr_scheduler_spec": null,
+        "gpu": false
+      }
+    }],
+    "env": [{
+      "name": "QbertNoFrameskip-v4",
+      "frame_op": "concat",
+      "frame_op_len": 4,
+      "reward_scale": "sign",
+      "num_envs": 8,
+      "max_t": null,
+      "max_frame": 1e7
+    }],
+    "body": {
+      "product": "outer",
+      "num": 1
+    },
+    "meta": {
+      "distributed": "synced",
+      "log_frequency": 10000,
+      "eval_frequency": 10000,
+      "rigorous_eval": 0,
+      "max_session": 16,
+      "max_trial": 1,
+    }
+  }
+}

--- a/slm_lab/spec/benchmark/a3c/a3c_nstep_atari.json
+++ b/slm_lab/spec/benchmark/a3c/a3c_nstep_atari.json
@@ -148,8 +148,9 @@
     },
     "meta": {
       "distributed": "shared",
-      "log_frequency": 10000,
       "eval_frequency": 10000,
+      "log_frequency": 10000,
+      "rigorous_eval": 0,
       "max_session": 16,
       "max_trial": 1
     },

--- a/slm_lab/spec/benchmark/a3c/a3c_nstep_qbert.json
+++ b/slm_lab/spec/benchmark/a3c/a3c_nstep_qbert.json
@@ -1,0 +1,153 @@
+{
+  "a3c_nstep_qbert": {
+    "agent": [{
+      "name": "A3C",
+      "algorithm": {
+        "name": "ActorCritic",
+        "action_pdtype": "default",
+        "action_policy": "default",
+        "explore_var_spec": null,
+        "gamma": 0.99,
+        "lam": null,
+        "num_step_returns": 5,
+        "entropy_coef_spec": {
+          "name": "no_decay",
+          "start_val": 0.01,
+          "end_val": 0.01,
+          "start_step": 0,
+          "end_step": 0
+        },
+        "val_loss_coef": 0.5,
+        "training_frequency": 5
+      },
+      "memory": {
+        "name": "OnPolicyBatchReplay",
+      },
+      "net": {
+        "type": "ConvNet",
+        "shared": true,
+        "conv_hid_layers": [
+          [32, 8, 4, 0, 1],
+          [64, 4, 2, 0, 1],
+          [32, 3, 1, 0, 1]
+        ],
+        "fc_hid_layers": [512],
+        "hid_layers_activation": "relu",
+        "init_fn": "orthogonal_",
+        "normalize": true,
+        "batch_norm": false,
+        "clip_grad_val": 0.5,
+        "use_same_optim": false,
+        "loss_spec": {
+          "name": "MSELoss"
+        },
+        "actor_optim_spec": {
+          "name": "GlobalAdam",
+          "lr": 1e-4
+        },
+        "critic_optim_spec": {
+          "name": "GlobalAdam",
+          "lr": 1e-4
+        },
+        "lr_scheduler_spec": null,
+        "gpu": false
+      }
+    }],
+    "env": [{
+      "name": "PongNoFrameskip-v4",
+      "frame_op": "concat",
+      "frame_op_len": 4,
+      "reward_scale": "sign",
+      "num_envs": 8,
+      "max_t": null,
+      "max_frame": 1e7
+    }],
+    "body": {
+      "product": "outer",
+      "num": 1
+    },
+    "meta": {
+      "distributed": "synced",
+      "log_frequency": 10000,
+      "eval_frequency": 10000,
+      "max_session": 16,
+      "max_trial": 1,
+    }
+  },
+  "gpu_a3c_nstep_pong": {
+    "agent": [{
+      "name": "A3C",
+      "algorithm": {
+        "name": "ActorCritic",
+        "action_pdtype": "default",
+        "action_policy": "default",
+        "explore_var_spec": null,
+        "gamma": 0.99,
+        "lam": null,
+        "num_step_returns": 5,
+        "entropy_coef_spec": {
+          "name": "no_decay",
+          "start_val": 0.01,
+          "end_val": 0.01,
+          "start_step": 0,
+          "end_step": 0
+        },
+        "val_loss_coef": 0.5,
+        "training_frequency": 5
+      },
+      "memory": {
+        "name": "OnPolicyBatchReplay",
+      },
+      "net": {
+        "type": "ConvNet",
+        "shared": true,
+        "conv_hid_layers": [
+          [32, 8, 4, 0, 1],
+          [64, 4, 2, 0, 1],
+          [32, 3, 1, 0, 1]
+        ],
+        "fc_hid_layers": [512],
+        "hid_layers_activation": "relu",
+        "init_fn": "orthogonal_",
+        "normalize": true,
+        "batch_norm": false,
+        "clip_grad_val": 0.5,
+        "use_same_optim": false,
+        "loss_spec": {
+          "name": "MSELoss"
+        },
+        "actor_optim_spec": {
+          "name": "GlobalAdam",
+          "lr": 1e-4
+        },
+        "critic_optim_spec": {
+          "name": "GlobalAdam",
+          "lr": 1e-4
+        },
+        "lr_scheduler_spec": null,
+        "gpu": false
+      }
+    }],
+    "env": [{
+      "name": "QbertNoFrameskip-v4",
+      "frame_op": "concat",
+      "frame_op_len": 4,
+      "reward_scale": "sign",
+      "num_envs": 8,
+      "max_t": null,
+      "max_frame": 1e7
+    }],
+    "body": {
+      "product": "outer",
+      "num": 1
+    },
+    "meta": {
+      "distributed": "synced",
+      "log_frequency": 10000,
+      "eval_frequency": 10000,
+      "rigorous_eval": 0,
+      "max_session": 16,
+      "max_trial": 1,
+    }
+  }
+}

--- a/slm_lab/spec/benchmark/dqn/ddqn_atari.json
+++ b/slm_lab/spec/benchmark/dqn/ddqn_atari.json
@@ -67,6 +67,7 @@
       "distributed": false,
       "eval_frequency": 10000,
       "log_frequency": 10000,
+      "rigorous_eval": 0,
       "max_session": 4,
       "max_trial": 1
     },

--- a/slm_lab/spec/benchmark/dqn/ddqn_per_atari.json
+++ b/slm_lab/spec/benchmark/dqn/ddqn_per_atari.json
@@ -69,6 +69,7 @@
       "distributed": false,
       "eval_frequency": 10000,
       "log_frequency": 10000,
+      "rigorous_eval": 0,
       "max_session": 4,
       "max_trial": 1
     },

--- a/slm_lab/spec/benchmark/dqn/ddqn_per_qbert.json
+++ b/slm_lab/spec/benchmark/dqn/ddqn_per_qbert.json
@@ -1,0 +1,77 @@
+{
+  "ddqn_per_qbert": {
+    "agent": [{
+      "name": "DoubleDQN",
+      "algorithm": {
+        "name": "DoubleDQN",
+        "action_pdtype": "Argmax",
+        "action_policy": "epsilon_greedy",
+        "explore_var_spec": {
+          "name": "linear_decay",
+          "start_val": 1.0,
+          "end_val": 0.01,
+          "start_step": 10000,
+          "end_step": 1000000
+        },
+        "gamma": 0.99,
+        "training_batch_iter": 1,
+        "training_iter": 4,
+        "training_frequency": 4,
+        "training_start_step": 10000
+      },
+      "memory": {
+        "name": "PrioritizedReplay",
+        "alpha": 0.6,
+        "epsilon": 0.0001,
+        "batch_size": 32,
+        "max_size": 200000,
+        "use_cer": false,
+      },
+      "net": {
+        "type": "ConvNet",
+        "conv_hid_layers": [
+          [32, 8, 4, 0, 1],
+          [64, 4, 2, 0, 1],
+          [64, 3, 1, 0, 1]
+        ],
+        "fc_hid_layers": [256],
+        "hid_layers_activation": "relu",
+        "init_fn": null,
+        "batch_norm": false,
+        "clip_grad_val": 10.0,
+        "loss_spec": {
+          "name": "SmoothL1Loss"
+        },
+        "optim_spec": {
+          "name": "Adam",
+          "lr": 2.5e-5,
+        },
+        "lr_scheduler_spec": null,
+        "update_type": "replace",
+        "update_frequency": 1000,
+        "gpu": true
+      }
+    }],
+    "env": [{
+      "name": "QbertNoFrameskip-v4",
+      "frame_op": "concat",
+      "frame_op_len": 4,
+      "reward_scale": "sign",
+      "num_envs": 16,
+      "max_t": null,
+      "max_frame": 4e6
+    }],
+    "body": {
+      "product": "outer",
+      "num": 1
+    },
+    "meta": {
+      "distributed": false,
+      "eval_frequency": 10000,
+      "log_frequency": 10000,
+      "rigorous_eval": 0,
+      "max_session": 4,
+      "max_trial": 1
+    }
+  }
+}

--- a/slm_lab/spec/benchmark/dqn/ddqn_qbert.json
+++ b/slm_lab/spec/benchmark/dqn/ddqn_qbert.json
@@ -1,0 +1,75 @@
+{
+  "ddqn_qbert": {
+    "agent": [{
+      "name": "DoubleDQN",
+      "algorithm": {
+        "name": "DoubleDQN",
+        "action_pdtype": "Argmax",
+        "action_policy": "epsilon_greedy",
+        "explore_var_spec": {
+          "name": "linear_decay",
+          "start_val": 1.0,
+          "end_val": 0.01,
+          "start_step": 10000,
+          "end_step": 1000000
+        },
+        "gamma": 0.99,
+        "training_batch_iter": 1,
+        "training_iter": 4,
+        "training_frequency": 4,
+        "training_start_step": 10000
+      },
+      "memory": {
+        "name": "Replay",
+        "batch_size": 32,
+        "max_size": 200000,
+        "use_cer": false,
+      },
+      "net": {
+        "type": "ConvNet",
+        "conv_hid_layers": [
+          [32, 8, 4, 0, 1],
+          [64, 4, 2, 0, 1],
+          [64, 3, 1, 0, 1]
+        ],
+        "fc_hid_layers": [256],
+        "hid_layers_activation": "relu",
+        "init_fn": null,
+        "batch_norm": false,
+        "clip_grad_val": 10.0,
+        "loss_spec": {
+          "name": "SmoothL1Loss"
+        },
+        "optim_spec": {
+          "name": "Adam",
+          "lr": 1e-4,
+        },
+        "lr_scheduler_spec": null,
+        "update_type": "replace",
+        "update_frequency": 1000,
+        "gpu": true
+      }
+    }],
+    "env": [{
+      "name": "QbertNoFrameskip-v4",
+      "frame_op": "concat",
+      "frame_op_len": 4,
+      "reward_scale": "sign",
+      "num_envs": 16,
+      "max_t": null,
+      "max_frame": 4e6
+    }],
+    "body": {
+      "product": "outer",
+      "num": 1
+    },
+    "meta": {
+      "distributed": false,
+      "eval_frequency": 10000,
+      "log_frequency": 10000,
+      "rigorous_eval": 0,
+      "max_session": 4,
+      "max_trial": 1
+    }
+  }
+}

--- a/slm_lab/spec/benchmark/dqn/dqn_atari.json
+++ b/slm_lab/spec/benchmark/dqn/dqn_atari.json
@@ -67,6 +67,7 @@
       "distributed": false,
       "eval_frequency": 10000,
       "log_frequency": 10000,
+      "rigorous_eval": 0,
       "max_session": 4,
       "max_trial": 1
     },

--- a/slm_lab/spec/benchmark/dqn/dqn_per_atari.json
+++ b/slm_lab/spec/benchmark/dqn/dqn_per_atari.json
@@ -69,6 +69,7 @@
       "distributed": false,
       "eval_frequency": 10000,
       "log_frequency": 10000,
+      "rigorous_eval": 0,
       "max_session": 4,
       "max_trial": 1
     },

--- a/slm_lab/spec/benchmark/dqn/dqn_per_qbert.json
+++ b/slm_lab/spec/benchmark/dqn/dqn_per_qbert.json
@@ -1,0 +1,77 @@
+{
+  "dqn_per_qbert": {
+    "agent": [{
+      "name": "DQN",
+      "algorithm": {
+        "name": "DQN",
+        "action_pdtype": "Argmax",
+        "action_policy": "epsilon_greedy",
+        "explore_var_spec": {
+          "name": "linear_decay",
+          "start_val": 1.0,
+          "end_val": 0.01,
+          "start_step": 10000,
+          "end_step": 1000000
+        },
+        "gamma": 0.99,
+        "training_batch_iter": 1,
+        "training_iter": 4,
+        "training_frequency": 4,
+        "training_start_step": 10000
+      },
+      "memory": {
+        "name": "PrioritizedReplay",
+        "alpha": 0.6,
+        "epsilon": 0.0001,
+        "batch_size": 32,
+        "max_size": 200000,
+        "use_cer": false
+      },
+      "net": {
+        "type": "ConvNet",
+        "conv_hid_layers": [
+          [32, 8, 4, 0, 1],
+          [64, 4, 2, 0, 1],
+          [64, 3, 1, 0, 1]
+        ],
+        "fc_hid_layers": [256],
+        "hid_layers_activation": "relu",
+        "init_fn": null,
+        "batch_norm": false,
+        "clip_grad_val": 10.0,
+        "loss_spec": {
+          "name": "SmoothL1Loss"
+        },
+        "optim_spec": {
+          "name": "Adam",
+          "lr": 2.5e-5,
+        },
+        "lr_scheduler_spec": null,
+        "update_type": "replace",
+        "update_frequency": 1000,
+        "gpu": true
+      }
+    }],
+    "env": [{
+      "name": "QbertNoFrameskip-v4",
+      "frame_op": "concat",
+      "frame_op_len": 4,
+      "reward_scale": "sign",
+      "num_envs": 16,
+      "max_t": null,
+      "max_frame": 4e6
+    }],
+    "body": {
+      "product": "outer",
+      "num": 1
+    },
+    "meta": {
+      "distributed": false,
+      "eval_frequency": 10000,
+      "log_frequency": 10000,
+      "rigorous_eval": 0,
+      "max_session": 4,
+      "max_trial": 1
+    }
+  }
+}

--- a/slm_lab/spec/benchmark/dqn/dqn_qbert.json
+++ b/slm_lab/spec/benchmark/dqn/dqn_qbert.json
@@ -1,0 +1,75 @@
+{
+  "dqn_qbert": {
+    "agent": [{
+      "name": "DQN",
+      "algorithm": {
+        "name": "DQN",
+        "action_pdtype": "Argmax",
+        "action_policy": "epsilon_greedy",
+        "explore_var_spec": {
+          "name": "linear_decay",
+          "start_val": 1.0,
+          "end_val": 0.01,
+          "start_step": 10000,
+          "end_step": 1000000
+        },
+        "gamma": 0.99,
+        "training_batch_iter": 1,
+        "training_iter": 4,
+        "training_frequency": 4,
+        "training_start_step": 10000
+      },
+      "memory": {
+        "name": "Replay",
+        "batch_size": 32,
+        "max_size": 200000,
+        "use_cer": false
+      },
+      "net": {
+        "type": "ConvNet",
+        "conv_hid_layers": [
+          [32, 8, 4, 0, 1],
+          [64, 4, 2, 0, 1],
+          [64, 3, 1, 0, 1]
+        ],
+        "fc_hid_layers": [256],
+        "hid_layers_activation": "relu",
+        "init_fn": null,
+        "batch_norm": false,
+        "clip_grad_val": 10.0,
+        "loss_spec": {
+          "name": "SmoothL1Loss"
+        },
+        "optim_spec": {
+          "name": "Adam",
+          "lr": 1e-4,
+        },
+        "lr_scheduler_spec": null,
+        "update_type": "replace",
+        "update_frequency": 1000,
+        "gpu": true
+      }
+    }],
+    "env": [{
+      "name": "QbertNoFrameskip-v4",
+      "frame_op": "concat",
+      "frame_op_len": 4,
+      "reward_scale": "sign",
+      "num_envs": 16,
+      "max_t": null,
+      "max_frame": 4e6
+    }],
+    "body": {
+      "product": "outer",
+      "num": 1
+    },
+    "meta": {
+      "distributed": false,
+      "eval_frequency": 10000,
+      "log_frequency": 10000,
+      "rigorous_eval": 0,
+      "max_session": 4,
+      "max_trial": 1,
+    }
+  }
+}

--- a/slm_lab/spec/benchmark/ppo/ppo_atari.json
+++ b/slm_lab/spec/benchmark/ppo/ppo_atari.json
@@ -79,8 +79,9 @@
     },
     "meta": {
       "distributed": false,
-      "log_frequency": 10000,
       "eval_frequency": 10000,
+      "log_frequency": 10000,
+      "rigorous_eval": 0,
       "max_session": 4,
       "max_trial": 1
     },

--- a/slm_lab/spec/benchmark/ppo/ppo_qbert.json
+++ b/slm_lab/spec/benchmark/ppo/ppo_qbert.json
@@ -1,0 +1,89 @@
+{
+  "ppo_qbert": {
+    "agent": [{
+      "name": "PPO",
+      "algorithm": {
+        "name": "PPO",
+        "action_pdtype": "default",
+        "action_policy": "default",
+        "explore_var_spec": null,
+        "gamma": 0.99,
+        "lam": 0.70,
+        "clip_eps_spec": {
+          "name": "no_decay",
+          "start_val": 0.10,
+          "end_val": 0.10,
+          "start_step": 0,
+          "end_step": 0
+        },
+        "entropy_coef_spec": {
+          "name": "no_decay",
+          "start_val": 0.01,
+          "end_val": 0.01,
+          "start_step": 0,
+          "end_step": 0
+        },
+        "val_loss_coef": 0.5,
+        "time_horizon": 128,
+        "minibatch_size": 256,
+        "training_epoch": 4
+      },
+      "memory": {
+        "name": "OnPolicyBatchReplay",
+      },
+      "net": {
+        "type": "ConvNet",
+        "shared": true,
+        "conv_hid_layers": [
+          [32, 8, 4, 0, 1],
+          [64, 4, 2, 0, 1],
+          [32, 3, 1, 0, 1]
+        ],
+        "fc_hid_layers": [512],
+        "hid_layers_activation": "relu",
+        "init_fn": "orthogonal_",
+        "normalize": true,
+        "batch_norm": false,
+        "clip_grad_val": 0.5,
+        "use_same_optim": false,
+        "loss_spec": {
+          "name": "MSELoss"
+        },
+        "actor_optim_spec": {
+          "name": "Adam",
+          "lr": 2.5e-4,
+        },
+        "critic_optim_spec": {
+          "name": "Adam",
+          "lr": 2.5e-4,
+        },
+        "lr_scheduler_spec": {
+          "name": "LinearToZero",
+          "frame": 1e7
+        },
+        "gpu": true
+      }
+    }],
+    "env": [{
+      "name": "QbertNoFrameskip-v4",
+      "frame_op": "concat",
+      "frame_op_len": 4,
+      "reward_scale": "sign",
+      "num_envs": 16,
+      "max_t": null,
+      "max_frame": 1e7
+    }],
+    "body": {
+      "product": "outer",
+      "num": 1
+    },
+    "meta": {
+      "distributed": false,
+      "log_frequency": 10000,
+      "eval_frequency": 10000,
+      "rigorous_eval": 0,
+      "max_session": 4,
+      "max_trial": 1,
+    }
+  }
+}

--- a/slm_lab/spec/experimental/misc/random.json
+++ b/slm_lab/spec/experimental/misc/random.json
@@ -108,6 +108,7 @@
       "distributed": false,
       "log_frequency": 10000,
       "eval_frequency": 10000,
+      "rigorous_eval": 0,
       "max_session": 1,
       "max_trial": 1,
     }

--- a/slm_lab/spec/experimental/misc/random.json
+++ b/slm_lab/spec/experimental/misc/random.json
@@ -92,7 +92,7 @@
       "net": {}
     }],
     "env": [{
-      "name": "QbertNoFrameskip-v4",
+      "name": "BreakoutNoFrameskip-v4",
       "frame_op": "concat",
       "frame_op_len": 4,
       "reward_scale": "sign",

--- a/slm_lab/spec/experimental/ppo/ppo_eps_search.json
+++ b/slm_lab/spec/experimental/ppo/ppo_eps_search.json
@@ -8,7 +8,7 @@
         "action_policy": "default",
         "explore_var_spec": null,
         "gamma": 0.99,
-        "lam": 0.95,
+        "lam": 0.70,
         "clip_eps_spec": {
           "name": "no_decay",
           "start_val": 0.10,

--- a/slm_lab/spec/random_baseline.py
+++ b/slm_lab/spec/random_baseline.py
@@ -83,11 +83,9 @@ def gen_random_return(env_name, seed):
     env.seed(seed)
     env.reset()
     done = False
-    total_reward = 0
     while not done:
         _, reward, done, _ = env.step(env.action_space.sample())
-        total_reward += reward
-    return total_reward
+    return env.total_reward
 
 
 def gen_random_baseline(env_name, num_eval=NUM_EVAL):

--- a/slm_lab/spec/spec_util.py
+++ b/slm_lab/spec/spec_util.py
@@ -119,6 +119,7 @@ def check_all():
 def extend_meta_spec(spec):
     '''Extend meta spec with information for lab functions'''
     extended_meta_spec = {
+        'rigorous_eval': ps.get(spec, 'meta.rigorous_eval', 8),
         # reset lab indices to -1 so that they tick to 0
         'experiment': -1,
         'trial': -1,

--- a/slm_lab/spec/spec_util.py
+++ b/slm_lab/spec/spec_util.py
@@ -35,7 +35,6 @@ SPEC_FORMAT = {
         "num": (int, list),
     },
     "meta": {
-        "eval_frequency": (int, float),
         "max_session": int,
         "max_trial": (type(None), int),
     },


### PR DESCRIPTION
## Faster evaluation alternative
- introduce `TrackReward` env wrapper as a simpler way to track total reward. This also works naturally with vec env.
- retire obsolete custom `total_reward` tracking logic
- refactor `body.ckpt` logic and env logic
- add backward-compatible `meta.rigorous_eval: int` spec to use rigorous slow eval, or fast eval by inferring `total_reward` directly from env
