### PR TITLE
Resume a training

### DIFF
--- a/run_lab.py
+++ b/run_lab.py
@@ -52,18 +52,8 @@ def read_spec_and_run(spec_file, spec_name, lab_mode):
     else:
         lab_mode, prename = lab_mode.split('@')
         if lab_mode in TRAIN_MODES:
-            predir = f'data/{prename}'
-            os.environ['LOG_PREPATH'] = f'{predir}/log/resumed_training'  # to prevent overwriting log file
-            logger.info(f'Resume training from {prename} data folder')
-            session_spec_paths = glob(f'{predir}/*_s*_spec.json')
-            # remove session spec paths
-            trial_spec_paths = ps.difference(glob(f'{predir}/*_t*_spec.json'), session_spec_paths)
-            # TODO which session to choose ? Add a Meta argument to choose ?
-            if len(trial_spec_paths) == 0:
-                raise FileNotFoundError(f'Unable to load the spec in order to resume the training in {predir}')
-            trial_spec = trial_spec_paths[0]
-            spec = spec_util.get_resume_training_specs(spec_file, trial_spec, spec_name)
-        else: # eval mode
+            spec = spec_util.get_resume_training_specs(spec_file, spec_name)
+        else:  # eval mode
             spec = spec_util.get_eval_spec(spec_file, prename)
 
     if 'spec_params' not in spec:

--- a/slm_lab/agent/algorithm/base.py
+++ b/slm_lab/agent/algorithm/base.py
@@ -48,6 +48,11 @@ class Algorithm(ABC):
         if util.in_eval_lab_modes():
             self.load()
             logger.info(f'Loaded algorithm models for lab_mode: {util.get_lab_mode()}')
+        elif 'load_net' in self.agent.spec['meta']:
+            # we load the spec in training mode while providing a network to load
+            net_to_load = self.agent.spec['meta']['load_net']
+            self.load()
+            logger.info(f'Load previously trained network {net_to_load} for lab_mode: {util.get_lab_mode()}')
         else:
             logger.info(f'Initialized algorithm models for lab_mode: {util.get_lab_mode()}')
 

--- a/slm_lab/agent/net/net_util.py
+++ b/slm_lab/agent/net/net_util.py
@@ -210,6 +210,9 @@ def load_algorithm(algorithm):
     if util.in_eval_lab_modes():
         # load specific model in eval mode
         model_prepath = agent.spec['meta']['eval_model_prepath']
+    elif 'load_net' in agent.spec['meta']:
+        # we load network from previous training
+        model_prepath = agent.spec['meta']['load_net']
     else:
         model_prepath = agent.spec['meta']['model_prepath']
     logger.info(f'Loading algorithm {util.get_class_name(algorithm)} nets {net_names} from {model_prepath}_*.pt')

--- a/slm_lab/spec/demo_first_half.json
+++ b/slm_lab/spec/demo_first_half.json
@@ -1,0 +1,74 @@
+{
+  "dqn_cartpole": {
+    "agent": [{
+      "name": "DQN",
+      "algorithm": {
+        "name": "DQN",
+        "action_pdtype": "Argmax",
+        "action_policy": "epsilon_greedy",
+        "explore_var_spec": {
+          "name": "linear_decay",
+          "start_val": 1.0,
+          "end_val": 0.1,
+          "start_step": 0,
+          "end_step": 1000,
+        },
+        "gamma": 0.99,
+        "training_batch_iter": 8,
+        "training_iter": 4,
+        "training_frequency": 4
+      },
+      "memory": {
+        "name": "Replay",
+        "batch_size": 32,
+        "max_size": 10000,
+        "use_cer": true
+      },
+      "net": {
+        "type": "MLPNet",
+        "hid_layers": [64],
+        "hid_layers_activation": "selu",
+        "clip_grad_val": 0.5,
+        "loss_spec": {
+          "name": "MSELoss"
+        },
+        "optim_spec": {
+          "name": "Adam",
+          "lr": 0.02
+        },
+        "lr_scheduler_spec": {
+          "name": "StepLR",
+          "step_size": 1000,
+          "gamma": 0.9,
+        },
+        "update_type": "polyak",
+        "update_frequency": 32,
+        "polyak_coef": 0.1,
+        "gpu": false
+      }
+    }],
+    "env": [{
+      "name": "CartPole-v0",
+      "max_t": null,
+      "max_frame": 3000
+    }],
+    "body": {
+      "product": "outer",
+      "num": 1
+    },
+    "meta": {
+      "distributed": false,
+      "eval_frequency": 100,
+      "log_frequency": 100,
+      "max_session": 2,
+      "max_trial": 1
+    },
+    "search": {
+      "agent": [{
+        "algorithm": {
+          "gamma__grid_search": [0.5, 0.7, 0.90, 0.95, 0.99]
+        }
+      }]
+    }
+  }
+}

