### PR TITLE
`train` mode with resume; `enjoy` mode refactor

### DIFF
--- a/run_lab.py
+++ b/run_lab.py
@@ -23,14 +23,19 @@ def get_spec(spec_file, spec_name, lab_mode, pre_):
     if lab_mode in TRAIN_MODES:
         if pre_ is None:  # new train trial
             spec = spec_util.get(spec_file, spec_name)
-        else:  # resume train trial with train@{predir}
+        else:
+            # for resuming with train@{predir}
+            # e.g. train@latest (fill find the latest predir)
+            # e.g. train@data/reinforce_cartpole_2020_04_13_232521
             predir = pre_
             if predir == 'latest':
                 predir = sorted(glob(f'data/{spec_name}*/'))[-1]  # get the latest predir with spec_name
             _, _, _, _, experiment_ts = util.prepath_split(predir)  # get experiment_ts to resume train spec
             logger.info(f'Resolved to train@{predir}')
             spec = spec_util.get(spec_file, spec_name, experiment_ts)
-    elif lab_mode in EVAL_MODES:
+    elif lab_mode == 'enjoy':
+        # for enjoy@{session_spec_file}
+        # e.g. enjoy@data/reinforce_cartpole_2020_04_13_232521/reinforce_cartpole_t0_s0_spec.json
         session_spec_file = pre_
         assert session_spec_file is not None, 'enjoy mode must specify a `enjoy@{session_spec_file}`'
         spec = util.read(f'{session_spec_file}')

--- a/run_lab.py
+++ b/run_lab.py
@@ -31,9 +31,9 @@ def get_spec(spec_file, spec_name, lab_mode, pre_):
             logger.info(f'Resolved to train@{predir}')
             spec = spec_util.get(spec_file, spec_name, experiment_ts)
     elif lab_mode in EVAL_MODES:
-        prename = pre_
-        assert prename is not None, 'enjoy mode must specify a `enjoy@{prename}`'
-        spec = util.read(f'{prename}_spec.json')
+        session_spec_file = pre_
+        assert session_spec_file is not None, 'enjoy mode must specify a `enjoy@{session_spec_file}`'
+        spec = util.read(f'{session_spec_file}')
     else:
         raise ValueError(f'Unrecognizable lab_mode not of {TRAIN_MODES} or {EVAL_MODES}')
     return spec

--- a/run_lab.py
+++ b/run_lab.py
@@ -27,12 +27,13 @@ def get_spec(spec_file, spec_name, lab_mode, pre_):
             predir = pre_
             if predir == 'latest':
                 predir = sorted(glob(f'data/{spec_name}*/'))[-1]  # get the latest predir with spec_name
-            _, _, _, _, experiment_ts, _ = util.prepath_split(predir)  # get experiment_ts to resume train spec
+            _, _, _, _, experiment_ts = util.prepath_split(predir)  # get experiment_ts to resume train spec
+            logger.info(f'Resolved to train@{predir}')
             spec = spec_util.get(spec_file, spec_name, experiment_ts)
     elif lab_mode in EVAL_MODES:
         prename = pre_
         assert prename is not None, 'enjoy mode must specify a `enjoy@{prename}`'
-        spec = spec_util.get_eval_spec(spec_file, prename)
+        spec = util.read(f'{prename}_spec.json')
     else:
         raise ValueError(f'Unrecognizable lab_mode not of {TRAIN_MODES} or {EVAL_MODES}')
     return spec

--- a/run_lab.py
+++ b/run_lab.py
@@ -21,11 +21,10 @@ logger = logger.get_logger(__name__)
 
 def run_spec(spec, lab_mode):
     '''Run a spec in lab_mode'''
-    os.environ['lab_mode'] = lab_mode
+    os.environ['lab_mode'] = lab_mode  # set lab_mode
+    spec = spec_util.override_spec(spec, lab_mode)  # conditionally override spec
     if lab_mode in TRAIN_MODES:
         spec_util.save(spec)  # first save the new spec
-        if lab_mode == 'dev':
-            spec = spec_util.override_dev_spec(spec)
         if lab_mode == 'search':
             spec_util.tick(spec, 'experiment')
             Experiment(spec).run()
@@ -33,7 +32,6 @@ def run_spec(spec, lab_mode):
             spec_util.tick(spec, 'trial')
             Trial(spec).run()
     elif lab_mode in EVAL_MODES:
-        spec = spec_util.override_enjoy_spec(spec)
         Session(spec).run()
     else:
         raise ValueError(f'Unrecognizable lab_mode not of {TRAIN_MODES} or {EVAL_MODES}')

--- a/run_lab.py
+++ b/run_lab.py
@@ -1,13 +1,12 @@
 # The SLM Lab entrypoint
+from glob import glob
 from slm_lab import EVAL_MODES, TRAIN_MODES
 from slm_lab.experiment import search
 from slm_lab.experiment.control import Session, Trial, Experiment
 from slm_lab.lib import logger, util
 from slm_lab.spec import spec_util
 import os
-import pydash as ps
 import sys
-import torch
 import torch.multiprocessing as mp
 
 
@@ -17,6 +16,26 @@ debug_modules = [
 debug_level = 'DEBUG'
 logger.toggle_debug(debug_modules, debug_level)
 logger = logger.get_logger(__name__)
+
+
+def get_spec(spec_file, spec_name, lab_mode, pre_):
+    '''Get spec using args processed from inputs'''
+    if lab_mode in TRAIN_MODES:
+        if pre_ is None:  # new train trial
+            spec = spec_util.get(spec_file, spec_name)
+        else:  # resume train trial with train@{predir}
+            predir = pre_
+            if predir == 'latest':
+                predir = sorted(glob(f'data/{spec_name}*/'))[-1]  # get the latest predir with spec_name
+            _, _, _, _, experiment_ts, _ = util.prepath_split(predir)  # get experiment_ts to resume train spec
+            spec = spec_util.get(spec_file, spec_name, experiment_ts)
+    elif lab_mode in EVAL_MODES:
+        prename = pre_
+        assert prename is not None, 'enjoy mode must specify a `enjoy@{prename}`'
+        spec = spec_util.get_eval_spec(spec_file, prename)
+    else:
+        raise ValueError(f'Unrecognizable lab_mode not of {TRAIN_MODES} or {EVAL_MODES}')
+    return spec
 
 
 def run_spec(spec, lab_mode):
@@ -37,14 +56,14 @@ def run_spec(spec, lab_mode):
         raise ValueError(f'Unrecognizable lab_mode not of {TRAIN_MODES} or {EVAL_MODES}')
 
 
-def read_spec_and_run(spec_file, spec_name, lab_mode):
+def get_spec_and_run(spec_file, spec_name, lab_mode):
     '''Read a spec and run it in lab mode'''
     logger.info(f'Running lab spec_file:{spec_file} spec_name:{spec_name} in mode:{lab_mode}')
-    if lab_mode in TRAIN_MODES:
-        spec = spec_util.get(spec_file, spec_name)
-    else:  # eval mode
-        lab_mode, prename = lab_mode.split('@')
-        spec = spec_util.get_eval_spec(spec_file, prename)
+    if '@' in lab_mode:  # process lab_mode@{predir/prename}
+        lab_mode, pre_ = lab_mode.split('@')
+    else:
+        pre_ = None
+    spec = get_spec(spec_file, spec_name, lab_mode, pre_)
 
     if 'spec_params' not in spec:
         run_spec(spec, lab_mode)
@@ -60,10 +79,10 @@ def main():
         job_file = args[0] if len(args) == 1 else 'job/experiments.json'
         for spec_file, spec_and_mode in util.read(job_file).items():
             for spec_name, lab_mode in spec_and_mode.items():
-                read_spec_and_run(spec_file, spec_name, lab_mode)
+                get_spec_and_run(spec_file, spec_name, lab_mode)
     else:  # run single spec
         assert len(args) == 3, f'To use sys args, specify spec_file, spec_name, lab_mode'
-        read_spec_and_run(*args)
+        get_spec_and_run(*args)
 
 
 if __name__ == '__main__':

--- a/slm_lab/agent/__init__.py
+++ b/slm_lab/agent/__init__.py
@@ -104,8 +104,7 @@ class Body:
             'epi', 't', 'wall_t', 'opt_step', 'frame', 'fps', 'total_reward', 'total_reward_ma', 'loss', 'lr',
             'explore_var', 'entropy_coef', 'entropy', 'grad_norm'])
 
