### PR TITLE
use native json for stabler parsing feature

### DIFF
--- a/slm_lab/lib/util.py
+++ b/slm_lab/lib/util.py
@@ -394,7 +394,7 @@ def read_as_plain(data_path, **kwargs):
     open_file = open(data_path, 'r')
     ext = get_file_ext(data_path)
     if ext == '.json':
-        data = ujson.load(open_file, **kwargs)
+        data = json.load(open_file, **kwargs)
     elif ext == '.yml':
         data = yaml.load(open_file, **kwargs)
     else:


### PR DESCRIPTION
_details filled in by @kengz_
>Some users experience JSON parsing error caused by a newer version of `ujson`. This replaces the `ujson` call when parsing spec files with the native `json` package for better stability.