### PR TITLE
Update setup_macOS

### DIFF
--- a/bin/setup_macOS
+++ b/bin/setup_macOS
@@ -14,7 +14,7 @@ fi
 if brew cask --version | grep --quiet "Cask" >/dev/null; then
   true
 else
-  brew tap caskroom/cask
+  brew tap homebrew/cask
 fi
 
 echo "--- Installing brew system dependencies ---"


### PR DESCRIPTION
Caskroom is deprecated and moved to homebrew.