--- a/slm_lab/spec/demo_second_half.json
+++ b/slm_lab/spec/demo_second_half.json
@@ -1,0 +1,63 @@
+{
+  "dqn_cartpole": {
+    "agent": [{
+      "name": "DQN",
+      "algorithm": {
+        "name": "DQN",
+        "action_pdtype": "Argmax",
+        "action_policy": "epsilon_greedy",
+        "explore_var_start": 0.11,
+        "explore_var_end": 0.1,
+        "explore_anneal_epi": 1,
+        "gamma": 0.99,
+        "training_batch_iter": 8,
+        "training_iter": 4,
+        "training_frequency": 4
+      },
+      "memory": {
+        "name": "Replay",
+        "batch_size": 32,
+        "max_size": 10000,
+        "use_cer": true
+      },
+      "net": {
+        "type": "MLPNet",
+        "hid_layers": [64],
+        "hid_layers_activation": "selu",
+        "clip_grad_val": 0.5,
+        "loss_spec": {
+          "name": "MSELoss"
+        },
+        "optim_spec": {
+          "name": "Adam",
+          "lr": 0.02
+        },
+        "gpu": false
+      }
+    }],
+    "env": [{
+      "name": "CartPole-v0",
+      "max_t": null,
+      "max_frame": 7000
+    }],
+    "body": {
+      "product": "outer",
+      "num": 1
+    },
+    "meta": {
+      "distributed": false,
+      "eval_frequency": 100,
+      "log_frequency": 100,
+      "max_session": 2,
+      "max_trial": 1,
+      "load_net": "data/dqn_cartpole_2020_02_10_162907/model/dqn_cartpole_t0_s0"
+    },
+    "search": {
+      "agent": [{
+        "algorithm": {
+          "gamma__grid_search": [0.5, 0.7, 0.90, 0.95, 0.99]
+        }
+      }]
+    }
+  }
+}

--- a/slm_lab/spec/spec_util.py
+++ b/slm_lab/spec/spec_util.py
@@ -187,13 +187,13 @@ def get_param_specs(spec):
         specs.append(spec)
     return specs
 
-def get_resume_training_specs(spec_file_training, spec_file_enjoy, spec_name):
+def get_resume_training_specs(spec_file, spec_name):
     '''Get the spec in order to resume the training'''
-    logger.info(f'Load spec to resume training {spec_file_training} with enjoy sepc: {spec_file_enjoy}')
-    training_spec = get(spec_file_training, spec_name)
-    enjoy_spec = get_eval_spec(spec_file_enjoy, spec_name)
-    network_path = enjoy_spec['meta']['eval_model_prepath']
-    training_spec['meta']['load_net'] = f'{network_path}_t0_s0'
+    logger.info(f'Load spec to resume training {spec_file}')
+    training_spec = get(spec_file, spec_name)
+    enjoy_spec = get_eval_spec(spec_file, spec_name)
+    training_spec['meta']['load_model'] =  enjoy_spec['meta']['eval_model_prepath']
+    training_spec['meta']['experiment_ts'] = util.get_ts()
     return training_spec
 
 

--- a/slm_lab/spec/spec_util.py
+++ b/slm_lab/spec/spec_util.py
@@ -187,6 +187,15 @@ def get_param_specs(spec):
         specs.append(spec)
     return specs
 
+def get_resume_training_specs(spec_file_training, spec_file_enjoy, spec_name):
+    '''Get the spec in order to resume the training'''
+    logger.info(f'Load spec to resume training {spec_file_training} with enjoy sepc: {spec_file_enjoy}')
+    training_spec = get(spec_file_training, spec_name)
+    enjoy_spec = get_eval_spec(spec_file_enjoy, spec_name)
+    network_path = enjoy_spec['meta']['eval_model_prepath']
+    training_spec['meta']['load_net'] = f'{network_path}_t0_s0'
+    return training_spec
+
 
 def override_dev_spec(spec):
     spec['meta']['max_session'] = 1


### PR DESCRIPTION
## Resume a training

**This is a preliminary work**

- Addition of a new meta argument **load_net** in order to give a neural net to start the training with to an agent, so it can handle two scenarios: 
    - resume training by giving him the previously trained network
    - transfer learning approach (reuse network train for a similar task)
- New command **spec_training_file spec_name train@prename**

This pull request is linked to this issue: https://github.com/kengz/SLM-Lab/issues/444