-        if ps.get(self.spec, 'meta.resume'):
-            # in train@ resume mode, override from saved train_df if exists
+        if ps.get(self.spec, 'meta.resume') and util.in_train_lab_modes():
             train_df_filepath = util.get_session_df_path(self.spec, 'train')
             if os.path.exists(train_df_filepath):
                 self.train_df = util.read(train_df_filepath)

--- a/slm_lab/agent/__init__.py
+++ b/slm_lab/agent/__init__.py
@@ -103,6 +103,17 @@ class Body:
         self.train_df = pd.DataFrame(columns=[
             'epi', 't', 'wall_t', 'opt_step', 'frame', 'fps', 'total_reward', 'total_reward_ma', 'loss', 'lr',
             'explore_var', 'entropy_coef', 'entropy', 'grad_norm'])
+
+        if ps.get(self.spec, 'meta.resume'):
+            # in train@ resume mode, override from saved train_df if exists
+            train_df_filepath = util.get_session_df_path(self.spec, 'train')
+            if os.path.exists(train_df_filepath):
+                self.train_df = util.read(train_df_filepath)
+                # since train_df exists, load the last clock values from train_df
+                last_row = self.train_df.iloc[-1]
+                last_clock_vals = ps.pick(last_row, *['epi', 't', 'wall_t', 'opt_step', 'frame'])
+                util.set_attr(self.env.clock, last_clock_vals)
+
         # track eval data within run_eval. the same as train_df except for reward
         if ps.get(self.spec, 'meta.rigorous_eval'):
             self.eval_df = self.train_df.copy()

--- a/slm_lab/agent/__init__.py
+++ b/slm_lab/agent/__init__.py
@@ -109,10 +109,7 @@ class Body:
             train_df_filepath = util.get_session_df_path(self.spec, 'train')
             if os.path.exists(train_df_filepath):
                 self.train_df = util.read(train_df_filepath)
-                # since train_df exists, load the last clock values from train_df
-                last_row = self.train_df.iloc[-1]
-                last_clock_vals = ps.pick(last_row, *['epi', 't', 'wall_t', 'opt_step', 'frame'])
-                util.set_attr(self.env.clock, last_clock_vals)
+                self.env.clock.load(self.train_df)
 
         # track eval data within run_eval. the same as train_df except for reward
         if ps.get(self.spec, 'meta.rigorous_eval'):

--- a/slm_lab/agent/__init__.py
+++ b/slm_lab/agent/__init__.py
@@ -104,7 +104,7 @@ class Body:
             'epi', 't', 'wall_t', 'opt_step', 'frame', 'fps', 'total_reward', 'total_reward_ma', 'loss', 'lr',
             'explore_var', 'entropy_coef', 'entropy', 'grad_norm'])
 
-        if util.in_train_lab_modes() and ps.get(self.spec, 'meta.resume'):
+        if util.in_train_lab_modes() and self.spec['meta']['resume']:
             # in train@ mode, override from saved train_df if exists
             train_df_filepath = util.get_session_df_path(self.spec, 'train')
             if os.path.exists(train_df_filepath):
@@ -112,7 +112,7 @@ class Body:
                 self.env.clock.load(self.train_df)
 
         # track eval data within run_eval. the same as train_df except for reward
-        if ps.get(self.spec, 'meta.rigorous_eval'):
+        if self.spec['meta']['rigorous_eval']:
             self.eval_df = self.train_df.copy()
         else:
             self.eval_df = self.train_df
@@ -200,10 +200,9 @@ class Body:
 
     def get_log_prefix(self):
         '''Get the prefix for logging'''
-        spec = self.agent.spec
-        spec_name = spec['name']
-        trial_index = spec['meta']['trial']
-        session_index = spec['meta']['session']
+        spec_name = self.spec['name']
+        trial_index = self.spec['meta']['trial']
+        session_index = self.spec['meta']['session']
         prefix = f'Trial {trial_index} session {session_index} {spec_name}_t{trial_index}_s{session_index}'
         return prefix
 
@@ -240,8 +239,8 @@ class Body:
             self.tb_actions = []  # store actions for tensorboard
             logger.info(f'Using TensorBoard logging for dev mode. Run `tensorboard --logdir={log_prepath}` to start TensorBoard.')
 
-        trial_index = self.agent.spec['meta']['trial']
-        session_index = self.agent.spec['meta']['session']
+        trial_index = self.spec['meta']['trial']
+        session_index = self.spec['meta']['session']
         if session_index != 0:  # log only session 0
             return
         idx_suffix = f'trial{trial_index}_session{session_index}'

--- a/slm_lab/agent/__init__.py
+++ b/slm_lab/agent/__init__.py
@@ -104,7 +104,8 @@ class Body:
             'epi', 't', 'wall_t', 'opt_step', 'frame', 'fps', 'total_reward', 'total_reward_ma', 'loss', 'lr',
             'explore_var', 'entropy_coef', 'entropy', 'grad_norm'])
 
-        if ps.get(self.spec, 'meta.resume') and util.in_train_lab_modes():
+        if util.in_train_lab_modes() and ps.get(self.spec, 'meta.resume'):
+            # in train@ mode, override from saved train_df if exists
             train_df_filepath = util.get_session_df_path(self.spec, 'train')
             if os.path.exists(train_df_filepath):
                 self.train_df = util.read(train_df_filepath)

--- a/slm_lab/agent/__init__.py
+++ b/slm_lab/agent/__init__.py
@@ -104,8 +104,8 @@ class Body:
             'epi', 't', 'wall_t', 'opt_step', 'frame', 'fps', 'total_reward', 'total_reward_ma', 'loss', 'lr',
             'explore_var', 'entropy_coef', 'entropy', 'grad_norm'])
 
+        # in train@ mode, override from saved train_df if exists
         if util.in_train_lab_modes() and self.spec['meta']['resume']:
-            # in train@ mode, override from saved train_df if exists
             train_df_filepath = util.get_session_df_path(self.spec, 'train')
             if os.path.exists(train_df_filepath):
                 self.train_df = util.read(train_df_filepath)

