### PR TITLE
Add missing conda env update command to arch install

### DIFF
--- a/bin/setup_arch
+++ b/bin/setup_arch
@@ -31,6 +31,7 @@ fi
 # conda env remove -n lab -y
 # conda env export > environment.yml
 echo "--- Updating Conda environment ---"
+conda env update -f environment.yml
 
 source ~/.bashrc
 echo "--- Lab setup complete ---"


### PR DESCRIPTION
## Fix Arch install

- Add missing env update to arch install according to ubuntu install

Somehow arch install currently only creates the env but does not update it.
This is confusing for the user as the script even outputs "Updating Conda environment".