### PR TITLE
fix color scale and orca zombie processes

### DIFF
--- a/slm_lab/experiment/analysis.py
+++ b/slm_lab/experiment/analysis.py
@@ -255,6 +255,8 @@ def analyze_session(session_spec, session_df, df_mode, plot=True):
         # plot graph
         viz.plot_session(session_spec, session_metrics, session_df, df_mode)
         viz.plot_session(session_spec, session_metrics, session_df, df_mode, ma=True)
+    # manually shut down orca server to avoid zombie processes
+    viz.pio.orca.shutdown_server()
     return session_metrics
 
 
@@ -266,6 +268,8 @@ def analyze_trial(trial_spec, session_metrics_list):
     # plot graphs
     viz.plot_trial(trial_spec, trial_metrics)
     viz.plot_trial(trial_spec, trial_metrics, ma=True)
+    # manually shut down orca server to avoid zombie processes
+    viz.pio.orca.shutdown_server()
     # zip files
     if util.get_lab_mode() == 'train':
         predir, _, _, _, _, _ = util.prepath_split(info_prepath)
@@ -284,6 +288,8 @@ def analyze_experiment(spec, trial_data_dict):
     # plot graph
     viz.plot_experiment(spec, experiment_df, METRICS_COLS)
     viz.plot_experiment_trials(spec, experiment_df, METRICS_COLS)
+    # manually shut down orca server to avoid zombie processes
+    viz.pio.orca.shutdown_server()
     # zip files
     predir, _, _, _, _, _ = util.prepath_split(info_prepath)
     zipdir = util.smart_path(predir)

--- a/slm_lab/lib/viz.py
+++ b/slm_lab/lib/viz.py
@@ -233,7 +233,7 @@ def plot_experiment(experiment_spec, experiment_df, metrics_cols):
                     'symbol': 'circle-open-dot', 'color': strength_sr, 'opacity': 0.5,
                     # dump first portion of colorscale that is too bright
                     'cmin': min_strength - 0.5 * (max_strength - min_strength), 'cmax': max_strength,
-                    'colorscale': 'YlGnBu', 'reversescale': True
+                    'colorscale': 'YlGnBu', 'reversescale': False
                 },
             )
             fig.add_trace(trace, row_idx + 1, col_idx + 1)

--- a/slm_lab/lib/viz.py
+++ b/slm_lab/lib/viz.py
@@ -10,7 +10,6 @@ import pydash as ps
 
 logger = logger.get_logger(__name__)
 pio.templates.default = 'none'  # set default white background for plots
-pio.orca.config.timeout = 30  # shutdown orca server after 30s inactivity
 # moving-average window size for plotting
 PLOT_MA_WINDOW = 100
 # warn orca failure only once


### PR DESCRIPTION
## Minor fixes

- plotly backward incompatible: fix reverse scale in experiment plot
- use manual orca shutdown to avoid zombie processes