--- a/slm_lab/agent/__init__.py
+++ b/slm_lab/agent/__init__.py
@@ -186,6 +186,7 @@ class Body:
         df = getattr(self, f'{df_mode}_df')
         df.loc[len(df)] = row  # append efficiently to df
         df.iloc[-1]['total_reward_ma'] = total_reward_ma = df[-viz.PLOT_MA_WINDOW:]['total_reward'].mean()
+        df.drop_duplicates('frame', inplace=True)  # remove any duplicates by the same frame
         self.total_reward_ma = total_reward_ma
 
     def get_mean_lr(self):

--- a/slm_lab/agent/__init__.py
+++ b/slm_lab/agent/__init__.py
@@ -47,7 +47,7 @@ class Agent:
     def update(self, state, action, reward, next_state, done):
         '''Update per timestep after env transitions, e.g. memory, algorithm, update agent params, train net'''
         self.body.update(state, action, reward, next_state, done)
-        if util.in_eval_lab_modes():  # eval does not update agent for training
+        if util.in_eval_lab_mode():  # eval does not update agent for training
             return
         self.body.memory.update(state, action, reward, next_state, done)
         loss = self.algorithm.train()
@@ -59,7 +59,7 @@ class Agent:
     @lab_api
     def save(self, ckpt=None):
         '''Save agent'''
-        if util.in_eval_lab_modes():  # eval does not save new models
+        if util.in_eval_lab_mode():  # eval does not save new models
             return
         self.algorithm.save(ckpt=ckpt)
 
@@ -105,7 +105,7 @@ class Body:
             'explore_var', 'entropy_coef', 'entropy', 'grad_norm'])
 
         # in train@ mode, override from saved train_df if exists
-        if util.in_train_lab_modes() and self.spec['meta']['resume']:
+        if util.in_train_lab_mode() and self.spec['meta']['resume']:
             train_df_filepath = util.get_session_df_path(self.spec, 'train')
             if os.path.exists(train_df_filepath):
                 self.train_df = util.read(train_df_filepath)

--- a/slm_lab/agent/algorithm/actor_critic.py
+++ b/slm_lab/agent/algorithm/actor_critic.py
@@ -162,7 +162,7 @@ class ActorCritic(Reinforce):
             self.critic_optim = net_util.get_optim(self.critic_net, self.critic_net.optim_spec)
             self.critic_lr_scheduler = net_util.get_lr_scheduler(self.critic_optim, self.critic_net.lr_scheduler_spec)
         net_util.set_global_nets(self, global_nets)
-        self.post_init_nets()
+        self.end_init_nets()
 
     @lab_api
     def calc_pdparam(self, x, net=None):

--- a/slm_lab/agent/algorithm/actor_critic.py
+++ b/slm_lab/agent/algorithm/actor_critic.py
@@ -278,8 +278,6 @@ class ActorCritic(Reinforce):
 
     def train(self):
         '''Train actor critic by computing the loss in batch efficiently'''
-        if util.in_eval_lab_modes():
-            return np.nan
         clock = self.body.env.clock
         if self.to_train == 1:
             batch = self.sample()

--- a/slm_lab/agent/algorithm/base.py
+++ b/slm_lab/agent/algorithm/base.py
@@ -45,7 +45,7 @@ class Algorithm(ABC):
         assert hasattr(self, 'net_names')
         for net_name in self.net_names:
             assert net_name.endswith('net'), f'Naming convention: net_name must end with "net"; got {net_name}'
-        if self.agent.spec['meta']['resume']:
+        if self.agent.spec['meta']['resume'] or util.get_lab_mode() == 'enjoy':
             self.load()
             logger.info(f'Loaded algorithm models for lab_mode: {util.get_lab_mode()}')
         else:

--- a/slm_lab/agent/algorithm/base.py
+++ b/slm_lab/agent/algorithm/base.py
@@ -37,19 +37,20 @@ class Algorithm(ABC):
         raise NotImplementedError
 
     @lab_api
-    def post_init_nets(self):
-        '''
-        Method to conditionally load models.
-        Call at the end of init_nets() after setting self.net_names
-        '''
+    def end_init_nets(self):
+        '''Checkers and conditional loaders called at the end of init_nets()'''
+        # check all nets naming
         assert hasattr(self, 'net_names')
         for net_name in self.net_names:
             assert net_name.endswith('net'), f'Naming convention: net_name must end with "net"; got {net_name}'
-        if self.agent.spec['meta']['resume'] or util.get_lab_mode() == 'enjoy':
+
+        # load algorithm if is in train@ resume or enjoy mode
+        lab_mode = util.get_lab_mode()
+        if self.agent.spec['meta']['resume'] or lab_mode == 'enjoy':
             self.load()
-            logger.info(f'Loaded algorithm models for lab_mode: {util.get_lab_mode()}')
+            logger.info(f'Loaded algorithm models for lab_mode: {lab_mode}')
         else:
-            logger.info(f'Initialized algorithm models for lab_mode: {util.get_lab_mode()}')
+            logger.info(f'Initialized algorithm models for lab_mode: {lab_mode}')
 
     @lab_api
     def calc_pdparam(self, x, net=None):

--- a/slm_lab/agent/algorithm/base.py
+++ b/slm_lab/agent/algorithm/base.py
@@ -76,8 +76,6 @@ class Algorithm(ABC):
     @lab_api
     def train(self):
         '''Implement algorithm train, or throw NotImplementedError'''
-        if util.in_eval_lab_modes():
-            return np.nan
         raise NotImplementedError
 
     @abstractmethod

--- a/slm_lab/agent/algorithm/base.py
+++ b/slm_lab/agent/algorithm/base.py
@@ -45,7 +45,7 @@ class Algorithm(ABC):
         assert hasattr(self, 'net_names')
         for net_name in self.net_names:
             assert net_name.endswith('net'), f'Naming convention: net_name must end with "net"; got {net_name}'
-        if util.in_eval_lab_modes():
+        if self.agent.spec['meta']['resume']:
             self.load()
             logger.info(f'Loaded algorithm models for lab_mode: {util.get_lab_mode()}')
         else:

--- a/slm_lab/agent/algorithm/base.py
+++ b/slm_lab/agent/algorithm/base.py
@@ -22,7 +22,7 @@ class Algorithm(ABC):
         self.body = self.agent.body
         self.init_algorithm_params()
         self.init_nets(global_nets)
-        logger.info(util.self_desc(self))
+        logger.info(util.self_desc(self, omit=['algorithm_spec', 'name', 'memory_spec', 'net_spec', 'body']))
 
     @abstractmethod
     @lab_api

--- a/slm_lab/agent/algorithm/dqn.py
+++ b/slm_lab/agent/algorithm/dqn.py
@@ -87,7 +87,7 @@ class VanillaDQN(SARSA):
         self.optim = net_util.get_optim(self.net, self.net.optim_spec)
         self.lr_scheduler = net_util.get_lr_scheduler(self.optim, self.net.lr_scheduler_spec)
         net_util.set_global_nets(self, global_nets)
-        self.post_init_nets()
+        self.end_init_nets()
 
     def calc_q_loss(self, batch):
         '''Compute the Q value loss using predicted and target Q values from the appropriate networks'''
