### PR TITLE
use Straight-Through Gumbel Softmax

### DIFF
--- a/slm_lab/lib/distribution.py
+++ b/slm_lab/lib/distribution.py
@@ -40,6 +40,15 @@ class GumbelSoftmax(distributions.RelaxedOneHotCategorical):
         noisy_logits = self.logits - torch.log(-torch.log(u))
         return torch.argmax(noisy_logits, dim=-1)
 
+    def rsample(self, sample_shape=torch.Size()):
+        '''
+        Gumbel-softmax resampling using the Straight-Through trick.
+        Credit to Ian Temple for bringing this to our attention. To see standalone code of how this works, refer to https://gist.github.com/yzh119/fd2146d2aeb329d067568a493b20172f
+        '''
+        rout = super().rsample(sample_shape)  # differentiable
+        out = F.one_hot(torch.argmax(rout, dim=-1), self.logits.shape[-1]).float()
+        return (out - rout).detach() + rout
+
     def log_prob(self, value):
         '''value is one-hot or relaxed'''
         if value.shape != self.logits.shape:


### PR DESCRIPTION
## Straight-Through Gumbel Softmax Fix
>credit to @IanTempleGH for pointing out this bug and the available trick.

The previous Gumbel-Softmax implementation missed a Straight-Through Gumbel Softmax implementation which allows the use of reparametrizable one-hot encoding. This trick is straightforward:

Let `rout` be the reparametrized output, so it is differentiable, and let `out` be the one-hot output obtained through argmax, so it is not differentiable. We wish to obtained a differentiable one-hot output:

```python
(out - rout).detach() + rout
```

This way, we obtain the desired magnitude of one-hot, and the gradient is propagated through the right `rout` term, which is what we want.

The previous version simply used `rout` obtained directly from the `rsample` distribution. This means that when calculating the loss for SAC, the input to the Q-function was not one-hot like `[1.0, 0.0]` (hard input), but rather the underlying distribution, for example `[0.9, 0.1]` (soft input). This is a small bug and does not impact the algorithm's performance, as we will show below.

### Experiment results

Even with this small concession, discrete SAC is able to train well. With this concession fixed, the result is comparable to the previous results. A comparison using LunarLander is given below, with the difference being only the git diff in this Pull Request.

| before fix | after fix |
|:---|:---|
| ![sac_lunar_t0_trial_graph_mean_returns_ma_vs_frames](https://user-images.githubusercontent.com/8209263/66720573-4db2c080-edb3-11e9-921b-0a30add20bee.png) | ![sac_lunar_t0_trial_graph_mean_returns_ma_vs_frames](https://user-images.githubusercontent.com/8209263/66720566-3d9ae100-edb3-11e9-87e4-7d9d7517a665.png) |
| git SHA ae9b82cdd9dd9a64e9be767ec1237a04e8276804 | git SHA b8ef1737aa93661c8a45b6cce0dcb970a2a08262 |

The gradients are always propagated correctly since it will only use `rout` in both cases. The only effective difference is the magnitude of values input to the Q function, say `Q(state, action=[0.9, 0.1])` vs `Q(state, action=[1.0, 0.0])` in the before and after cases respectively. The Q function seems to be able to learn to work with both the soft and hard inputs to yield a similar output Q value, therefore learning is not impaired.

### Conclusion
Overall, the results are similar, given a bit of variations (RL results tend to have high variance). We also observe no significant difference in the performance of SAC on Atari Pong, which will be published in the future. In conclusion, this small bug does not break things/results, but good to have fixed.