### PR TITLE
add TensorBoard

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,6 +189,14 @@ Below shows a trial graph with multiple sessions:
 
 ![](https://kengz.gitbooks.io/slm-lab/content/assets/a2c_gae_pong_t0_trial_graph_mean_returns_ma_vs_frames.png)
 
+### TensorBoard
+
+Launch TensorBoard during/after a run for diagnosis.
+
+```shell
+tensorboard --log_dir=data
+```
+
 ### Enjoy mode
 
 Once a Trial completes with a good model saved into the `data/` folder, for example `data/a2c_gae_pong_2019_08_01_010727`, use the `enjoy` mode to show the trained agent playing the environment. Use the `enjoy@{prename}` mode to pick a saved trial-sesison, for example:

--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ SLM Lab integrates with multiple environment offerings:
 ### Metrics and Experimentation
 
 To facilitate better RL development, SLM Lab also comes with prebuilt *metrics* and *experimentation framework*:
-- every run generates metrics, graphs and data for analysis, as well as spec for reproducibility
+- every run generates metrics, TensorBoard summaries, graphs and data for analysis, as well as spec for reproducibility
 - scalable hyperparameter search using [Ray tune](https://ray.readthedocs.io/en/latest/tune.html)
 
 
@@ -191,11 +191,16 @@ Below shows a trial graph with multiple sessions:
 
 ### TensorBoard
 
+TensorBoard writer is initialized in `agent.body` along with other logging variables and methods. It will log summary variables, graph, network parameter histograms, and action histograms automatically during checkpoint logging. This allows for richer diagnosis of the network and policy, e.g. by seeing if the distributions shift over the course of learning.
+
 Launch TensorBoard during/after a run for diagnosis.
 
 ```shell
 tensorboard --log_dir=data
 ```
+
+![](https://user-images.githubusercontent.com/8209263/66803221-d9bc0980-eed3-11e9-92b8-0e5cd42a6eab.png)
+
 
 ### Enjoy mode
 

--- a/environment.yml
+++ b/environment.yml
@@ -13,6 +13,7 @@ dependencies:
   - numpy=1.16.3
   - openpyxl=2.6.1
   - pandas=0.24.2
+  - pillow=6.2.0
   - pip=19.1.1
   - plotly-orca=1.2.1
   - psutil=5.6.2

--- a/environment.yml
+++ b/environment.yml
@@ -26,6 +26,7 @@ dependencies:
   - pyyaml=5.1
   - regex=2019.05.25
   - scipy=1.3.0
+  - tensorboard=1.14.0
   - ujson=1.35
   - xlrd=1.2.0
   - pip:

--- a/slm_lab/agent/__init__.py
+++ b/slm_lab/agent/__init__.py
@@ -224,7 +224,10 @@ class Body:
         Log summary and useful info to TensorBoard.
         To launch TensorBoard, run `tensorboard --logdir=data` after a session/trial is completed.
         '''
-        # log to tensorboard
+        if self.env.clock.t == 0:
+            # can only log 1 net to tb now
+            net = self.agent.algorithm.net
+            self.tb_writer.add_graph(net, torch.rand(net.in_dim))
         last_row = self.train_df.iloc[-1]
         trial_index = self.agent.spec['meta']['trial']
         session_index = self.agent.spec['meta']['session']

--- a/slm_lab/agent/__init__.py
+++ b/slm_lab/agent/__init__.py
@@ -127,8 +127,8 @@ class Body:
 
     def calc_df_row(self, env):
         '''Calculate a row for updating train_df or eval_df.'''
-        frame = self.env.clock.get('frame')
-        wall_t = env.clock.get_elapsed_wall_t()
+        frame = self.env.clock.frame
+        wall_t = self.env.clock.wall_t
         fps = 0 if wall_t == 0 else frame / wall_t
         with warnings.catch_warnings():  # mute np.nanmean warning
             warnings.filterwarnings('ignore')
@@ -141,11 +141,11 @@ class Body:
 
         row = pd.Series({
             # epi and frame are always measured from training env
-            'epi': self.env.clock.get('epi'),
+            'epi': self.env.clock.epi,
             # t and reward are measured from a given env or eval_env
-            't': env.clock.get('t'),
+            't': env.clock.t,
             'wall_t': wall_t,
-            'opt_step': self.env.clock.get('opt_step'),
+            'opt_step': self.env.clock.opt_step,
             'frame': frame,
             'fps': fps,
             'total_reward': total_reward,

--- a/slm_lab/agent/__init__.py
+++ b/slm_lab/agent/__init__.py
@@ -243,9 +243,9 @@ class Body:
         frame = self.env.clock.frame
         # add main graph
         if self.env.clock.t == 0 and hasattr(self.agent.algorithm, 'net'):
-            # can only log 1 net to tb now
+            # can only log 1 net to tb now, and 4 is a good common length for stacked and rnn inputs
             net = self.agent.algorithm.net
-            self.tb_writer.add_graph(net, torch.rand(net.in_dim))
+            self.tb_writer.add_graph(net, torch.rand((4, net.in_dim)))
         # add summary variables
         last_row = self.train_df.iloc[-1]
         for k, v in last_row.items():

--- a/slm_lab/agent/__init__.py
+++ b/slm_lab/agent/__init__.py
@@ -12,7 +12,6 @@ import pydash as ps
 import torch
 import warnings
 
-
 logger = logger.get_logger(__name__)
 
 
@@ -242,10 +241,10 @@ class Body:
         idx_suffix = f'trial{trial_index}_session{session_index}'
         frame = self.env.clock.frame
         # add main graph
-        if self.env.clock.t == 0 and hasattr(self.agent.algorithm, 'net'):
+        if self.env.clock.frame == 0 and hasattr(self.agent.algorithm, 'net'):
             # can only log 1 net to tb now, and 4 is a good common length for stacked and rnn inputs
             net = self.agent.algorithm.net
-            self.tb_writer.add_graph(net, torch.rand((4, net.in_dim)))
+            self.tb_writer.add_graph(net, torch.rand(ps.flatten([4, net.in_dim])))
         # add summary variables
         last_row = self.train_df.iloc[-1]
         for k, v in last_row.items():

--- a/slm_lab/agent/__init__.py
+++ b/slm_lab/agent/__init__.py
@@ -242,9 +242,9 @@ class Body:
         frame = self.env.clock.frame
         # add main graph
         if self.env.clock.frame == 0 and hasattr(self.agent.algorithm, 'net'):
-            # can only log 1 net to tb now, and 4 is a good common length for stacked and rnn inputs
+            # can only log 1 net to tb now, and 8 is a good common length for stacked and rnn inputs
             net = self.agent.algorithm.net
-            self.tb_writer.add_graph(net, torch.rand(ps.flatten([4, net.in_dim])))
+            self.tb_writer.add_graph(net, torch.rand(ps.flatten([8, net.in_dim])))
         # add summary variables
         last_row = self.train_df.iloc[-1]
         for k, v in last_row.items():

--- a/slm_lab/agent/__init__.py
+++ b/slm_lab/agent/__init__.py
@@ -138,7 +138,7 @@ class Body:
         if self.env.is_venv:
             self.tb_actions.extend(action.tolist())
         else:
-            self.tb_actions.append(action.tolist())
+            self.tb_actions.append(action)
 
     def __str__(self):
         class_attr = util.get_class_attr(self)
@@ -242,7 +242,7 @@ class Body:
         idx_suffix = f'trial{trial_index}_session{session_index}'
         frame = self.env.clock.frame
         # add main graph
-        if self.env.clock.t == 0:
+        if self.env.clock.t == 0 and hasattr(self.agent.algorithm, 'net'):
             # can only log 1 net to tb now
             net = self.agent.algorithm.net
             self.tb_writer.add_graph(net, torch.rand(net.in_dim))

--- a/slm_lab/agent/__init__.py
+++ b/slm_lab/agent/__init__.py
@@ -76,10 +76,11 @@ class Body:
     - acts as non-gradient variable storage for monitoring and analysis
     '''
 
-    def __init__(self, env, agent_spec, aeb=(0, 0, 0)):
+    def __init__(self, env, spec, aeb=(0, 0, 0)):
         # essential reference variables
         self.agent = None  # set later
         self.env = env
+        self.spec = spec
         # agent, env, body index for multi-agent-env
         self.a, self.e, self.b = self.aeb = aeb
 
@@ -113,7 +114,7 @@ class Body:
         self.is_discrete = self.env.is_discrete
         # set the ActionPD class for sampling action
         self.action_type = policy_util.get_action_type(self.action_space)
-        self.action_pdtype = agent_spec[self.a]['algorithm'].get('action_pdtype')
+        self.action_pdtype = ps.get(spec, f'agent.{self.a}.algorithm.action_pdtype')
         if self.action_pdtype in (None, 'default'):
             self.action_pdtype = policy_util.ACTION_PDS[self.action_type][0]
         self.ActionPD = policy_util.get_action_pd_cls(self.action_pdtype, self.action_type)

--- a/slm_lab/env/base.py
+++ b/slm_lab/env/base.py
@@ -42,6 +42,7 @@ class Clock:
         self.frame = 0  # i.e. total_t
         self.epi = 0
         self.start_wall_t = time.time()
+        self.wall_t = 0
         self.batch_size = 1  # multiplier to accurately count opt steps
         self.opt_step = 0  # count the number of optimizer updates
 
@@ -59,6 +60,7 @@ class Clock:
         if unit == 't':  # timestep
             self.t += self.clock_speed
             self.frame += self.clock_speed
+            self.wall_t = self.get_elapsed_wall_t()
         elif unit == 'epi':  # episode, reset timestep
             self.epi += 1
             self.t = 0

--- a/slm_lab/experiment/control.py
+++ b/slm_lab/experiment/control.py
@@ -75,7 +75,8 @@ class Session:
             if ps.get(self.spec, 'meta.rigorous_eval'):
                 analysis.gen_avg_return(agent, self.eval_env)
             body.ckpt(self.eval_env, 'eval')
-            body.log_summary('eval')
+            if ps.get(self.spec, 'meta.rigorous_eval'):
+                body.log_summary('eval')
             if body.total_reward_ma >= body.best_total_reward_ma:
                 body.best_total_reward_ma = body.total_reward_ma
                 agent.save(ckpt='best')

--- a/slm_lab/experiment/control.py
+++ b/slm_lab/experiment/control.py
@@ -82,7 +82,8 @@ class Session:
                 agent.save(ckpt='best')
             if len(body.eval_df) > 2:  # need more rows to calculate metrics
                 metrics = analysis.analyze_session(self.spec, body.eval_df, 'eval', plot=False)
-                body.log_metrics(metrics['scalar'], 'eval')
+                if ps.get(self.spec, 'meta.rigorous_eval'):
+                    body.log_metrics(metrics['scalar'], 'eval')
 
     def run_rl(self):
         '''Run the main RL loop until clock.max_frame'''

--- a/slm_lab/experiment/control.py
+++ b/slm_lab/experiment/control.py
@@ -15,7 +15,7 @@ import torch.multiprocessing as mp
 def make_agent_env(spec, global_nets=None):
     '''Helper to create agent and env given spec'''
     env = make_env(spec)
-    body = Body(env, spec['agent'])
+    body = Body(env, spec)
     agent = Agent(spec, body=body, global_nets=global_nets)
     return agent, env
 

--- a/slm_lab/spec/demo.json
+++ b/slm_lab/spec/demo.json
@@ -60,6 +60,7 @@
     "meta": {
       "distributed": false,
       "eval_frequency": 500,
+      "log_frequency": 500,
       "max_session": 2,
       "max_trial": 1
     },

--- a/slm_lab/spec/spec_util.py
+++ b/slm_lab/spec/spec_util.py
@@ -119,7 +119,7 @@ def check_all():
 def extend_meta_spec(spec):
     '''Extend meta spec with information for lab functions'''
     extended_meta_spec = {
-        'rigorous_eval': ps.get(spec, 'meta.rigorous_eval', 8),
+        'rigorous_eval': ps.get(spec, 'meta.rigorous_eval', 0),
         # reset lab indices to -1 so that they tick to 0
         'experiment': -1,
         'trial': -1,

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -9,6 +9,7 @@ import pytest
 @pytest.fixture(scope='session')
 def test_spec():
     spec = spec_util.get('experimental/misc/base.json', 'base_case_openai')
+    spec_util.tick(spec, 'trial')
     spec = spec_util.override_test_spec(spec)
     return spec
 
@@ -73,6 +74,7 @@ def test_str():
 ])
 def test_memory(request):
     spec = spec_util.get('experimental/misc/base.json', 'base_memory')
+    spec_util.tick(spec, 'trial')
     agent, env = make_agent_env(spec)
     res = (agent.body.memory, ) + request.param
     return res
@@ -95,6 +97,7 @@ def test_memory(request):
 ])
 def test_on_policy_episodic_memory(request):
     spec = spec_util.get('experimental/misc/base.json', 'base_on_policy_memory')