@@ -185,7 +185,7 @@ class DQNBase(VanillaDQN):
         self.optim = net_util.get_optim(self.net, self.net.optim_spec)
         self.lr_scheduler = net_util.get_lr_scheduler(self.optim, self.net.lr_scheduler_spec)
         net_util.set_global_nets(self, global_nets)
-        self.post_init_nets()
+        self.end_init_nets()
         self.online_net = self.target_net
         self.eval_net = self.target_net
 

--- a/slm_lab/agent/algorithm/dqn.py
+++ b/slm_lab/agent/algorithm/dqn.py
@@ -130,8 +130,6 @@ class VanillaDQN(SARSA):
         For each of the batches, the target Q values (q_targets) are computed and a single training step is taken k times
         Otherwise this function does nothing.
         '''
-        if util.in_eval_lab_modes():
-            return np.nan
         clock = self.body.env.clock
         if self.to_train == 1:
             total_loss = torch.tensor(0.0)

--- a/slm_lab/agent/algorithm/dqn.py
+++ b/slm_lab/agent/algorithm/dqn.py
@@ -1,11 +1,9 @@
 from slm_lab.agent import net
-from slm_lab.agent.algorithm import policy_util
 from slm_lab.agent.algorithm.sarsa import SARSA
 from slm_lab.agent.net import net_util
-from slm_lab.lib import logger, math_util, util
+from slm_lab.lib import logger, util
 from slm_lab.lib.decorator import lab_api
 import numpy as np
-import pydash as ps
 import torch
 
 logger = logger.get_logger(__name__)

--- a/slm_lab/agent/algorithm/policy_util.py
+++ b/slm_lab/agent/algorithm/policy_util.py
@@ -142,7 +142,7 @@ def default(state, algorithm, body):
 
 def random(state, algorithm, body):
     '''Random action using gym.action_space.sample(), with the same format as default()'''
-    if body.env.is_venv and not util.in_eval_lab_modes():
+    if body.env.is_venv and util.in_train_lab_modes():
         _action = [body.action_space.sample() for _ in range(body.env.num_envs)]
     else:
         _action = [body.action_space.sample()]

--- a/slm_lab/agent/algorithm/policy_util.py
+++ b/slm_lab/agent/algorithm/policy_util.py
@@ -61,7 +61,7 @@ def guard_tensor(state, body):
     if isinstance(state, LazyFrames):
         state = state.__array__()  # realize data
     state = torch.from_numpy(state.astype(np.float32))
-    if not body.env.is_venv or util.in_eval_lab_modes():
+    if not body.env.is_venv or util.in_eval_lab_mode():
         # singleton state, unsqueeze as minibatch for net input
         state = state.unsqueeze(dim=0)
     return state
@@ -142,7 +142,7 @@ def default(state, algorithm, body):
 
 def random(state, algorithm, body):
     '''Random action using gym.action_space.sample(), with the same format as default()'''
-    if body.env.is_venv and util.in_train_lab_modes():
+    if body.env.is_venv and util.in_train_lab_mode():
         _action = [body.action_space.sample() for _ in range(body.env.num_envs)]
     else:
         _action = [body.action_space.sample()]
@@ -269,7 +269,7 @@ class VarScheduler:
 
     def update(self, algorithm, clock):
         '''Get an updated value for var'''
-        if (util.in_eval_lab_modes()) or self._updater_name == 'no_decay':
+        if (util.in_eval_lab_mode()) or self._updater_name == 'no_decay':
             return self.end_val
         step = clock.get()
         val = self._updater(self.start_val, self.end_val, self.start_step, self.end_step, step)

--- a/slm_lab/agent/algorithm/policy_util.py
+++ b/slm_lab/agent/algorithm/policy_util.py
@@ -61,7 +61,7 @@ def guard_tensor(state, body):
     if isinstance(state, LazyFrames):
         state = state.__array__()  # realize data
     state = torch.from_numpy(state.astype(np.float32))
-    if not body.env.is_venv or util.in_eval_lab_mode():
+    if not body.env.is_venv:
         # singleton state, unsqueeze as minibatch for net input
         state = state.unsqueeze(dim=0)
     return state
@@ -142,7 +142,7 @@ def default(state, algorithm, body):
 
 def random(state, algorithm, body):
     '''Random action using gym.action_space.sample(), with the same format as default()'''
-    if body.env.is_venv and util.in_train_lab_mode():
+    if body.env.is_venv:
         _action = [body.action_space.sample() for _ in range(body.env.num_envs)]
     else:
         _action = [body.action_space.sample()]

--- a/slm_lab/agent/algorithm/policy_util.py
+++ b/slm_lab/agent/algorithm/policy_util.py
@@ -5,7 +5,6 @@ from slm_lab.env.wrapper import LazyFrames
 from slm_lab.lib import distribution, logger, math_util, util
 from torch import distributions
 import numpy as np
-import pydash as ps
 import torch
 
 logger = logger.get_logger(__name__)

--- a/slm_lab/agent/algorithm/ppo.py
+++ b/slm_lab/agent/algorithm/ppo.py
@@ -168,8 +168,6 @@ class PPO(ActorCritic):
         return policy_loss
 
     def train(self):
-        if util.in_eval_lab_modes():
-            return np.nan
         clock = self.body.env.clock
         if self.to_train == 1:
             net_util.copy(self.net, self.old_net)  # update old net

--- a/slm_lab/agent/algorithm/ppo.py
+++ b/slm_lab/agent/algorithm/ppo.py
@@ -1,5 +1,4 @@
 from copy import deepcopy
-from slm_lab.agent import net
 from slm_lab.agent.algorithm import policy_util
 from slm_lab.agent.algorithm.actor_critic import ActorCritic
 from slm_lab.agent.net import net_util
@@ -7,7 +6,6 @@ from slm_lab.lib import logger, math_util, util
 from slm_lab.lib.decorator import lab_api
 import math
 import numpy as np
-import pydash as ps
 import torch
 
 logger = logger.get_logger(__name__)

--- a/slm_lab/agent/algorithm/random.py
+++ b/slm_lab/agent/algorithm/random.py
@@ -29,7 +29,7 @@ class Random(Algorithm):
     def act(self, state):
         '''Random action'''
         body = self.body
-        if body.env.is_venv and util.in_train_lab_mode():
+        if body.env.is_venv:
             action = np.array([body.action_space.sample() for _ in range(body.env.num_envs)])
         else:
             action = body.action_space.sample()

--- a/slm_lab/agent/algorithm/random.py
+++ b/slm_lab/agent/algorithm/random.py
@@ -1,7 +1,7 @@
 # The random agent algorithm
 # For basic dev purpose
 from slm_lab.agent.algorithm.base import Algorithm
-from slm_lab.lib import logger, util
+from slm_lab.lib import logger
 from slm_lab.lib.decorator import lab_api
 import numpy as np
 

--- a/slm_lab/agent/algorithm/random.py
+++ b/slm_lab/agent/algorithm/random.py
@@ -29,7 +29,7 @@ class Random(Algorithm):
     def act(self, state):
         '''Random action'''
         body = self.body
-        if body.env.is_venv and util.in_train_lab_modes():
+        if body.env.is_venv and util.in_train_lab_mode():
             action = np.array([body.action_space.sample() for _ in range(body.env.num_envs)])
         else:
             action = body.action_space.sample()

--- a/slm_lab/agent/algorithm/random.py
+++ b/slm_lab/agent/algorithm/random.py
@@ -29,7 +29,7 @@ class Random(Algorithm):
     def act(self, state):
         '''Random action'''
         body = self.body
-        if body.env.is_venv and not util.in_eval_lab_modes():
+        if body.env.is_venv and util.in_train_lab_modes():
             action = np.array([body.action_space.sample() for _ in range(body.env.num_envs)])
         else:
             action = body.action_space.sample()

--- a/slm_lab/agent/algorithm/reinforce.py
+++ b/slm_lab/agent/algorithm/reinforce.py
@@ -145,8 +145,6 @@ class Reinforce(Algorithm):
 
     @lab_api
     def train(self):
-        if util.in_eval_lab_modes():
-            return np.nan
         clock = self.body.env.clock
         if self.to_train == 1:
             batch = self.sample()

--- a/slm_lab/agent/algorithm/reinforce.py
+++ b/slm_lab/agent/algorithm/reinforce.py
@@ -87,7 +87,7 @@ class Reinforce(Algorithm):
         self.optim = net_util.get_optim(self.net, self.net.optim_spec)
         self.lr_scheduler = net_util.get_lr_scheduler(self.optim, self.net.lr_scheduler_spec)
         net_util.set_global_nets(self, global_nets)
-        self.post_init_nets()
+        self.end_init_nets()
 
     @lab_api
     def calc_pdparam(self, x, net=None):

--- a/slm_lab/agent/algorithm/sac.py
+++ b/slm_lab/agent/algorithm/sac.py
@@ -90,7 +90,7 @@ class SoftActorCritic(ActorCritic):
         self.alpha_optim = net_util.get_optim(self.log_alpha, self.net.optim_spec)
         self.alpha_lr_scheduler = net_util.get_lr_scheduler(self.alpha_optim, self.net.lr_scheduler_spec)
         net_util.set_global_nets(self, global_nets)
-        self.post_init_nets()
+        self.end_init_nets()
 
     @lab_api
     def act(self, state):

--- a/slm_lab/agent/algorithm/sac.py
+++ b/slm_lab/agent/algorithm/sac.py
@@ -187,8 +187,6 @@ class SoftActorCritic(ActorCritic):
 
     def train(self):
         '''Train actor critic by computing the loss in batch efficiently'''
-        if util.in_eval_lab_modes():
-            return np.nan
         clock = self.body.env.clock
         if self.to_train == 1:
             for _ in range(self.training_iter):

--- a/slm_lab/agent/algorithm/sarsa.py
+++ b/slm_lab/agent/algorithm/sarsa.py
@@ -5,7 +5,6 @@ from slm_lab.agent.net import net_util
 from slm_lab.lib import logger, math_util, util
 from slm_lab.lib.decorator import lab_api
 import numpy as np
-import pydash as ps
 import torch
 
 logger = logger.get_logger(__name__)

--- a/slm_lab/agent/algorithm/sarsa.py
+++ b/slm_lab/agent/algorithm/sarsa.py
@@ -134,8 +134,6 @@ class SARSA(Algorithm):
         Completes one training step for the agent if it is time to train.
         Otherwise this function does nothing.
         '''
