### PR TITLE
fix(dqn): increase vanilla_dqn_boltzmann_cartpole max frames

### DIFF
--- a/slm_lab/spec/benchmark/dqn/dqn_cartpole.json
+++ b/slm_lab/spec/benchmark/dqn/dqn_cartpole.json
@@ -47,7 +47,7 @@
     "env": [{
       "name": "CartPole-v0",
       "max_t": null,
-      "max_frame": 10000
+      "max_frame": 30000
     }],
     "body": {
       "product": "outer",


### PR DESCRIPTION
## fix error when max_frame is lower than log_frequency

Fix error in benchmark spec vanilla_dqn_boltzmann_cartpole when max_frame is lower than log_frequency, causing metrics calculation to not have enough data points.