### PR TITLE
upgrade plotly, replace orca with kaleido

### DIFF
--- a/environment-byo.yml
+++ b/environment-byo.yml
@@ -14,8 +14,7 @@ dependencies:
   - pandas=0.24.2
   - pillow=6.2.0
   - pip=19.1.1
-  - plotly-orca=1.3.0
-  - plotly=4.5.4
+  - plotly=4.9.0
   - psutil=5.6.2
   - pycodestyle=2.5.0
   - pydash=4.2.1
@@ -33,6 +32,7 @@ dependencies:
       - cloudpickle==0.5.2
       - colorlover==0.3.0
       - future==0.18.2
+      - kaleido==0.2.1
       - opencv-python==4.1.0.25
       - pyopengl==3.1.0
       - ray==0.7.0

--- a/environment.yml
+++ b/environment.yml
@@ -15,8 +15,7 @@ dependencies:
   - pandas=0.24.2
   - pillow=6.2.0
   - pip=19.1.1
-  - plotly-orca=1.3.0
-  - plotly=4.5.4
+  - plotly=4.9.0
   - psutil=5.6.2
   - pycodestyle=2.5.0
   - pydash=4.2.1
@@ -31,20 +30,21 @@ dependencies:
   - ujson=1.35
   - xlrd=1.2.0
   - pip:
-    - box2d-py==2.3.8
-    - cloudpickle==0.5.2
-    - colorlover==0.3.0
-    - future==0.18.2
-    - opencv-python==4.1.0.25
-    - pyopengl==3.1.0
-    - ray==0.7.0
-    - redis==2.10.6
-    - tensorboard==2.1.1
-    - xvfbwrapper==0.2.9
-    - gym==0.12.1
-    - gym[atari]
-    - gym[box2d]
-    - gym[classic_control]
-    - pybullet==2.8.4
-    - roboschool==1.0.46
-    - atari-py==0.2.6
+      - box2d-py==2.3.8
+      - cloudpickle==0.5.2
+      - colorlover==0.3.0
+      - future==0.18.2
+      - kaleido==0.2.1
+      - opencv-python==4.1.0.25
+      - pyopengl==3.1.0
+      - ray==0.7.0
+      - redis==2.10.6
+      - tensorboard==2.1.1
+      - xvfbwrapper==0.2.9
+      - gym==0.12.1
+      - gym[atari]
+      - gym[box2d]
+      - gym[classic_control]
+      - pybullet==2.8.4
+      - roboschool==1.0.46
+      - atari-py==0.2.6

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "retro_analyze": "python -c 'import sys; from slm_lab.experiment import retro_analysis; retro_analysis.retro_analyze(sys.argv[1])'",
     "retro_eval": "python -c 'import sys; from slm_lab.experiment import retro_analysis; retro_analysis.retro_eval(sys.argv[1])'",
     "reset": "rm -rf data/* .cache __pycache__ */__pycache__ *egg-info .pytest* htmlcov .coverage* *.xml",
-    "kill": "pkill -f run_lab; pkill -f slm-env; pkill -f ipykernel; pkill -f ray; pkill -f orca; pkill -f Xvfb; ps aux | grep -i Unity | awk '{print $2}' | xargs sudo kill -9",
+    "kill": "pkill -f run_lab; pkill -f slm-env; pkill -f ipykernel; pkill -f ray; pkill -f Xvfb; ps aux | grep -i Unity | awk '{print $2}' | xargs sudo kill -9",
     "update": "conda env update -f environment.yml; yarn install;",
     "export-env": "conda env export > environment.yml",
     "build": "docker build -t kengz/slm_lab:latest -t kengz/slm_lab:v$v .",

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ class PyTest(TestCommand):
 
 setup(
     name='slm_lab',
-    version='4.2.3',
+    version='4.2.4',
     description='Modular Deep Reinforcement Learning framework in PyTorch.',
     long_description='https://github.com/kengz/slm_lab',
     keywords='SLM Lab',

--- a/slm_lab/experiment/analysis.py
+++ b/slm_lab/experiment/analysis.py
@@ -254,8 +254,6 @@ def analyze_session(session_spec, session_df, df_mode, plot=True):
         # plot graph
         viz.plot_session(session_spec, session_metrics, session_df, df_mode)
         viz.plot_session(session_spec, session_metrics, session_df, df_mode, ma=True)
-    # manually shut down orca server to avoid zombie processes
-    viz.pio.orca.shutdown_server()
     return session_metrics
 
 
@@ -267,8 +265,6 @@ def analyze_trial(trial_spec, session_metrics_list):
     # plot graphs
     viz.plot_trial(trial_spec, trial_metrics)
     viz.plot_trial(trial_spec, trial_metrics, ma=True)
-    # manually shut down orca server to avoid zombie processes
-    viz.pio.orca.shutdown_server()
     # zip files
     if util.get_lab_mode() == 'train':
         predir, _, _, _, _ = util.prepath_split(info_prepath)
@@ -287,8 +283,6 @@ def analyze_experiment(spec, trial_data_dict):
     # plot graph
     viz.plot_experiment(spec, experiment_df, METRICS_COLS)
     viz.plot_experiment_trials(spec, experiment_df, METRICS_COLS)
-    # manually shut down orca server to avoid zombie processes
-    viz.pio.orca.shutdown_server()
     # zip files
     predir, _, _, _, _ = util.prepath_split(info_prepath)
     zipdir = util.smart_path(predir)

--- a/slm_lab/lib/viz.py
+++ b/slm_lab/lib/viz.py
@@ -12,8 +12,6 @@ logger = logger.get_logger(__name__)
 pio.templates.default = 'none'  # set default white background for plots
 # moving-average window size for plotting
 PLOT_MA_WINDOW = 100
-# warn orca failure only once
-orca_warn_once = ps.once(lambda e: logger.warning(f'Failed to generate graph. Run retro-analysis to generate graphs later. {e}\nIf running on a headless server, prepend your Python command with `xvfb-run -a `, for example `xvfb-run -a python run_lab.py`'))
 if util.is_jupyter():
     init_notebook_mode(connected=True)
 
@@ -121,7 +119,7 @@ def save_image(figure, filepath):
     try:
         pio.write_image(figure, filepath, scale=2)
     except Exception as e:
-        orca_warn_once(e)
+        logger.warning(f'Failed to generate graph. Run retro-analysis to generate graphs later. {e}\nIf running on a headless server, prepend your Python command with `xvfb-run -a `, for example `xvfb-run -a python run_lab.py`')
 
 
 # analysis plot methods


### PR DESCRIPTION
## upgrade plotly, replace orca with kaleido

Plotly has moved away from `orca` to `kaleido` for static image generation since version 4.9.0. This also improves stability and simplifies the image export logic.
This fixes #451

- upgrade plotly to 4.9.0
- replace [`orca`](https://github.com/plotly/orca) with [`kaleido`](https://github.com/plotly/Kaleido)

tested to work on MacOS and Ubuntu