-        if util.in_eval_lab_modes():
-            return np.nan
         clock = self.body.env.clock
         if self.to_train == 1:
             batch = self.sample()

--- a/slm_lab/agent/algorithm/sarsa.py
+++ b/slm_lab/agent/algorithm/sarsa.py
@@ -79,7 +79,7 @@ class SARSA(Algorithm):
         self.optim = net_util.get_optim(self.net, self.net.optim_spec)
         self.lr_scheduler = net_util.get_lr_scheduler(self.optim, self.net.lr_scheduler_spec)
         net_util.set_global_nets(self, global_nets)
-        self.post_init_nets()
+        self.end_init_nets()
 
     @lab_api
     def calc_pdparam(self, x, net=None):

--- a/slm_lab/agent/net/net_util.py
+++ b/slm_lab/agent/net/net_util.py
@@ -184,7 +184,7 @@ def save_algorithm(algorithm, ckpt=None):
     net_names = algorithm.net_names
     model_prepath = agent.spec['meta']['model_prepath']
     if ckpt is not None:
-        model_prepath = f'{model_prepath}_ckpt-{ckpt}'
+        model_prepath += f'_ckpt-{ckpt}'
     for net_name in net_names:
         net = getattr(algorithm, net_name)
         model_path = f'{model_prepath}_{net_name}_model.pt'
@@ -207,11 +207,9 @@ def load_algorithm(algorithm):
     '''Save all the nets for an algorithm'''
     agent = algorithm.agent
     net_names = algorithm.net_names
-    if util.in_eval_lab_modes():
-        # load specific model in eval mode
-        model_prepath = agent.spec['meta']['eval_model_prepath']
-    else:
-        model_prepath = agent.spec['meta']['model_prepath']
+    model_prepath = agent.spec['meta']['model_prepath']
+    if util.get_lab_mode() == 'enjoy':
+        model_prepath += '_ckpt-best'
     logger.info(f'Loading algorithm {util.get_class_name(algorithm)} nets {net_names} from {model_prepath}_*.pt')
     for net_name in net_names:
         net = getattr(algorithm, net_name)

--- a/slm_lab/env/base.py
+++ b/slm_lab/env/base.py
@@ -51,7 +51,7 @@ class Clock:
         last_row = train_df.iloc[-1]
         last_clock_vals = ps.pick(last_row, *['epi', 't', 'wall_t', 'opt_step', 'frame'])
         util.set_attr(self, last_clock_vals)
-        self.start_wall_t += self.wall_t
+        self.start_wall_t -= self.wall_t  # offset elapsed wall_t
 
     def get(self, unit='frame'):
         return getattr(self, unit)

--- a/slm_lab/env/base.py
+++ b/slm_lab/env/base.py
@@ -122,8 +122,7 @@ class BaseEnv(ABC):
             'max_t',
             'max_frame',
         ])
-        # override if env is for eval
-        if util.in_eval_lab_modes():
+        if util.get_lab_mode() == 'eval':  # override if env is for eval
             self.num_envs = ps.get(spec, 'meta.rigorous_eval')
         self.to_render = util.to_render()
         self._infer_frame_attr(spec)

--- a/slm_lab/env/base.py
+++ b/slm_lab/env/base.py
@@ -46,6 +46,13 @@ class Clock:
         self.batch_size = 1  # multiplier to accurately count opt steps
         self.opt_step = 0  # count the number of optimizer updates
 
+    def load(self, train_df):
+        '''Load clock from the last row of body.train_df'''
+        last_row = train_df.iloc[-1]
+        last_clock_vals = ps.pick(last_row, *['epi', 't', 'wall_t', 'opt_step', 'frame'])
+        util.set_attr(self, last_clock_vals)
+        self.start_wall_t += self.wall_t
+
     def get(self, unit='frame'):
         return getattr(self, unit)
 

--- a/slm_lab/env/openai.py
+++ b/slm_lab/env/openai.py
@@ -34,7 +34,7 @@ class OpenAIEnv(BaseEnv):
         super().__init__(spec)
         try_register_env(spec)  # register if it's a custom gym env
         seed = ps.get(spec, 'meta.random_seed')