+    spec_util.tick(spec, 'trial')
     agent, env = make_agent_env(spec)
     res = (agent.body.memory, ) + request.param
     return res
@@ -117,6 +120,7 @@ def test_on_policy_episodic_memory(request):
 ])
 def test_on_policy_batch_memory(request):
     spec = spec_util.get('experimental/misc/base.json', 'base_on_policy_batch_memory')
+    spec_util.tick(spec, 'trial')
     agent, env = make_agent_env(spec)
     res = (agent.body.memory, ) + request.param
     return res
@@ -139,6 +143,7 @@ def test_on_policy_batch_memory(request):
 ])
 def test_prioritized_replay_memory(request):
     spec = spec_util.get('experimental/misc/base.json', 'base_prioritized_replay_memory')
+    spec_util.tick(spec, 'trial')
     agent, env = make_agent_env(spec)
     res = (agent.body.memory, ) + request.param
     return res


### PR DESCRIPTION
## add TensorBoard

Add TensorBoard in body to auto-log summary variables, graph, network parameter histograms, action histogram. To launch TensorBoard, run `tensorboard --logdir=data` after a session/trial is completed. Example screenshot:

<img width="1423" alt="Screen Shot 2019-10-14 at 10 41 36 PM" src="https://user-images.githubusercontent.com/8209263/66803221-d9bc0980-eed3-11e9-92b8-0e5cd42a6eab.png">


## Misc
- cleanup eval-skipping ckpt logic
- disable rigorous eval by default for efficiency