-        episode_life = not util.in_eval_lab_modes()
+        episode_life = util.in_train_lab_modes()
         if self.is_venv:  # make vector environment
             self.u_env = make_gym_venv(name=self.name, num_envs=self.num_envs, seed=seed, frame_op=self.frame_op, frame_op_len=self.frame_op_len, image_downsize=self.image_downsize, reward_scale=self.reward_scale, normalize_state=self.normalize_state, episode_life=episode_life)
         else:

--- a/slm_lab/env/openai.py
+++ b/slm_lab/env/openai.py
@@ -34,7 +34,7 @@ class OpenAIEnv(BaseEnv):
         super().__init__(spec)
         try_register_env(spec)  # register if it's a custom gym env
         seed = ps.get(spec, 'meta.random_seed')
-        episode_life = util.in_train_lab_modes()
+        episode_life = util.in_train_lab_mode()
         if self.is_venv:  # make vector environment
             self.u_env = make_gym_venv(name=self.name, num_envs=self.num_envs, seed=seed, frame_op=self.frame_op, frame_op_len=self.frame_op_len, image_downsize=self.image_downsize, reward_scale=self.reward_scale, normalize_state=self.normalize_state, episode_life=episode_life)
         else:

--- a/slm_lab/env/wrapper.py
+++ b/slm_lab/env/wrapper.py
@@ -10,7 +10,7 @@ import numpy as np
 
 def try_scale_reward(cls, reward):
     '''Env class to scale reward'''
-    if util.in_eval_lab_modes():  # only trigger on training
+    if util.in_eval_lab_mode():  # only trigger on training
         return reward
     if cls.reward_scale is not None:
         if cls.sign_reward:

--- a/slm_lab/experiment/analysis.py
+++ b/slm_lab/experiment/analysis.py
@@ -246,7 +246,7 @@ def calc_experiment_df(trial_data_dict, info_prepath=None):
 def analyze_session(session_spec, session_df, df_mode, plot=True):
     '''Analyze session and save data, then return metrics. Note there are 2 types of session_df: body.eval_df and body.train_df'''
     info_prepath = session_spec['meta']['info_prepath']
-    session_df = session_df.copy()
+    session_df = session_df.drop_duplicates('frame')  # ensure uniqueness by frame
     assert len(session_df) > 2, f'Need more than 2 datapoint to calculate metrics'  # first datapoint at frame 0 is empty
     util.write(session_df, util.get_session_df_path(session_spec, df_mode))
     # calculate metrics
@@ -272,7 +272,7 @@ def analyze_trial(trial_spec, session_metrics_list):
     viz.pio.orca.shutdown_server()
     # zip files
     if util.get_lab_mode() == 'train':
-        predir, _, _, _, _, _ = util.prepath_split(info_prepath)
+        predir, _, _, _, _ = util.prepath_split(info_prepath)
         zipdir = util.smart_path(predir)
         shutil.make_archive(zipdir, 'zip', zipdir)
         logger.info(f'All trial data zipped to {predir}.zip')
@@ -291,7 +291,7 @@ def analyze_experiment(spec, trial_data_dict):
     # manually shut down orca server to avoid zombie processes
     viz.pio.orca.shutdown_server()
     # zip files
-    predir, _, _, _, _, _ = util.prepath_split(info_prepath)
+    predir, _, _, _, _ = util.prepath_split(info_prepath)
     zipdir = util.smart_path(predir)
     shutil.make_archive(zipdir, 'zip', zipdir)
     logger.info(f'All experiment data zipped to {predir}.zip')

--- a/slm_lab/experiment/analysis.py
+++ b/slm_lab/experiment/analysis.py
@@ -245,7 +245,7 @@ def calc_experiment_df(trial_data_dict, info_prepath=None):
 def analyze_session(session_spec, session_df, df_mode, plot=True):
     '''Analyze session and save data, then return metrics. Note there are 2 types of session_df: body.eval_df and body.train_df'''
     info_prepath = session_spec['meta']['info_prepath']
-    session_df = session_df.drop_duplicates('frame')  # ensure uniqueness by frame
+    session_df = session_df.copy()  # prevent modification
     assert len(session_df) > 2, f'Need more than 2 datapoint to calculate metrics'  # first datapoint at frame 0 is empty
     util.write(session_df, util.get_session_df_path(session_spec, df_mode))
     # calculate metrics

--- a/slm_lab/experiment/analysis.py
+++ b/slm_lab/experiment/analysis.py
@@ -1,7 +1,6 @@
 from slm_lab.lib import logger, util, viz
 from slm_lab.spec import random_baseline
 import numpy as np
-import os
 import pandas as pd
 import pydash as ps
 import shutil

--- a/slm_lab/experiment/analysis.py
+++ b/slm_lab/experiment/analysis.py
@@ -248,7 +248,7 @@ def analyze_session(session_spec, session_df, df_mode, plot=True):
     info_prepath = session_spec['meta']['info_prepath']
     session_df = session_df.copy()
     assert len(session_df) > 2, f'Need more than 2 datapoint to calculate metrics'  # first datapoint at frame 0 is empty
-    util.write(session_df, f'{info_prepath}_session_df_{df_mode}.csv')
+    util.write(session_df, util.get_session_df_path(session_spec, df_mode))
     # calculate metrics
     session_metrics = calc_session_metrics(session_df, ps.get(session_spec, 'env.0.name'), info_prepath, df_mode)
     if plot:

--- a/slm_lab/experiment/control.py
+++ b/slm_lab/experiment/control.py
@@ -52,7 +52,7 @@ class Session:
 
     def to_ckpt(self, env, mode='eval'):
         '''Check with clock whether to run log/eval ckpt: at the start, save_freq, and the end'''
-        if mode == 'eval' and util.in_eval_lab_modes():  # avoid double-eval: eval-ckpt in eval mode
+        if mode == 'eval' and util.in_eval_lab_mode():  # avoid double-eval: eval-ckpt in eval mode
             return False
         clock = env.clock
         frame = clock.get()

--- a/slm_lab/experiment/control.py
+++ b/slm_lab/experiment/control.py
@@ -66,6 +66,7 @@ class Session:
         if self.to_ckpt(env, 'log'):
             body.ckpt(self.env, 'train')
             body.log_summary('train')
+            agent.save()  # save the latest ckpt
             if body.total_reward_ma >= body.best_total_reward_ma:
                 body.best_total_reward_ma = body.total_reward_ma
                 agent.save(ckpt='best')

--- a/slm_lab/lib/util.py
+++ b/slm_lab/lib/util.py
@@ -245,12 +245,12 @@ def insert_folder(prepath, folder):
     return '/'.join(split_path)
 
 
-def in_eval_lab_modes():
+def in_eval_lab_mode():
     '''Check if lab_mode is one of EVAL_MODES'''
     return get_lab_mode() in EVAL_MODES
 
 
-def in_train_lab_modes():
+def in_train_lab_mode():
     '''Check if lab_mode is one of TRAIN_MODES'''
     return get_lab_mode() in TRAIN_MODES
 

--- a/slm_lab/lib/util.py
+++ b/slm_lab/lib/util.py
@@ -234,6 +234,12 @@ def get_prepath(spec, unit='experiment'):
     return prepath
 
 
+def get_session_df_path(session_spec, df_mode):
+    '''Method to return standard filepath for session_df (agent.body.train_df/eval_df) for saving and loading'''
+    info_prepath = session_spec['meta']['info_prepath']
+    return f'{info_prepath}_session_df_{df_mode}.csv'
+
+
 def get_ts(pattern=FILE_TS_FORMAT):
     '''
     Get current ts, defaults to format used for filename

--- a/slm_lab/lib/util.py
+++ b/slm_lab/lib/util.py
@@ -404,24 +404,6 @@ def read_as_plain(data_path, **kwargs):
     return data
 
 
-def run_cmd(cmd):
-    '''Run shell command'''
-    print(f'+ {cmd}')
-    proc = subprocess.Popen(cmd, cwd=ROOT_DIR, shell=True, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, close_fds=True)
-    return proc
-
-
-def run_cmd_wait(proc):
-    '''Wait on a running process created by util.run_cmd and print its stdout'''
-    for line in proc.stdout:
-        print(line.decode(), end='')
-    output = proc.communicate()[0]
-    if proc.returncode != 0:
-        raise subprocess.CalledProcessError(proc.args, proc.returncode, output)
-    else:
-        return output
-
-
 def self_desc(cls, omit=None):
     '''Method to get self description, used at init.'''
     desc_list = [f'{get_class_name(cls)}:']

--- a/slm_lab/lib/util.py
+++ b/slm_lab/lib/util.py
@@ -330,9 +330,9 @@ def prepath_split(prepath):
 
 def prepath_to_idxs(prepath):
     '''Extract trial index and session index from prepath if available'''
-    tidxs = re.findall('_t(\d+)', prepath)
+    tidxs = re.findall(r'_t(\d+)', prepath)
     trial_index = int(tidxs[0]) if tidxs else None
-    sidxs = re.findall('_s(\d+)', prepath)
+    sidxs = re.findall(r'_s(\d+)', prepath)
     session_index = int(sidxs[0]) if sidxs else None
     return trial_index, session_index
 
@@ -378,7 +378,6 @@ def read(data_path, **kwargs):
 
 def read_as_df(data_path, **kwargs):
     '''Submethod to read data as DataFrame'''
-    ext = get_file_ext(data_path)
     data = pd.read_csv(data_path, **kwargs)
     return data
 
@@ -591,7 +590,6 @@ def write(data, data_path):
 def write_as_df(data, data_path):
     '''Submethod to write data as DataFrame'''
     df = cast_df(data)
-    ext = get_file_ext(data_path)
     df.to_csv(data_path, index=False)
     return data_path
 

--- a/slm_lab/lib/util.py
+++ b/slm_lab/lib/util.py
@@ -3,7 +3,7 @@ from contextlib import contextmanager
 from datetime import datetime
 from importlib import reload
 from pprint import pformat
-from slm_lab import ROOT_DIR, EVAL_MODES
+from slm_lab import ROOT_DIR, EVAL_MODES, TRAIN_MODES
 import cv2
 import json
 import numpy as np
@@ -248,6 +248,11 @@ def insert_folder(prepath, folder):
 def in_eval_lab_modes():
     '''Check if lab_mode is one of EVAL_MODES'''
     return get_lab_mode() in EVAL_MODES
+
+
+def in_train_lab_modes():
+    '''Check if lab_mode is one of TRAIN_MODES'''
+    return get_lab_mode() in TRAIN_MODES
 
 
 def is_jupyter():

--- a/slm_lab/lib/util.py
+++ b/slm_lab/lib/util.py
@@ -422,12 +422,15 @@ def run_cmd_wait(proc):
         return output
 
 
-def self_desc(cls):
+def self_desc(cls, omit=None):
     '''Method to get self description, used at init.'''
     desc_list = [f'{get_class_name(cls)}:']
+    omit_list = ps.compact(cast_list(omit))
     for k, v in get_class_attr(cls).items():
-        if k == 'spec':
-            desc_v = v['name']
+        if k in omit_list:
+            continue
+        if k == 'spec':  # spec components are described at their object level; for session, only desc spec.meta
+            desc_v = pformat(v['meta'])
         elif ps.is_dict(v) or ps.is_dict(ps.head(v)):
             desc_v = pformat(v)
         else:

--- a/slm_lab/spec/spec_util.py
+++ b/slm_lab/spec/spec_util.py
@@ -116,8 +116,12 @@ def check_all():
     return True
 
 
-def extend_meta_spec(spec):
-    '''Extend meta spec with information for lab functions'''
+def extend_meta_spec(spec, experiment_ts=None):
+    '''
+    Extend meta spec with information for lab functions
+    @param dict:spec
+    @param str:experiment_ts Use this experiment_ts if given; used for resuming training
+    '''
     extended_meta_spec = {
         'rigorous_eval': ps.get(spec, 'meta.rigorous_eval', 0),
         # reset lab indices to -1 so that they tick to 0
@@ -125,7 +129,8 @@ def extend_meta_spec(spec):
         'trial': -1,
         'session': -1,
         'cuda_offset': int(os.environ.get('CUDA_OFFSET', 0)),
-        'experiment_ts': util.get_ts(),
+        'resume': experiment_ts is not None,
+        'experiment_ts': experiment_ts or util.get_ts(),
         'prepath': None,
         # ckpt extends prepath, e.g. ckpt_str = ckpt-epi10-totalt1000
         'ckpt': None,
@@ -137,10 +142,13 @@ def extend_meta_spec(spec):
     return spec
 
 
-def get(spec_file, spec_name):
+def get(spec_file, spec_name, experiment_ts=None):
     '''
     Get an experiment spec from spec_file, spec_name.
     Auto-check spec.
+    @param str:spec_file
+    @param str:spec_name
+    @param str:experiment_ts Use this experiment_ts if given; used for resuming training
     @example
 
     spec = spec_util.get('demo.json', 'dqn_cartpole')
@@ -156,7 +164,7 @@ def get(spec_file, spec_name):
         spec = spec_dict[spec_name]
         # fill-in info at runtime
         spec['name'] = spec_name
-        spec = extend_meta_spec(spec)
+        spec = extend_meta_spec(spec, experiment_ts)
     check(spec)
     return spec
 

--- a/slm_lab/spec/spec_util.py
+++ b/slm_lab/spec/spec_util.py
@@ -188,24 +188,18 @@ def get_param_specs(spec):
     return specs
 
 
-def override_dev_spec(spec):
+def _override_dev_spec(spec):
     spec['meta']['max_session'] = 1
     spec['meta']['max_trial'] = 2
     return spec
 
 
-def override_enjoy_spec(spec):
+def _override_enjoy_spec(spec):
     spec['meta']['max_session'] = 1
     return spec
 
 
-def override_eval_spec(spec):
-    spec['meta']['max_session'] = 1
-    # evaluate by episode is set in env clock init in env/base.py
-    return spec
-
-
-def override_test_spec(spec):
+def _override_test_spec(spec):
     for agent_spec in spec['agent']:
         # onpolicy freq is episodic
         freq = 1 if agent_spec['memory']['name'] == 'OnPolicyReplay' else 8
@@ -223,6 +217,18 @@ def override_test_spec(spec):
     spec['meta']['eval_frequency'] = 10
     spec['meta']['max_session'] = 1
     spec['meta']['max_trial'] = 2
+    return spec
+
+
+def override_spec(spec, mode):
+    '''Override spec based on the (lab_)mode, do nothing otherwise.'''
+    overrider = {
+        'dev': _override_dev_spec,
+        'enjoy': _override_enjoy_spec,
+        'test': _override_test_spec,
+    }.get(mode)
+    if overrider is not None:
+        overrider(spec)
     return spec
 
 

--- a/slm_lab/spec/spec_util.py
+++ b/slm_lab/spec/spec_util.py
@@ -5,7 +5,6 @@ from slm_lab.lib import logger, util
 from string import Template
 import itertools
 import json
-import numpy as np
 import os
 import pydash as ps
 

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -10,7 +10,7 @@ import pytest
 def test_spec():
     spec = spec_util.get('experimental/misc/base.json', 'base_case_openai')
     spec_util.tick(spec, 'trial')
-    spec = spec_util.override_test_spec(spec)
+    spec = spec_util.override_spec(spec, 'test')
     return spec
 
 

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -1,5 +1,4 @@
 from slm_lab.experiment.control import make_agent_env
-from slm_lab.lib import util
 from slm_lab.spec import spec_util
 import numpy as np
 import pandas as pd

--- a/test/experiment/test_control.py
+++ b/test/experiment/test_control.py
@@ -27,7 +27,7 @@ def test_trial(test_spec):
 def test_trial_demo():
     spec = spec_util.get('demo.json', 'dqn_cartpole')
     spec_util.save(spec, unit='experiment')
-    spec = spec_util.override_test_spec(spec)
+    spec = spec_util.override_spec(spec, 'test')
     spec_util.tick(spec, 'trial')
     trial_metrics = Trial(spec).run()
     assert isinstance(trial_metrics, dict)
@@ -53,7 +53,7 @@ def test_demo_performance():
 def test_experiment():
     spec = spec_util.get('demo.json', 'dqn_cartpole')
     spec_util.save(spec, unit='experiment')
-    spec = spec_util.override_test_spec(spec)
+    spec = spec_util.override_spec(spec, 'test')
     spec_util.tick(spec, 'experiment')
     experiment_df = Experiment(spec).run()
     assert isinstance(experiment_df, pd.DataFrame)

--- a/test/lib/test_util.py
+++ b/test/lib/test_util.py
@@ -86,13 +86,12 @@ def test_is_jupyter():
 
 def test_prepath_split():
     prepath = 'data/dqn_pong_2018_12_02_082510/dqn_pong_t0_s0'
-    predir, prefolder, prename, spec_name, experiment_ts, ckpt = util.prepath_split(prepath)
+    predir, prefolder, prename, spec_name, experiment_ts = util.prepath_split(prepath)
     assert predir == 'data/dqn_pong_2018_12_02_082510'
     assert prefolder == 'dqn_pong_2018_12_02_082510'
     assert prename == 'dqn_pong_t0_s0'
     assert spec_name == 'dqn_pong'
     assert experiment_ts == '2018_12_02_082510'
-    assert ckpt == None
 
 
 def test_set_attr():

--- a/test/spec/test_dist_spec.py
+++ b/test/spec/test_dist_spec.py
@@ -12,7 +12,7 @@ import pytest
 # helper method to run all tests in test_spec
 def run_trial_test_dist(spec_file, spec_name=False):
     spec = spec_util.get(spec_file, spec_name)
-    spec = spec_util.override_test_spec(spec)
+    spec = spec_util.override_spec(spec, 'test')
     spec_util.tick(spec, 'trial')
     spec['meta']['distributed'] = 'synced'
     spec['meta']['max_session'] = 2

--- a/test/spec/test_spec.py
+++ b/test/spec/test_spec.py
@@ -7,7 +7,7 @@ import pytest
 # helper method to run all tests in test_spec
 def run_trial_test(spec_file, spec_name=False):
     spec = spec_util.get(spec_file, spec_name)
-    spec = spec_util.override_test_spec(spec)
+    spec = spec_util.override_spec(spec, 'test')
     spec_util.tick(spec, 'trial')
     trial = Trial(spec)
     trial_metrics = trial.run()


### PR DESCRIPTION
## `train` mode with resume
Fixes #444. This adds capability to resume a training in a past-future-consistent manner. See explanation below.

Suppose we run a training with 10M frames to completion, and see that further improvements may be possible if we had run it for longer, say 20M frames. If only we could travel back in time and set the frames to 20M to begin with.

This resume mode allows us to do that without time traveling. We can the spec file in the present and resume training so the run picks up where it left off as if it was already using the edited spec. Of course, the modification to the spec file must itself be past-future consistent, e.g. we cannot suddenly modify the initial learning rate or variable values.

To achieve this, the lab relies on 3 objects and their `load` methods
- `algorithm.load()`: this already loads the algorithm and their networks for enjoy mode, now it's used for `train@` mode
- `body.train_df`: this object tracks the training metrics data, hence needs to be loaded
- `env.clock`: this tracks the time within the session.

Since everything in the lab runs according to `env.clock`, the above are all we need to restore for resuming training. Once the network and training metrics are restored, and the clock is set correctly, everything runs from the designated point in time.

**NOTE:** for off-policy algorithms the replay memory is not restored simply due to the cost of storing replay data (GBs of data per session and slow write during frequent checkpoints). Hence the behavior of off-policy replay is slightly different: it will need to fill up again from resume-point and training will only start again at the specified replay size threshold, so we will lose a small fraction of the total timesteps.

### Usage example

Specify train mode as `train@{predir}`, where `{predir} is the data directory of the last training run, or simply use `latest` to use the latest. e.g.:
```bash
python run_lab.py slm_lab/spec/benchmark/reinforce/reinforce_cartpole.json reinforce_cartpole train
# terminate run before its completion
# optionally edit the spec file in a forward-compatible manner
# run resume with either of the commands
python run_lab.py slm_lab/spec/benchmark/reinforce/reinforce_cartpole.json reinforce_cartpole train@latest
# or to use a specific run folder
python run_lab.py slm_lab/spec/benchmark/reinforce/reinforce_cartpole.json reinforce_cartpole train@data/reinforce_cartpole_2020_04_13_232521
```

## `enjoy` mode refactor

The `train@` resume mode API allows for the `enjoy` mode to be refactored. Both share similar syntax. Continuing with the example above, to enjoy a train model, we now use:
```bash
python run_lab.py slm_lab/spec/benchmark/reinforce/reinforce_cartpole.json reinforce_cartpole enjoy@data/reinforce_cartpole_2020_04_13_232521/reinforce_cartpole_t0_s0_spec.json
```

The refactored changes are summarized below:
- API: `enjoy@{prename}` -> `enjoy@{session_spec_file}
- removed `eval_model_prepath` and `ckpt` injection from meta spec and related methods
- removed the need for `ckpt` entirely and related methods
- refactored spec methods accordingly

## Misc
- cleaned up logging and `self_desc` for better clarity
- renamed `read_spec_and_run` -> `get_spec_and_run`
- renamed `post_init_nets` -> `end_init_nets`
- renamed `in_eval_lab_modes` -> `in_eval_lab_mode`
- added counterpart `in_train_lab_mode`